### PR TITLE
Keep painter reorders local and remove renderer semantic keys

### DIFF
--- a/crates/noon-compile/src/lib.rs
+++ b/crates/noon-compile/src/lib.rs
@@ -1103,22 +1103,27 @@ impl CompiledScene {
                 if before_index == Some(index) {
                     return Ok(stats);
                 }
-                let position = self
-                    .painter_order
-                    .iter()
-                    .position(|candidate| *candidate == index)
-                    .expect("live object has one painter-order entry");
-                self.painter_order.remove(position);
-                let destination = before_index
-                    .and_then(|anchor| {
-                        self.painter_order
-                            .iter()
-                            .position(|candidate| *candidate == anchor)
-                    })
-                    .unwrap_or(self.painter_order.len());
-                self.painter_order.insert(destination, index);
+                // Both positions are already indexed. Searching the dense painter
+                // vector would make even an adjacent move scan the whole prefix.
+                let position =
+                    self.painter_rank(index)
+                        .expect("live object has a painter rank") as usize;
+                let destination = before_index.map_or(self.painter_order.len() - 1, |anchor| {
+                    let rank = self
+                        .painter_rank(anchor)
+                        .expect("live anchor has a painter rank")
+                        as usize;
+                    rank - usize::from(position < rank)
+                });
                 let first = position.min(destination);
-                let last = position.max(destination).min(self.painter_order.len() - 1);
+                let last = position.max(destination);
+                // Shift only the crossed range. remove+insert would move the
+                // untouched suffix twice, even for a one-position reorder.
+                if position < destination {
+                    self.painter_order[first..=last].rotate_left(1);
+                } else {
+                    self.painter_order[first..=last].rotate_right(1);
+                }
                 for rank in first..=last {
                     self.painter_ranks[self.painter_order[rank] as usize] = Some(rank as u32);
                 }
@@ -2949,5 +2954,40 @@ mod tests {
         assert_eq!(compiled.painter_order(), &[0, 1]);
         assert_eq!(compiled.object_index(returning), Some(0));
         assert_eq!(compiled.object_index(later), Some(1));
+    }
+    #[test]
+    fn indexed_painter_moves_preserve_ranks_and_stable_rows_in_both_directions() {
+        let object = |n| {
+            CompiledObject::new(
+                ObjectId::new(n),
+                GeometryRef::circle(1.),
+                Transform2D::IDENTITY,
+                Style::default(),
+            )
+        };
+        let mut compiled =
+            CompiledScene::compile_objects((1..=5).map(object).collect(), &[]).unwrap();
+        for (moving, before, expected) in [
+            (2, Some(5), [0, 2, 3, 1, 4]),
+            (5, Some(3), [0, 4, 2, 3, 1]),
+            (1, None, [4, 2, 3, 1, 0]),
+            (4, Some(4), [4, 2, 3, 1, 0]),
+            (1, Some(5), [0, 4, 2, 3, 1]),
+        ] {
+            compiled
+                .apply_execution_patch(&ExecutionPatch::ReorderObject {
+                    object: ObjectId::new(moving),
+                    before: before.map(ObjectId::new),
+                })
+                .unwrap();
+            assert_eq!(compiled.painter_order(), &expected);
+            for (rank, index) in expected.into_iter().enumerate() {
+                assert_eq!(compiled.painter_rank(index), Some(rank as u32));
+                assert_eq!(
+                    compiled.object_index(ObjectId::new(index as u64 + 1)),
+                    Some(index)
+                );
+            }
+        }
     }
 }

--- a/crates/noon-render-wgpu/examples/frame_preparation_perf.rs
+++ b/crates/noon-render-wgpu/examples/frame_preparation_perf.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use noon_core::{GeometryRef, ObjectId, Style, Transform2D, Vec2};
-use noon_render_wgpu::{CircleInstance, FramePreparer, RenderOrderKey};
+use noon_render_wgpu::{CircleInstance, FramePreparer};
 use noon_runtime::{FrameChanges, FrameObjectState, FrameState};
 
 const DEFAULT_SIZES: [usize; 3] = [1_000, 10_000, 100_000];
@@ -51,16 +51,14 @@ fn benchmark_size(object_count: usize, config: Config) {
         black_box(prepared.stats.instances_repacked);
     });
 
-    let mut keyed_preparer = FramePreparer::new();
-    let keyed_order = (0..object_count)
-        .map(|index| RenderOrderKey::new((index % 7) as i32, index as u64))
-        .collect::<Vec<_>>();
-    keyed_preparer
-        .set_render_order_keys(&frame, &keyed_order)
-        .expect("benchmark render-order key count must match frame");
-    keyed_preparer.prepare(&frame);
+    let mut ordered_preparer = FramePreparer::new();
+    // A precomputed permutation models the execution plan's ordering input.
+    let mut painter_order = (0..object_count as u32).collect::<Vec<_>>();
+    painter_order.sort_by_key(|index| index % 7);
+    ordered_preparer.set_painter_order(&frame, &painter_order);
+    ordered_preparer.prepare(&frame);
     let explicit_order = measure(config, |_| {
-        let prepared = keyed_preparer.prepare(black_box(&frame));
+        let prepared = ordered_preparer.prepare(black_box(&frame));
         black_box(prepared.stats.instances_repacked);
     });
 

--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -559,7 +559,6 @@ pub struct FramePreparer {
     visible_projection_ready: bool,
     visible_projection_key: Vec<VisibleProjectionKey>,
     visible_projection_stats: VisibleRenderProjectionStats,
-    render_order_keys: Vec<RenderOrderKey>,
     // Stable execution-row indices in the runtime's derived semantic painter order.
     painter_order_indices: Vec<u32>,
     // Distinguishes the runtime's explicit empty scene order from the legacy dense
@@ -805,7 +804,7 @@ impl FramePreparer {
     }
 
     fn can_append_structural_slot(&self, frame: &FrameState, object_index: usize) -> bool {
-        if !self.render_order_keys.is_empty() || !frame.is_present(object_index) {
+        if !frame.is_present(object_index) {
             return false;
         }
         matches!(

--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -6,21 +6,6 @@ use crate::{
 };
 use noon_runtime::{FrameChanges, FrameState};
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RenderOrderKey {
-    pub z_index: i32,
-    pub insertion_order: u64,
-}
-
-impl RenderOrderKey {
-    pub const fn new(z_index: i32, insertion_order: u64) -> Self {
-        Self {
-            z_index,
-            insertion_order,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RenderPrimitive {
     Circle,
@@ -42,24 +27,6 @@ pub struct OrderedRenderBatch {
     pub primitive: RenderPrimitive,
     pub instance_range: Range<u32>,
 }
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RenderOrderError {
-    KeyCountMismatch { objects: usize, keys: usize },
-}
-
-impl std::fmt::Display for RenderOrderError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::KeyCountMismatch { objects, keys } => write!(
-                formatter,
-                "render order key count {keys} does not match scene object count {objects}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for RenderOrderError {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VisibleRenderError {
@@ -263,67 +230,16 @@ impl FramePreparer {
 }
 
 impl FramePreparer {
-    /// Install explicit semantic z/painter keys for subsequent preparations.
-    ///
-    /// The current runtime has not yet migrated #62 presentation metadata into
-    /// `FrameObjectState`, so this narrow adapter lets that migration land later
-    /// without changing the renderer ordering algorithm again. When no keys are
-    /// supplied, object-vector order remains the stable painter order.
-    pub fn set_render_order_keys(
-        &mut self,
-        frame: &FrameState,
-        keys: &[RenderOrderKey],
-    ) -> Result<(), RenderOrderError> {
-        if keys.len() != frame.objects.len() {
-            return Err(RenderOrderError::KeyCountMismatch {
-                objects: frame.objects.len(),
-                keys: keys.len(),
-            });
-        }
-        if self.render_order_keys != keys {
-            self.render_order_keys.clear();
-            self.render_order_keys.extend_from_slice(keys);
-            self.initialized = false;
-        }
-        Ok(())
-    }
-
-    pub fn clear_render_order_keys(&mut self) {
-        if !self.render_order_keys.is_empty() {
-            self.render_order_keys.clear();
-            self.initialized = false;
-        }
-    }
-
     pub(crate) fn append_ordered_render_slot(&mut self, slot: PreparedSlot) {
-        debug_assert!(
-            self.render_order_keys.is_empty(),
-            "explicit render-order keys require structural rebuild",
-        );
         push_slot_batches(&mut self.render_batches, slot);
     }
 
     pub(crate) fn append_ordered_reveal_head(&mut self, line_index: usize) {
-        debug_assert!(
-            self.render_order_keys.is_empty(),
-            "explicit render-order keys require structural rebuild",
-        );
         push_batch(&mut self.render_batches, RenderPrimitive::Line, line_index);
     }
 
     pub(crate) fn rebuild_ordered_render_batches(&mut self) {
         self.render_batches.clear();
-
-        if self.render_order_keys.len() == self.slots.len() {
-            // Explicit z-order is comparatively uncommon and genuinely needs a
-            // sortable indirection. Keep that allocation isolated to this path.
-            let mut object_indices = (0..self.slots.len()).collect::<Vec<_>>();
-            object_indices.sort_by_key(|&index| self.render_order_keys[index]);
-            for object_index in object_indices {
-                push_slot_batches(&mut self.render_batches, self.slots[object_index]);
-            }
-            return;
-        }
 
         if self.painter_order_installed {
             for &object_index in &self.painter_order_indices {
@@ -334,7 +250,7 @@ impl FramePreparer {
             return;
         }
 
-        // Legacy/default painter order is the semantic object-vector order.
+        // Low-level scratch frames without a runtime permutation use storage order.
         for slot in self.slots.iter().copied() {
             push_slot_batches(&mut self.render_batches, slot);
         }
@@ -347,17 +263,6 @@ impl FramePreparer {
     /// compatible boundary batches without touching immutable geometry or mega-path
     /// streams.
     pub(crate) fn rebuild_render_order_chunks(&mut self, range: Option<Range<usize>>) {
-        if !self.render_order_keys.is_empty() {
-            self.render_chunks.clear();
-            self.render_chunks_active = false;
-            self.render_order_batch_count = 0;
-            self.render_order_mega_batch_count = 0;
-            self.render_order_mega_path_count = 0;
-            self.render_chunk_boundary_merges.clear();
-            self.render_order_boundary_merge_count = 0;
-            self.render_order_mega_boundary_merge_count = 0;
-            return;
-        }
         let position_count = if self.painter_order_installed {
             self.painter_order_indices.len()
         } else {
@@ -728,23 +633,14 @@ mod tests {
     }
 
     #[test]
-    fn explicit_z_keys_reorder_without_changing_instance_storage() {
+    fn runtime_painter_order_preserves_instance_storage() {
         let frame = frame(vec![
             object(0, GeometryRef::circle(1.0)),
             object(1, GeometryRef::rectangle(2.0, 2.0)),
             object(2, GeometryRef::circle(0.5)),
         ]);
         let mut preparer = FramePreparer::new();
-        preparer
-            .set_render_order_keys(
-                &frame,
-                &[
-                    RenderOrderKey::new(5, 0),
-                    RenderOrderKey::new(-1, 1),
-                    RenderOrderKey::new(5, 2),
-                ],
-            )
-            .unwrap();
+        preparer.set_painter_order(&frame, &[1, 0, 2]);
         let prepared = preparer.prepare(&frame);
         assert_eq!(
             prepared.render_batches[0].primitive,
@@ -755,19 +651,6 @@ mod tests {
             RenderPrimitive::Circle
         );
         assert_eq!(prepared.render_batches[1].instance_range, 0..2);
-    }
-
-    #[test]
-    fn key_count_must_match_scene() {
-        let frame = frame(vec![object(0, GeometryRef::circle(1.0))]);
-        let mut preparer = FramePreparer::new();
-        assert!(matches!(
-            preparer.set_render_order_keys(&frame, &[]),
-            Err(RenderOrderError::KeyCountMismatch {
-                objects: 1,
-                keys: 0
-            })
-        ));
     }
 
     #[test]


### PR DESCRIPTION
Advances #74 / #954 by making an adjacent painter reorder local through compilation and keeping semantic ordering out of the reusable renderer.

`CompiledScene::ReorderObject` now uses retained ranks and rotates only the crossed range. Previously it searched the painter vector and performed remove/insert, scanning and moving an unrelated suffix even for a one-position move. Stable execution rows and resources remain unchanged; work is proportional to the order range that actually changes.

Deletes the unused renderer `RenderOrderKey` adapter, setter/clearer, stored semantic keys, sorting fallback, and its forced structural rebuild path. The normal typed product already supplies runtime painter permutations. The renderer benchmark now consumes a precomputed permutation through that same existing interface. No new authority, protocol, migration seam, or compatibility alias.

Validation actually run with shared target, two build jobs, and test debug info disabled:
- `cargo test -p noon-compile --lib indexed_painter_moves` — passed, covering moves in both directions, head/tail/self positioning, ranks, and stable rows.
- `cargo test -p noon-render-wgpu --lib render_order::tests` — 9 passed; runtime-order storage, mixed primitives, and retained visibility projection remain qualified.
- `bash scripts/check.sh fmt-lint` — architecture, format, workspace check and clippy passed.
- Repository search confirms no references to the removed API remain; `git diff --check` passed.

This is an ordering prerequisite, not a claim that public z-index mutation is complete. Shared numeric object/family z-index mutation and its paired Rust/Python overlap examples remain in #74. Existing native/direct-WASM painter-order examples continue to exercise the normal pipeline. Full local/browser tests are not claimed; required GitHub checks remain the merge gate.
