### PR TITLE
Observe live morph paths through shared ordered curve semantics

### DIFF
--- a/crates/noon-compile/src/transform.rs
+++ b/crates/noon-compile/src/transform.rs
@@ -52,9 +52,13 @@ pub(crate) fn compile_transform_geometry_plan(
                 let Some(target) = source.morph_target() else {
                     return Err(TransformCompileFailure::UnsupportedGeometry);
                 };
-                noon_geometry::plan_morph(source, target, noon_geometry::MorphOptions::DEFAULT)
-                    .map_err(|_| TransformCompileFailure::UnsupportedGeometry)?;
-                noon_geometry::plan_filled_morph(
+                noon_geometry::plan_morph_preserving_order(
+                    source,
+                    target,
+                    noon_geometry::MorphOptions::DEFAULT,
+                )
+                .map_err(|_| TransformCompileFailure::UnsupportedGeometry)?;
+                noon_geometry::plan_filled_morph_preserving_order(
                     source,
                     target,
                     noon_geometry::MorphOptions::DEFAULT,
@@ -227,8 +231,12 @@ fn compile_path_pair(
         return Err(TransformCompileFailure::RequiresRetessellation);
     }
     if from_style.fill.is_some()
-        && noon_geometry::plan_filled_morph(&source, &target, noon_geometry::MorphOptions::DEFAULT)
-            .is_err()
+        && noon_geometry::plan_filled_morph_preserving_order(
+            &source,
+            &target,
+            noon_geometry::MorphOptions::DEFAULT,
+        )
+        .is_err()
     {
         return Err(TransformCompileFailure::UnsafeFilledPath);
     }
@@ -257,7 +265,7 @@ fn compile_path_pair(
                 to_transform,
             )
             && (from_style.fill.is_none()
-                || noon_geometry::plan_filled_morph(
+                || noon_geometry::plan_filled_morph_preserving_order(
                     &world_source,
                     &world_target,
                     noon_geometry::MorphOptions::DEFAULT,

--- a/crates/noon-geometry/src/morph.rs
+++ b/crates/noon-geometry/src/morph.rs
@@ -189,6 +189,16 @@ pub fn plan_morph_preserving_order(
     plan_morph_impl(source, target, options, false)
 }
 
+/// Interpolate canonical cubic controls using the same correspondence as ordered
+/// morph preparation. This is an immutable observation, not tessellated geometry.
+pub fn interpolate_path_preserving_order(
+    source: &VectorPath,
+    target: &VectorPath,
+    progress: f32,
+) -> Result<VectorPath, MorphError> {
+    correspondence::interpolate(source, target, progress)
+}
+
 fn plan_morph_impl(
     source: &VectorPath,
     target: &VectorPath,

--- a/crates/noon-geometry/src/morph/correspondence.rs
+++ b/crates/noon-geometry/src/morph/correspondence.rs
@@ -6,25 +6,9 @@ pub(super) fn plan(
     target: &VectorPath,
     options: MorphOptions,
 ) -> Result<MorphPlan, MorphError> {
-    let (source, target) = crate::align_paths(source, target).map_err(MorphError::PathAlignment)?;
-    let source = crate::partial::cubic_contours(&source);
-    let target = crate::partial::cubic_contours(&target);
-    if source.len() != target.len() {
-        return Err(MorphError::ContourCountMismatch {
-            source: source.len(),
-            target: target.len(),
-        });
-    }
-    let mut contours = Vec::with_capacity(source.len());
-    for (index, (source, target)) in source.into_iter().zip(target).enumerate() {
-        if source.closed != target.closed {
-            return Err(MorphError::ClosureMismatch {
-                contour: index,
-                source_closed: source.closed,
-                target_closed: target.closed,
-            });
-        }
-        debug_assert_eq!(source.curves.len(), target.curves.len());
+    let pairs = aligned_contours(source, target)?;
+    let mut contours = Vec::with_capacity(pairs.len());
+    for (source, target) in pairs {
         let samples = options.samples_per_contour.div_ceil(source.curves.len());
         let minimum_depth = samples.clamp(1, 1 << 16).next_power_of_two().ilog2();
         let mut result = MorphContourPlan {
@@ -55,6 +39,64 @@ pub(super) fn plan(
         contours.push(result);
     }
     Ok(MorphPlan { contours })
+}
+
+fn aligned_contours(
+    source: &VectorPath,
+    target: &VectorPath,
+) -> Result<Vec<(crate::partial::CubicContour, crate::partial::CubicContour)>, MorphError> {
+    let (source, target) = crate::align_paths(source, target).map_err(MorphError::PathAlignment)?;
+    let source = crate::partial::cubic_contours(&source);
+    let target = crate::partial::cubic_contours(&target);
+    if source.len() != target.len() {
+        return Err(MorphError::ContourCountMismatch {
+            source: source.len(),
+            target: target.len(),
+        });
+    }
+    source
+        .into_iter()
+        .zip(target)
+        .enumerate()
+        .map(|(index, (source, target))| {
+            if source.closed != target.closed {
+                return Err(MorphError::ClosureMismatch {
+                    contour: index,
+                    source_closed: source.closed,
+                    target_closed: target.closed,
+                });
+            }
+            debug_assert_eq!(source.curves.len(), target.curves.len());
+            Ok((source, target))
+        })
+        .collect()
+}
+
+pub(super) fn interpolate(
+    source: &VectorPath,
+    target: &VectorPath,
+    progress: f32,
+) -> Result<VectorPath, MorphError> {
+    if !progress.is_finite() || !(0.0..=1.0).contains(&progress) {
+        return Err(MorphError::PathAlignment(
+            crate::PathProportionError::InvalidProportion(progress),
+        ));
+    }
+    let mut path = VectorPath::new();
+    for (source, target) in aligned_contours(source, target)? {
+        for (index, (a, b)) in source.curves.into_iter().zip(target.curves).enumerate() {
+            let p: [Vec2; 4] =
+                std::array::from_fn(|index| a[index] * (1.0 - progress) + b[index] * progress);
+            if index == 0 {
+                path = path.move_to(p[0]);
+            }
+            path = path.cubic_to(p[1], p[2], p[3]);
+        }
+        if source.closed {
+            path = path.close();
+        }
+    }
+    Ok(path)
 }
 
 fn split(p: [Vec2; 4]) -> ([Vec2; 4], [Vec2; 4]) {

--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -1815,9 +1815,9 @@ impl FramePreparer {
         } else {
             path
         };
-        let mesh = if style.stroke_width_mode == StrokeWidthMode::ScreenSpace
-            && tessellation_path.morph_target().is_some()
-        {
+        // Correspondence is established by shared transform preparation. Stroke
+        // scaling affects tessellation coordinates, never semantic point pairing.
+        let mesh = if tessellation_path.morph_target().is_some() {
             noon_geometry::tessellate_styled_with_fill_preserving_morph_order(
                 tessellation_path,
                 style.stroke_width,

--- a/crates/noon-web/src/authoring_error.rs
+++ b/crates/noon-web/src/authoring_error.rs
@@ -260,6 +260,9 @@ impl From<AuthoringError> for AuthoringFailure {
             AuthoringError::PathQuery(cause) => {
                 Self::new("invalid_input", "path.invalid_query", cause)
             }
+            AuthoringError::MorphQuery(cause) => {
+                Self::new("invalid_input", "path.invalid_morph_query", cause)
+            }
             AuthoringError::Boolean(cause) => {
                 Self::new("invalid_input", "path.invalid_boolean", cause)
             }

--- a/crates/noon/src/authoring_error.rs
+++ b/crates/noon/src/authoring_error.rs
@@ -181,6 +181,8 @@ pub enum AuthoringError {
     GeometryResource(noon_core::GeometryResourceError),
     /// A path observation received invalid geometry or sampling parameters.
     PathQuery(noon_geometry::PathProportionError),
+    /// Current path controls cannot be observed with the active correspondence.
+    MorphQuery(noon_geometry::MorphError),
     /// Filled-region construction failed before publication.
     Boolean(noon_geometry::BooleanPathError),
     /// The shared arc constructor rejected its inputs.
@@ -288,6 +290,7 @@ impl std::fmt::Display for AuthoringError {
             Self::VectorLowering(error) => error.fmt(f),
             Self::GeometryResource(error) => error.fmt(f),
             Self::PathQuery(error) => error.fmt(f),
+            Self::MorphQuery(error) => error.fmt(f),
             Self::Boolean(error) => error.fmt(f),
             Self::Arc(error) => error.fmt(f),
             Self::Elbow(error) => error.fmt(f),
@@ -310,6 +313,7 @@ impl std::error::Error for AuthoringError {
             Self::VectorLowering(error) => Some(error),
             Self::GeometryResource(error) => Some(error),
             Self::PathQuery(error) => Some(error),
+            Self::MorphQuery(error) => Some(error),
             Self::Boolean(error) => Some(error),
             Self::Arc(error) => Some(error),
             Self::Elbow(error) => Some(error),

--- a/crates/noon/src/example_scenes/path_queries.rs
+++ b/crates/noon/src/example_scenes/path_queries.rs
@@ -28,8 +28,32 @@ pub fn session() -> Result<ExecutionSession, String> {
                 scene.add(&marker)?;
             }
         }
+        let target = rectangle.target_editor()?;
+        crate::LayoutAnchor::from(&target).stretch(
+            1.2,
+            crate::LayoutDimension::Width,
+            crate::ManimRotationPivot::Center,
+        )?;
+        let start = rectangle.path_query()?.start()?;
+        let end = target.path_query()?.start()?;
+        let animation = scene.declare_transform_to(
+            &rectangle,
+            &target,
+            crate::AnimationOptions::new()
+                .run_time(1.)
+                .rate_func(crate::RateFunction::Linear),
+        )?;
         let mut session = scene.execution_session()?;
         let mut live = scene.live(&mut session);
+        let segment = live.play_animation(&animation)?;
+        live.advance_segment_to(segment, 0.5)?;
+        let captured = live.effective_path_query(&rectangle)?;
+        let midpoint = captured.start()?;
+        assert!((midpoint.0 - (start.0 + end.0) * 0.5).abs() < 2e-6);
+        assert!((midpoint.1 - (start.1 + end.1) * 0.5).abs() < 2e-6);
+        live.advance_segment_to(segment, segment.end_time())?;
+        live.complete_segment(segment)?;
+        assert_eq!(captured.start()?, midpoint);
         let before = live.effective_path_query(&rectangle)?.start()?;
         let wait = live.wait_segment(0.2)?;
         live.advance_segment_to(wait, wait.end_time())?;

--- a/crates/noon/src/execution_session/publication.rs
+++ b/crates/noon/src/execution_session/publication.rs
@@ -111,6 +111,10 @@ pub struct EffectiveSemanticObject<'a> {
     pub object: &'a FrameObjectState,
     pub publication: PublicationContext,
     authored_content_layout_applicable: bool,
+    pub(crate) render_geometry: Option<&'a noon_core::GeometryRef>,
+    pub(crate) render_transform: Option<noon_core::Transform2D>,
+    pub(crate) reveal: f32,
+    pub(crate) morph: f32,
 }
 
 impl EffectiveSemanticObject<'_> {
@@ -538,6 +542,10 @@ impl ExecutionSession {
             object,
             publication: self.publication_context(),
             authored_content_layout_applicable,
+            render_geometry: frame.render_geometries[object_index].as_deref(),
+            render_transform: frame.render_transforms[object_index],
+            reveal: frame.reveals[object_index],
+            morph: frame.morphs[object_index],
         })
     }
 }

--- a/crates/noon/src/live_session/path_queries.rs
+++ b/crates/noon/src/live_session/path_queries.rs
@@ -1,29 +1,46 @@
 use super::*;
-use crate::path_queries::{prepare_content, PathQuery};
+use crate::path_queries::PathQuery;
 use crate::{AuthoringError, UnsupportedAuthoringOperation};
 
 impl LiveSession<'_> {
-    /// Capture retained content and the effective affine transform from one
-    /// coherent publication. Active content overrides are explicitly rejected.
+    /// Capture exact current path controls and transform from one coherent
+    /// runtime publication. Active reveals remain explicitly unsupported.
     pub fn effective_path_query(&self, object: &Mobject) -> Result<PathQuery, LiveSessionError> {
         self.require_mobject(object)?;
         let store = self.store.borrow();
         let observed = self
             .session
             .effective_semantic_object(&store, object.node_id())?;
-        if !observed.authored_content_layout_applicable() {
-            return Err(AuthoringError::Unsupported(
-                UnsupportedAuthoringOperation::EffectivePathRenderOverride,
-            )
-            .into());
+        let unsupported = || {
+            AuthoringError::Unsupported(UnsupportedAuthoringOperation::EffectivePathRenderOverride)
+        };
+        if observed.reveal != 1.0 {
+            return Err(unsupported().into());
+        }
+        let geometry = observed
+            .render_geometry
+            .or_else(|| observed.object.content.geometry())
+            .ok_or(AuthoringError::Unsupported(
+                UnsupportedAuthoringOperation::PathQueryContent,
+            ))?;
+        let mut path = noon_geometry::canonical_outline_path(geometry).ok_or(
+            AuthoringError::Unsupported(UnsupportedAuthoringOperation::PathQueryContent),
+        )?;
+        if let Some(target) = path.morph_target() {
+            path = noon_geometry::interpolate_path_preserving_order(&path, target, observed.morph)
+                .map_err(AuthoringError::MorphQuery)?;
+        } else if observed.morph != 0.0 {
+            return Err(unsupported().into());
         }
         let state = store
             .semantic_object_state_checked(object.node_id())
             .map_err(AuthoringError::from)?;
         let transform = crate::semantic_mobject::semantic_transform_with_effective_affine(
             state.transform,
-            observed.object.transform,
+            observed
+                .render_transform
+                .unwrap_or(observed.object.transform),
         );
-        prepare_content(&store, state.content, transform).map_err(Into::into)
+        PathQuery::prepare(&path, transform).map_err(Into::into)
     }
 }

--- a/crates/noon/src/path_queries.rs
+++ b/crates/noon/src/path_queries.rs
@@ -18,7 +18,7 @@ pub struct PathQuery {
 }
 
 impl PathQuery {
-    fn prepare(
+    pub(crate) fn prepare(
         path: &VectorPath,
         transform: SemanticTransform2_5D,
     ) -> Result<Self, AuthoringError> {

--- a/crates/noon/tests/path_queries.rs
+++ b/crates/noon/tests/path_queries.rs
@@ -117,3 +117,112 @@ fn paired_query_example_uses_the_normal_execution_session() {
     let session = noon::example_scenes::path_queries::session().unwrap();
     assert_eq!(session.frame().objects.len(), 10);
 }
+
+#[test]
+fn effective_morph_queries_interpolate_controls_and_keep_snapshot_and_seek_coherent() {
+    let mut scene = Scene::new();
+    let mut object = scene.square(2.).unwrap();
+    object.rotate(0.37).unwrap();
+    object.shift(-1., 2.).unwrap();
+    scene.add(&object).unwrap();
+    let target = object.target_editor().unwrap();
+    noon::LayoutAnchor::from(&target)
+        .stretch(
+            2.,
+            noon::LayoutDimension::Width,
+            noon::ManimRotationPivot::Center,
+        )
+        .unwrap();
+    let source_query = object.path_query().unwrap();
+    let target_query = target.path_query().unwrap();
+    let animation = scene
+        .declare_transform_to(
+            &object,
+            &target,
+            AnimationOptions::new()
+                .run_time(2.)
+                .rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+    let mut session = scene.execution_session().unwrap();
+    let midpoint;
+    {
+        let mut live = scene.live(&mut session);
+        let segment = live.play_animation(&animation).unwrap();
+        live.advance_segment_to(segment, 1.).unwrap();
+        midpoint = live.effective_path_query(&object).unwrap();
+        assert_eq!(midpoint.curve_count(), 4);
+        for index in 0..4 {
+            let start = source_query.curve_points(index).unwrap();
+            let end = target_query.curve_points(index).unwrap();
+            for (point, (a, b)) in midpoint
+                .curve_points(index)
+                .unwrap()
+                .into_iter()
+                .zip(start.into_iter().zip(end))
+            {
+                near(point, ((a.0 + b.0) * 0.5, (a.1 + b.1) * 0.5));
+            }
+        }
+        live.advance_segment_to(segment, 2.).unwrap();
+        live.complete_segment(segment).unwrap();
+        near(
+            live.effective_path_query(&object).unwrap().start().unwrap(),
+            target_query.start().unwrap(),
+        );
+    }
+    session.seek(1.).unwrap();
+    let replay = scene
+        .live(&mut session)
+        .effective_path_query(&object)
+        .unwrap();
+    for index in 0..4 {
+        assert_eq!(
+            replay.curve_points(index).unwrap(),
+            midpoint.curve_points(index).unwrap()
+        );
+    }
+}
+
+#[test]
+fn native_object_scaled_strokes_use_the_same_morph_controls() {
+    let mut scene = Scene::new();
+    let path = VectorPath::new()
+        .move_to(Vec2::new(-1., -1.))
+        .line_to(Vec2::new(1., -1.))
+        .line_to(Vec2::new(1., 1.))
+        .line_to(Vec2::new(-1., 1.))
+        .line_to(Vec2::new(-1., -1.))
+        .close();
+    let object = scene
+        .path(path, noon_core::SemanticStyle::default())
+        .unwrap();
+    scene.add(&object).unwrap();
+    let mut target = object.target_editor().unwrap();
+    target
+        .set_points_as_corners(&[
+            Vec2::new(-2., -1.),
+            Vec2::new(2., -1.),
+            Vec2::new(2., 1.),
+            Vec2::new(-2., 1.),
+            Vec2::new(-2., -1.),
+        ])
+        .unwrap();
+    let animation = scene
+        .declare_transform_to(
+            &object,
+            &target,
+            AnimationOptions::new()
+                .run_time(2.)
+                .rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+    let mut session = scene.execution_session().unwrap();
+    let mut live = scene.live(&mut session);
+    let segment = live.play_animation(&animation).unwrap();
+    live.advance_segment_to(segment, 1.).unwrap();
+    near(
+        live.effective_path_query(&object).unwrap().start().unwrap(),
+        (-1.5, -1.),
+    );
+}

--- a/parity/manim-v0.21/core-examples/path_queries.py
+++ b/parity/manim-v0.21/core-examples/path_queries.py
@@ -12,8 +12,6 @@ class OrdinaryPathQueries(Scene):
             assert shape.get_arc_length() > 0
             for alpha in (0.125, 0.375, 0.625, 0.875):
                 self.add(Dot(shape.point_from_proportion(alpha), color="#ffcc44"))
-        before = rectangle.get_start()
+        target = rectangle.copy().stretch(1.2, 0)
+        self.play(Transform(rectangle, target), run_time=1, rate_func=linear)
         self.wait(0.2)
-        after = rectangle.get_start()
-        assert abs(before[0] - after[0]) < 1e-6
-        assert abs(before[1] - after[1]) < 1e-6

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -640,10 +640,10 @@
       "id": "path-queries",
       "scene": "OrdinaryPathQueries",
       "source": "parity/manim-v0.21/core-examples/path_queries.py",
-      "expected_duration": 0.2,
+      "expected_duration": 1.2,
       "raster_tolerance": {
         "max_bounds_delta_px": 1,
-        "max_differing_ratio": 0.003,
+        "max_differing_ratio": 0.0036,
         "max_mean_absolute_channel_error": 0.1
       }
     },

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -53,7 +53,7 @@ const examples = [
   { name: "Canonical curve layout", factory: "createDirectCanonicalCurveLayoutSmokeRenderer", objectCount: 4, duration: 0.2 },
   { name: "Point matching", factory: "createDirectPointMatchingSmokeRenderer", objectCount: 2, duration: 0.2 },
   { name: "Animated stroke width", factory: "createDirectAnimatedStrokeWidthSmokeRenderer", objectCount: 1, duration: 2 },
-  { name: "Path queries", factory: "createDirectPathQueriesSmokeRenderer", objectCount: 10, duration: 0.2 },
+  { name: "Path queries", factory: "createDirectPathQueriesSmokeRenderer", objectCount: 10, duration: 1.2 },
   { name: "Z-index", factory: "createDirectZIndexSmokeRenderer", objectCount: 3, duration: 0.2 },
   { name: "Scale pivots", factory: "createDirectScalePivotsSmokeRenderer", objectCount: 4, duration: 1.0 },
   { name: "Family grid", factory: "createDirectFamilyGridSmokeRenderer", objectCount: 4, duration: 0.2 },

--- a/scripts/manim-differential-noon.mjs
+++ b/scripts/manim-differential-noon.mjs
@@ -28,6 +28,8 @@ try {
   const observations = await page.evaluate(async ({ modules, probes, pyodideUrl }) => {
     const wasm = await import("/web/pkg/noon_web.js");
     await wasm.default();
+    const { resolveAnimationOptionsPlain } = await import("/web/animation-options.js");
+    globalThis.noonResolveAnimationOptions = (...args) => resolveAnimationOptionsPlain(wasm.resolveAnimationOptions, ...args);
     const { loadPyodide } = await import(pyodideUrl);
     const pyodide = await loadPyodide();
     const store = new wasm.WasmAuthoringStore();

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -833,6 +833,36 @@ def _canonical_curve_layout(api):
     return [_object_observation(obj) for obj in (circle, ellipse, circle.copy(), family)]
 
 
+def _morph_path_observation(shape):
+    return {"start": _point_observation(shape.get_start()),
+            "controls": [[_point_observation(p) for p in shape.get_nth_curve_points(i)]
+                         for i in range(shape.get_num_curves())]}
+
+
+def _noon_effective_morph_path():
+    scene = noon.Scene()
+    shape = noon.Square(side_length=2).rotate(.37).shift(noon.LEFT)
+    target = shape.copy().stretch(1.8, 0)
+    scene.add(shape)
+    animation = scene.declare_live_transform_to(shape, target, run_time=1, rate_func=noon.linear)
+    live = scene.live_execution()
+    end = live.play(animation)
+    live.advance_to(.5)
+    result = _morph_path_observation(shape)
+    live.advance_to(end)
+    live.complete()
+    return result
+
+
+def _manim_effective_morph_path():
+    shape = manim.Square(side_length=2).rotate(.37).shift(manim.LEFT)
+    target = shape.copy().stretch(1.8, 0)
+    animation = manim.Transform(shape, target, run_time=1, rate_func=manim.linear)
+    animation.begin()
+    animation.interpolate(.5)
+    return _morph_path_observation(shape)
+
+
 def _world_stretch(api):
     shape = api.Square(side_length=2).rotate(.37).shift(api.RIGHT - api.UP)
     shape.stretch(-1.5, 0, about_point=2 * api.RIGHT)
@@ -974,6 +1004,7 @@ def _point_matching(api):
 
 
 FIXTURES = [
+    Fixture("effective_morph_path", _noon_effective_morph_path, _manim_effective_morph_path, 1e-5),
     Fixture("world_stretch", lambda: _world_stretch(noon), lambda: _world_stretch(manim), 1e-5),
     Fixture("path_alignment", lambda: _path_alignment(noon), lambda: _path_alignment(manim), 1e-5),
     Fixture("boolean_geometry", lambda: _boolean_geometry(noon), lambda: _boolean_geometry(manim), 1e-5),

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -795,7 +795,7 @@ try {
     { filename: "ordinary_path_editing.py", objectCount: 3, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_point_matching.py", objectCount: 2, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_animated_stroke_width.py", objectCount: 1, expectedDuration: 2, endpointTime: null },
-    { filename: "ordinary_path_queries.py", objectCount: 10, expectedDuration: 0.2, endpointTime: null },
+    { filename: "ordinary_path_queries.py", objectCount: 10, expectedDuration: 1.2, endpointTime: null },
     { filename: "ordinary_z_index.py", objectCount: 3, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_scale_pivots.py", objectCount: 4, expectedDuration: 1.0, endpointTime: null },
     { filename: "ordinary_family_grid.py", objectCount: 4, expectedDuration: 0.2, endpointTime: null },

--- a/web/animation-options.js
+++ b/web/animation-options.js
@@ -1,0 +1,16 @@
+// Copy the typed Rust result before releasing its WASM owner.
+export function resolveAnimationOptionsPlain(resolveAnimationOptions, ...args) {
+  const result = resolveAnimationOptions(...args);
+  try {
+    return {
+      runTime: result.runTime,
+      rateFunc: result.rateFunc,
+      lagRatio: result.lagRatio,
+      pathArc: result.pathArc,
+      reverseRateFunction: result.reverseRateFunction,
+    };
+  } finally {
+    result.free();
+  }
+}
+

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -6,6 +6,7 @@ import initNoonWeb, {
   WasmSceneMembershipBatch,
   resolveAnimationOptions,
 } from "./pkg/noon_web.js";
+import { resolveAnimationOptionsPlain } from "./animation-options.js";
 import { attachSemanticEngine } from "./semantic-engine-endpoint.js";
 import { PYTHON_COMPAT_MODULES } from "./python-compat-modules.js";
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/pyodide.mjs";
@@ -133,7 +134,7 @@ async function initializePyodide() {
     authoringStore.createManimTypst(source, math, fontSize);
   self.noonAuthoringMembershipBatch = (kind) => new WasmSceneMembershipBatch(kind);
   self.noonCreateAuthoringFamilyHandle = (batch, zIndex) => authoringStore.createFamily(batch, zIndex);
-  self.noonResolveAnimationOptions = resolveAnimationOptionsPlain;
+  self.noonResolveAnimationOptions = (...args) => resolveAnimationOptionsPlain(resolveAnimationOptions, ...args);
   const bindingsReadyAt = performance.now();
 
   for (const [index, descriptor] of PYTHON_COMPAT_MODULES.entries()) {
@@ -212,20 +213,6 @@ async function loadCompatibilityBundle() {
   return bundle.modules;
 }
 
-function resolveAnimationOptionsPlain(...args) {
-  const result = resolveAnimationOptions(...args);
-  try {
-    return {
-      runTime: result.runTime,
-      rateFunc: result.rateFunc,
-      lagRatio: result.lagRatio,
-      pathArc: result.pathArc,
-      reverseRateFunction: result.reverseRateFunction,
-    };
-  } finally {
-    result.free();
-  }
-}
 
 function registerContinuationContext(context) {
   if (activeAuthoringRun === null) {

--- a/web/python/examples/ordinary_path_queries.py
+++ b/web/python/examples/ordinary_path_queries.py
@@ -12,8 +12,17 @@ class OrdinaryPathQueries(Scene):
             assert shape.get_arc_length() > 0
             for alpha in (0.125, 0.375, 0.625, 0.875):
                 self.add(Dot(shape.point_from_proportion(alpha), color="#ffcc44"))
-        before = rectangle.get_start()
-        self.wait(0.2)
-        after = rectangle.get_start()
-        assert abs(before[0] - after[0]) < 1e-6
-        assert abs(before[1] - after[1]) < 1e-6
+        target = rectangle.copy().stretch(1.2, 0)
+        start, end = rectangle.get_start(), target.get_start()
+        animation = self.declare_live_transform_to(rectangle, target, run_time=1, rate_func=linear)
+        live = self.live_execution()
+        finish = live.play(animation)
+        live.advance_to(0.5)
+        midpoint = rectangle.get_start()
+        assert abs(midpoint[0] - (start[0] + end[0]) * 0.5) < 2e-6
+        assert abs(midpoint[1] - (start[1] + end[1]) * 0.5) < 2e-6
+        live.advance_to(finish)
+        live.complete()
+        wait_end = live.wait(0.2)
+        live.advance_to(wait_end)
+        live.complete()


### PR DESCRIPTION
Advances #78/#82 under #954. Current path getters can observe an active retained morph's exact cubic controls, anchors and proportions through one coherent Runtime publication. Authored path inspections remain explicit. Reads create no semantic resources or mutations, and snapshots retain their sampled value after execution advances.

The query and retained morph mesh use the same shared curve alignment. Lowering, renderer preparation and live observation now agree on ordered correspondence regardless of stroke scaling; stroke mode controls stroke coordinates, not semantic point pairing. This removes the renderer's style-based choice of morph meaning. No new scene model, scheduler, transport or renderer authority is introduced. Query preparation is proportional to the selected path's curves; static rendering retains its existing caches.

The paired Rust native/direct-WASM and Python path-query examples inspect a transform halfway through execution, then continue through the ordinary runtime. A pinned Manim semantic probe compares intermediate controls. Native regressions cover immutable snapshots and forward/direct-seek agreement. Active reveal queries remain explicit #78 follow-up scope.

Validation:
- `bash scripts/check.sh full` passed with `NOON_WASM_PROFILE=dev`, `NOON_RENDERER_SMOKE=1` and the shared local Cargo target: all workspace tests, architecture guards, format/check/clippy, web/Python checks and 229 actual WASM API contracts.
- `cargo test -p noon --test path_queries` — seven tests passed, including a content-changing morph with object-scaled strokes.
- Five focused Python path-adapter tests passed.
- `node scripts/manim-differential-noon.mjs /tmp/noon-effective-path-semantic.json` — all 83 actual Rust/WASM/Python probes ran successfully.
- `NOON_WEB_PREFLIGHT_ONLY=1 bash scripts/build-web-demo.sh` passed after sharing the production animation-options binding with the semantic harness. The earlier CI failure was that missing harness binding.
- `node scripts/shared-authoring-smoke.mjs` — complete shared browser corpus passed.
- Final GitHub checks and pinned Manim oracle qualification are running.


Depends on #1409; initially based on its branch to keep the diff reviewable.
