### PR TITLE
Observe effective creation paths through shared reveal semantics

### DIFF
--- a/crates/noon/src/example_scenes/path_queries.rs
+++ b/crates/noon/src/example_scenes/path_queries.rs
@@ -59,6 +59,18 @@ pub fn session() -> Result<ExecutionSession, String> {
         live.advance_segment_to(wait, wait.end_time())?;
         live.complete_segment(wait)?;
         assert_eq!(live.effective_path_query(&rectangle)?.start()?, before);
+        live.remove(&ellipse)?;
+        let reveal = live.declare_and_activate_create(
+            &ellipse,
+            crate::AnimationOptions::new()
+                .run_time(1.)
+                .rate_func(crate::RateFunction::Linear),
+        )?;
+        live.advance_segment_to(reveal, reveal.end_time() - 0.5)?;
+        let endpoint = live.effective_path_query(&ellipse)?.end()?;
+        assert!((endpoint.0 - 1.3).abs() < 2e-6 && endpoint.1.abs() < 2e-6);
+        live.advance_segment_to(reveal, reveal.end_time())?;
+        live.complete_segment(reveal)?;
         Ok(session)
     };
     build().map_err(|error| error.to_string())

--- a/crates/noon/src/live_session/path_queries.rs
+++ b/crates/noon/src/live_session/path_queries.rs
@@ -4,7 +4,7 @@ use crate::{AuthoringError, UnsupportedAuthoringOperation};
 
 impl LiveSession<'_> {
     /// Capture exact current path controls and transform from one coherent
-    /// runtime publication. Active reveals remain explicitly unsupported.
+    /// runtime publication, including the currently revealed prefix of a path.
     pub fn effective_path_query(&self, object: &Mobject) -> Result<PathQuery, LiveSessionError> {
         self.require_mobject(object)?;
         let store = self.store.borrow();
@@ -14,9 +14,6 @@ impl LiveSession<'_> {
         let unsupported = || {
             AuthoringError::Unsupported(UnsupportedAuthoringOperation::EffectivePathRenderOverride)
         };
-        if observed.reveal != 1.0 {
-            return Err(unsupported().into());
-        }
         let geometry = observed
             .render_geometry
             .or_else(|| observed.object.content.geometry())
@@ -27,10 +24,18 @@ impl LiveSession<'_> {
             AuthoringError::Unsupported(UnsupportedAuthoringOperation::PathQueryContent),
         )?;
         if let Some(target) = path.morph_target() {
+            // Retained morph meshes currently use flattened sample progress for
+            // reveal. Do not report different curve-parameter geometry here.
+            if observed.reveal != 1.0 {
+                return Err(unsupported().into());
+            }
             path = noon_geometry::interpolate_path_preserving_order(&path, target, observed.morph)
                 .map_err(AuthoringError::MorphQuery)?;
         } else if observed.morph != 0.0 {
             return Err(unsupported().into());
+        }
+        if observed.reveal != 1.0 {
+            path = noon_geometry::authored_partial_path(&path, 0.0, observed.reveal);
         }
         let state = store
             .semantic_object_state_checked(object.node_id())

--- a/crates/noon/tests/path_queries.rs
+++ b/crates/noon/tests/path_queries.rs
@@ -102,14 +102,58 @@ fn effective_queries_capture_one_live_affine_publication() {
 }
 
 #[test]
-fn current_queries_reject_active_content_overrides() {
+fn effective_reveal_queries_keep_curve_boundaries_transforms_and_snapshots() {
     let scene = Scene::new();
-    let object = scene.circle(1.).unwrap();
-    let mut session = scene.execution_session().unwrap();
-    let mut live = scene.live(&mut session);
-    live.declare_and_activate_create(&object, AnimationOptions::new())
+    let mut object = scene
+        .path(
+            VectorPath::new()
+                .move_to(Vec2::ZERO)
+                .line_to(Vec2::new(4., 0.))
+                .move_to(Vec2::new(10., 0.))
+                .line_to(Vec2::new(10., 2.)),
+            Default::default(),
+        )
         .unwrap();
-    assert!(live.effective_path_query(&object).is_err());
+    object.set_scale(2., 1.).unwrap();
+    object.shift(1., 3.).unwrap();
+    let mut session = scene.execution_session().unwrap();
+    let snapshot;
+    {
+        let mut live = scene.live(&mut session);
+        let segment = live
+            .declare_and_activate_create(
+                &object,
+                AnimationOptions::new()
+                    .run_time(2.)
+                    .rate_func(RateFunction::Linear),
+            )
+            .unwrap();
+        let initial = live.effective_path_query(&object).unwrap();
+        near(initial.start().unwrap(), (1., 3.));
+        near(initial.end().unwrap(), (1., 3.));
+        live.advance_segment_to(segment, 1.5).unwrap();
+        snapshot = live.effective_path_query(&object).unwrap();
+        assert_eq!(snapshot.curve_count(), 2);
+        assert_eq!(snapshot.subpaths().len(), 2);
+        near(snapshot.end().unwrap(), (21., 4.));
+        assert!((snapshot.arc_length(None).unwrap() - 9.).abs() < 1e-6);
+        live.advance_segment_to(segment, 2.).unwrap();
+        live.complete_segment(segment).unwrap();
+        near(
+            live.effective_path_query(&object).unwrap().end().unwrap(),
+            (21., 5.),
+        );
+        near(snapshot.end().unwrap(), (21., 4.));
+    }
+    let committed_revision = scene.revision();
+    session.seek(1.5).unwrap();
+    let replay = scene
+        .live(&mut session)
+        .effective_path_query(&object)
+        .unwrap();
+    assert_eq!(replay.anchors_and_handles(), snapshot.anchors_and_handles());
+    assert_eq!(scene.revision(), committed_revision);
+    near(object.path_query().unwrap().end().unwrap(), (21., 5.));
 }
 
 #[test]

--- a/parity/manim-v0.21/core-examples/path_queries.py
+++ b/parity/manim-v0.21/core-examples/path_queries.py
@@ -15,3 +15,5 @@ class OrdinaryPathQueries(Scene):
         target = rectangle.copy().stretch(1.2, 0)
         self.play(Transform(rectangle, target), run_time=1, rate_func=linear)
         self.wait(0.2)
+        self.remove(ellipse)
+        self.play(Create(ellipse), run_time=1, rate_func=linear)

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -640,7 +640,7 @@
       "id": "path-queries",
       "scene": "OrdinaryPathQueries",
       "source": "parity/manim-v0.21/core-examples/path_queries.py",
-      "expected_duration": 1.2,
+      "expected_duration": 2.2,
       "raster_tolerance": {
         "max_bounds_delta_px": 1,
         "max_differing_ratio": 0.0036,

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -53,7 +53,7 @@ const examples = [
   { name: "Canonical curve layout", factory: "createDirectCanonicalCurveLayoutSmokeRenderer", objectCount: 4, duration: 0.2 },
   { name: "Point matching", factory: "createDirectPointMatchingSmokeRenderer", objectCount: 2, duration: 0.2 },
   { name: "Animated stroke width", factory: "createDirectAnimatedStrokeWidthSmokeRenderer", objectCount: 1, duration: 2 },
-  { name: "Path queries", factory: "createDirectPathQueriesSmokeRenderer", objectCount: 10, duration: 1.2 },
+  { name: "Path queries", factory: "createDirectPathQueriesSmokeRenderer", objectCount: 10, duration: 2.2 },
   { name: "Z-index", factory: "createDirectZIndexSmokeRenderer", objectCount: 3, duration: 0.2 },
   { name: "Scale pivots", factory: "createDirectScalePivotsSmokeRenderer", objectCount: 4, duration: 1.0 },
   { name: "Family grid", factory: "createDirectFamilyGridSmokeRenderer", objectCount: 4, duration: 0.2 },

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -863,6 +863,29 @@ def _manim_effective_morph_path():
     return _morph_path_observation(shape)
 
 
+def _noon_effective_reveal_path():
+    scene = noon.Scene()
+    shape = noon.Circle(radius=1).stretch(1.5, 0).shift(noon.RIGHT)
+    scene.play(noon.Create(shape), run_time=1, rate_func=noon.linear)
+    live = scene.live_execution()
+    observations = []
+    for t in (0., .25, .625, 1.):
+        live.evaluate(t)
+        observations.append(_morph_path_observation(shape))
+    return observations
+
+
+def _manim_effective_reveal_path():
+    shape = manim.Circle(radius=1).stretch(1.5, 0).shift(manim.RIGHT)
+    animation = manim.Create(shape, run_time=1, rate_func=manim.linear)
+    animation.begin()
+    observations = []
+    for t in (0., .25, .625, 1.):
+        animation.interpolate(t)
+        observations.append(_morph_path_observation(shape))
+    return observations
+
+
 def _world_stretch(api):
     shape = api.Square(side_length=2).rotate(.37).shift(api.RIGHT - api.UP)
     shape.stretch(-1.5, 0, about_point=2 * api.RIGHT)
@@ -1004,6 +1027,7 @@ def _point_matching(api):
 
 
 FIXTURES = [
+    Fixture("effective_reveal_path", _noon_effective_reveal_path, _manim_effective_reveal_path, 1e-5),
     Fixture("effective_morph_path", _noon_effective_morph_path, _manim_effective_morph_path, 1e-5),
     Fixture("world_stretch", lambda: _world_stretch(noon), lambda: _world_stretch(manim), 1e-5),
     Fixture("path_alignment", lambda: _path_alignment(noon), lambda: _path_alignment(manim), 1e-5),

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -795,7 +795,7 @@ try {
     { filename: "ordinary_path_editing.py", objectCount: 3, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_point_matching.py", objectCount: 2, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_animated_stroke_width.py", objectCount: 1, expectedDuration: 2, endpointTime: null },
-    { filename: "ordinary_path_queries.py", objectCount: 10, expectedDuration: 1.2, endpointTime: null },
+    { filename: "ordinary_path_queries.py", objectCount: 10, expectedDuration: 2.2, endpointTime: null },
     { filename: "ordinary_z_index.py", objectCount: 3, expectedDuration: 0.2, endpointTime: null },
     { filename: "ordinary_scale_pivots.py", objectCount: 4, expectedDuration: 1.0, endpointTime: null },
     { filename: "ordinary_family_grid.py", objectCount: 4, expectedDuration: 0.2, endpointTime: null },

--- a/web/python/examples/ordinary_path_queries.py
+++ b/web/python/examples/ordinary_path_queries.py
@@ -26,3 +26,10 @@ class OrdinaryPathQueries(Scene):
         wait_end = live.wait(0.2)
         live.advance_to(wait_end)
         live.complete()
+        self.remove(ellipse)
+        self.play(Create(ellipse), run_time=1, rate_func=linear)
+        observed = self.live_execution()
+        observed.evaluate(1.7)
+        endpoint = ellipse.get_end()
+        assert abs(endpoint[0] - 1.3) < 2e-6 and abs(endpoint[1]) < 2e-6
+        observed.evaluate(2.2)


### PR DESCRIPTION
Advances #78 under #954. Current path getters during creation and uncreation now observe the revealed prefix from one coherent Runtime publication. Shared Rust partial-path preparation preserves curve-count semantics, degenerate boundary controls, subpath breaks and effective transforms; snapshots remain unchanged after execution advances. No semantic resource or revision is created by a read.

The paired native Rust/direct-WASM and Python path-query example inspects the endpoint halfway through an ellipse reveal. A pinned Manim probe covers zero, interior curve boundaries, partial curves and completion. Combined morph plus reveal remains explicitly rejected until retained morph-mesh progress and curve-parameter progress share a contract; this does not silently return full authored geometry.

No migration seam or new authority. Preparation is proportional to the selected path's curves and does not inspect unrelated objects. Seven focused native path-query tests pass, including snapshot, subpath and seek checks. `bash scripts/check.sh full` passed with `NOON_WASM_PROFILE=dev` and `NOON_RENDERER_SMOKE=1`: workspace tests, architecture guards, format/check/clippy, web/Python checks and 229 WASM API contracts. `node scripts/manim-differential-noon.mjs /tmp/noon-reveal-semantic.json` ran all 84 actual WASM/Python probes successfully; `node scripts/shared-authoring-smoke.mjs` passed the complete shared browser corpus. Final GitHub checks and pinned Manim comparisons are running. Depends on #1410.
