### PR TITLE
Support rotated become through atomic shared path replacement

### DIFF
--- a/crates/noon/src/example_scenes/family_state.rs
+++ b/crates/noon/src/example_scenes/family_state.rs
@@ -53,10 +53,11 @@ pub fn program() -> Result<LiveProgram<FamilyState>, String> {
         let replacement = source.copy_family()?.root().clone();
         replacement.shift(1.0, 0.0)?;
         replacement.scale(1.5, 1.5)?;
+        replacement.rotate(0.3, crate::ManimRotationPivot::Center)?;
         source.become_family(
             &replacement,
             ManimBecomeOptions {
-                match_width: true,
+                stretch: true,
                 ..Default::default()
             },
         )?;

--- a/crates/noon/src/live_session.rs
+++ b/crates/noon/src/live_session.rs
@@ -18,13 +18,13 @@ pub use family_layout::LiveLayoutTarget;
 use crate::execution_session::EffectiveSemanticObject;
 use crate::{
     family_arrangement::FamilyArrangePlan,
-    semantic_mobject::{authoring_render_f64, stage_state_changes},
+    semantic_mobject::authoring_render_f64,
     semantic_mobject::{
         edit_color, edit_disable_fill, edit_disable_stroke, edit_fill, edit_fill_color,
         edit_fill_opacity, edit_manim_opacity, edit_object_opacity, edit_stroke, edit_stroke_color,
         edit_stroke_opacity,
     },
-    state_replacement::prepare_become_state,
+    state_replacement::prepare_become,
     DeclaredAnimation, ExecutionSegment, ExecutionSegmentAdvanceError,
     ExecutionSegmentCompletionError, ExecutionSegmentError, ExecutionSegmentState,
     ExecutionSession, ExecutionSessionAnimationError, ExecutionSessionPublicationError,
@@ -751,14 +751,16 @@ impl<'a> LiveSession<'a> {
     ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
         self.require_mobject(target)?;
         self.require_mobject(other)?;
-        let authored = target.state().map_err(LiveSessionError::from)?;
         let source = self.capture_mobject_state(target)?;
         let candidate = self.capture_mobject_state(other)?;
-        let next = prepare_become_state(&self.store.borrow(), &source, candidate, options)
-            .map_err(LiveSessionError::from)?;
-        let mut transaction = SemanticMutationTransaction::new();
-        stage_state_changes(&mut transaction, target.node_id(), &authored, &next);
-        self.apply(transaction)
+        let prepared = prepare_become(
+            &self.store.borrow(),
+            target.node_id(),
+            &source,
+            candidate,
+            options,
+        )?;
+        self.publish_path_edits(prepared)
     }
 
     /// Replace a matching family's presentation from one coherent capture.
@@ -772,13 +774,11 @@ impl<'a> LiveSession<'a> {
         self.require_family(source)?;
         self.require_family(target)?;
         self.require_target_capture()?;
-        let transaction = crate::state_replacement::family_become_transaction(
-            source,
-            target,
-            options,
-            |object| self.capture_mobject_state(object),
-        )?;
-        self.apply(transaction)
+        let prepared =
+            crate::state_replacement::prepare_family_become(source, target, options, |object| {
+                self.capture_mobject_state(object)
+            })?;
+        self.publish_path_edits(prepared)
     }
 
     fn capture_mobject_state(

--- a/crates/noon/src/live_session/family_layout.rs
+++ b/crates/noon/src/live_session/family_layout.rs
@@ -76,7 +76,7 @@ impl LiveSession<'_> {
             &leaves,
             boundary,
         )?;
-        self.publish_affine(prepared).map(|_| ())
+        self.publish_path_edits(prepared).map(|_| ())
     }
 
     /// Match the effective target dimension; no wrapper computes layout ratios.
@@ -154,7 +154,7 @@ impl LiveSession<'_> {
             stretch,
         )
         .map_err(LiveSessionError::from)?;
-        self.publish_affine(prepared).map(|_| ())
+        self.publish_path_edits(prepared).map(|_| ())
     }
 
     /// Publish one alias-aware family scale after validating every local member.
@@ -303,23 +303,7 @@ impl LiveSession<'_> {
             self.placement_authored_transform(&object)?;
         }
         let prepared = operation.prepare(&self.store.borrow(), &leaves, bounds)?;
-        self.publish_affine(prepared)
-    }
-
-    fn publish_affine(
-        &mut self,
-        prepared: crate::path_editing::PreparedPathEdits,
-    ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
-        let mut store = self.store.borrow_mut();
-        if prepared.creates_resources() {
-            self.session
-                .require_resource_creation_at_root(&store, self.root)?;
-        }
-        prepared.publish(&mut store, |store, transaction| {
-            self.session
-                .apply_semantic_transaction_at_root(store, self.root, transaction)
-                .map_err(LiveSessionError::from)
-        })
+        self.publish_path_edits(prepared)
     }
 
     /// Observe this family's effective bounds, including detached authored members.

--- a/crates/noon/src/live_session/path_editing.rs
+++ b/crates/noon/src/live_session/path_editing.rs
@@ -2,6 +2,22 @@ use super::*;
 use crate::path_editing::{path_is_unchanged, path_replacement_state, path_transaction, PathEdit};
 
 impl LiveSession<'_> {
+    pub(super) fn publish_path_edits(
+        &mut self,
+        prepared: crate::path_editing::PreparedPathEdits,
+    ) -> Result<SemanticMutationTransactionResult, LiveSessionError> {
+        let mut store = self.store.borrow_mut();
+        if prepared.creates_resources() {
+            self.session
+                .require_resource_creation_at_root(&store, self.root)?;
+        }
+        prepared.publish(&mut store, |store, transaction| {
+            self.session
+                .apply_semantic_transaction_at_root(store, self.root, transaction)
+                .map_err(LiveSessionError::from)
+        })
+    }
+
     /// Copy a selected interval from one coherent effective publication.
     pub fn subcurve(
         &mut self,

--- a/crates/noon/src/path_editing/transaction.rs
+++ b/crates/noon/src/path_editing/transaction.rs
@@ -5,6 +5,7 @@ use noon_core::{SemanticNodeId, StoredGeometry};
 pub(crate) struct PreparedPathEdits {
     states: Vec<(SemanticNodeId, SemanticObjectState, SemanticObjectState)>,
     paths: Vec<VectorPath>,
+    property_edits: Vec<(SemanticNodeId, SemanticObjectState, SemanticObjectState)>,
     transaction: SemanticMutationTransaction,
 }
 
@@ -16,12 +17,19 @@ impl PreparedPathEdits {
         let mut result = Self {
             states: Vec::new(),
             paths: Vec::new(),
+            property_edits: Vec::new(),
             transaction: SemanticMutationTransaction::new(),
         };
         for (node, captured, path) in replacements {
             let before = store.semantic_object_state_checked(node)?;
             let after = path_replacement_state(captured)?;
             if path_is_unchanged(store, before, &after, &path) {
+                // The geometry can already match while become changes paint or
+                // other presentation. Preserve the shared resource but publish
+                // those state changes in the same atomic transaction.
+                let mut after = after;
+                after.content = before.content;
+                result.property_edits.push((node, before.clone(), after));
                 continue;
             }
             result.states.push((node, before.clone(), after));
@@ -49,6 +57,14 @@ impl PreparedPathEdits {
     {
         store.with_geometry_paths(self.paths, |store, handles| {
             let mut transaction = self.transaction;
+            for (node, before, after) in self.property_edits {
+                crate::semantic_mobject::stage_state_changes(
+                    &mut transaction,
+                    node,
+                    &before,
+                    &after,
+                );
+            }
             for ((node, before, mut after), handle) in self.states.into_iter().zip(handles) {
                 after.content = StoredGeometry::Resource(*handle).into();
                 crate::semantic_mobject::stage_state_changes(
@@ -60,5 +76,45 @@ impl PreparedPathEdits {
             }
             publish(store, transaction)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unchanged_path_preserves_resource_and_still_publishes_target_paint() {
+        let scene = crate::Scene::new();
+        let object = scene
+            .path(
+                VectorPath::new()
+                    .move_to(Vec2::ZERO)
+                    .line_to(Vec2::new(2., 0.)),
+                Default::default(),
+            )
+            .unwrap();
+        let before = object.state().unwrap();
+        let mut captured = before.clone();
+        captured.style.object_opacity = 0.25;
+        let store = scene.integration_store();
+        let path = crate::path_editing::world_path(&store.borrow(), &before).unwrap();
+        let count = store.borrow().geometry_resources().len();
+        let prepared =
+            PreparedPathEdits::prepare(&store.borrow(), [(object.node_id(), captured, path)])
+                .unwrap();
+        let mut transaction = SemanticMutationTransaction::new();
+        transaction.set_z_index(object.node_id(), 2.0);
+        prepared
+            .with_transaction(transaction)
+            .publish(&mut store.borrow_mut(), |store, transaction| {
+                transaction.apply(store).map_err(AuthoringError::from)
+            })
+            .unwrap();
+        let after = object.state().unwrap();
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.style.object_opacity, 0.25);
+        assert_eq!(after.z_index(), 2.0);
+        assert_eq!(store.borrow().geometry_resources().len(), count);
     }
 }

--- a/crates/noon/src/semantic_mobject.rs
+++ b/crates/noon/src/semantic_mobject.rs
@@ -3,7 +3,7 @@
 //! Handles retain only their originating store and generational identity. All
 //! durable edits use the canonical transaction vocabulary. Captured state is
 //! transient input to shared preparation and coherent publication.
-use crate::{state_replacement::prepare_become_state, AuthoringError, ManimBecomeOptions};
+use crate::{state_replacement::prepare_become, AuthoringError, ManimBecomeOptions};
 use noon_core::{
     Bounds2D64, Color, GeometryRef, GeometryResource, PathCommand, SemanticMutationImpact,
     SemanticMutationTransaction, SemanticNodeCreation, SemanticNodeId, SemanticObjectContent,
@@ -621,8 +621,13 @@ impl Mobject {
         self.require_same_store(other)?;
         let source = self.state()?;
         let target = other.state()?;
-        let state = prepare_become_state(&self.store.borrow(), &source, target, options)?;
-        self.commit_state(state)
+        let prepared = prepare_become(&self.store.borrow(), self.id, &source, target, options)?;
+        prepared.publish(&mut self.store.borrow_mut(), |store, transaction| {
+            transaction
+                .apply(store)
+                .map(|_| ())
+                .map_err(AuthoringError::from)
+        })
     }
 
     /// Derive the effective transform that maps this analytic Line's immutable

--- a/crates/noon/src/state_replacement.rs
+++ b/crates/noon/src/state_replacement.rs
@@ -12,12 +12,12 @@ use noon_core::{Bounds2D64, SemanticMutationTransaction, SemanticObjectState, Se
 
 /// Pair through the same topology/alias contract as ordinary family Transform.
 /// All captures and fitting succeed before a caller can publish any edit.
-pub(crate) fn family_become_transaction<E: From<AuthoringError>>(
+pub(crate) fn prepare_family_become<E: From<AuthoringError>>(
     source: &MobjectFamily,
     target: &MobjectFamily,
     options: ManimBecomeOptions,
     mut capture: impl FnMut(&Mobject) -> Result<SemanticObjectState, E>,
-) -> Result<SemanticMutationTransaction, E> {
+) -> Result<crate::path_editing::PreparedPathEdits, E> {
     if !Rc::ptr_eq(source.integration_store(), target.integration_store()) {
         return Err(AuthoringError::ForeignStore.into());
     }
@@ -30,7 +30,11 @@ pub(crate) fn family_become_transaction<E: From<AuthoringError>>(
     {
         Ok(pairs) => pairs,
         Err(noon_core::SemanticFamilyPairingError::Empty) => {
-            return Ok(SemanticMutationTransaction::new())
+            return crate::path_editing::PreparedPathEdits::prepare(
+                &source.integration_store().borrow(),
+                Vec::new(),
+            )
+            .map_err(E::from)
         }
         Err(error) => return Err(AuthoringError::from(error).into()),
     };
@@ -49,8 +53,9 @@ pub(crate) fn family_become_transaction<E: From<AuthoringError>>(
     let store = source.integration_store().borrow();
     let targets = prepare_become_states(&store, &sources, targets, options)?;
     let mut transaction = SemanticMutationTransaction::new();
+    let mut replacements = Vec::new();
     let mut staged = HashMap::<noon_core::SemanticNodeId, SemanticObjectState>::new();
-    for ((source, target_id), mut target) in pairs.into_iter().zip(targets) {
+    for ((source, target_id), (mut target, path)) in pairs.into_iter().zip(targets) {
         // Plain Manim become reads a shared target after preceding leaf writes.
         // Matching options copy the target first, so those reads stay captured.
         if options == ManimBecomeOptions::default() {
@@ -62,9 +67,16 @@ pub(crate) fn family_become_transaction<E: From<AuthoringError>>(
         let previous = store
             .semantic_object_state_checked(source)
             .map_err(AuthoringError::from)?;
-        stage_state_changes(&mut transaction, source, previous, &target);
+        if let Some(path) = path {
+            replacements.push((source, target, path));
+        } else {
+            stage_state_changes(&mut transaction, source, previous, &target);
+        }
     }
-    Ok(transaction)
+    Ok(
+        crate::path_editing::PreparedPathEdits::prepare(&store, replacements)?
+            .with_transaction(transaction),
+    )
 }
 
 impl MobjectFamily {
@@ -76,10 +88,15 @@ impl MobjectFamily {
         target: &Self,
         options: ManimBecomeOptions,
     ) -> Result<(), AuthoringError> {
-        family_become_transaction(self, target, options, Mobject::state)?
-            .apply(&mut self.integration_store().borrow_mut())
-            .map(|_| ())
-            .map_err(AuthoringError::from)
+        prepare_family_become(self, target, options, Mobject::state)?.publish(
+            &mut self.integration_store().borrow_mut(),
+            |store, transaction| {
+                transaction
+                    .apply(store)
+                    .map(|_| ())
+                    .map_err(AuthoringError::from)
+            },
+        )
     }
 }
 
@@ -93,16 +110,32 @@ pub struct ManimBecomeOptions {
     pub stretch: bool,
 }
 
-pub(crate) fn prepare_become_state(
+pub(crate) fn prepare_become(
     store: &SemanticStore,
+    node: noon_core::SemanticNodeId,
     source: &SemanticObjectState,
     target: SemanticObjectState,
     options: ManimBecomeOptions,
-) -> Result<SemanticObjectState, AuthoringError> {
-    Ok(
+) -> Result<crate::path_editing::PreparedPathEdits, AuthoringError> {
+    let (target, path) =
         prepare_become_states(store, std::slice::from_ref(source), vec![target], options)?
             .pop()
-            .expect("one target state"),
+            .expect("one target state");
+    let mut transaction = SemanticMutationTransaction::new();
+    let replacements = if let Some(path) = path {
+        vec![(node, target, path)]
+    } else {
+        stage_state_changes(
+            &mut transaction,
+            node,
+            store.semantic_object_state_checked(node)?,
+            &target,
+        );
+        Vec::new()
+    };
+    Ok(
+        crate::path_editing::PreparedPathEdits::prepare(store, replacements)?
+            .with_transaction(transaction),
     )
 }
 
@@ -111,9 +144,9 @@ pub(crate) fn prepare_become_state(
 pub(crate) fn prepare_become_states(
     store: &SemanticStore,
     source: &[SemanticObjectState],
-    mut targets: Vec<SemanticObjectState>,
+    targets: Vec<SemanticObjectState>,
     options: ManimBecomeOptions,
-) -> Result<Vec<SemanticObjectState>, AuthoringError> {
+) -> Result<Vec<(SemanticObjectState, Option<noon_core::VectorPath>)>, AuthoringError> {
     fn bounds(
         store: &SemanticStore,
         states: &[SemanticObjectState],
@@ -195,15 +228,29 @@ pub(crate) fn prepare_become_states(
     } else {
         target_center
     };
-    for target in &mut targets {
-        let (local_x, local_y) =
-            crate::dimension_fit::world_scale_factors(target.transform.rotation_z, x, y)?;
-        let old_center = state_center(store, target)?;
+    let mut result = Vec::with_capacity(targets.len());
+    for mut target in targets {
+        let Ok((local_x, local_y)) =
+            crate::dimension_fit::world_scale_factors(target.transform.rotation_z, x, y)
+        else {
+            let path = crate::family_affine::world_scaled_path(
+                store,
+                &target,
+                x,
+                y,
+                target_center,
+                destination,
+            )?;
+            result.push((target, Some(path)));
+            continue;
+        };
+        let old_center = state_center(store, &target)?;
         let next_center = (
             destination.0 + (old_center.0 - target_center.0) * x,
             destination.1 + (old_center.1 - target_center.1) * y,
         );
-        scale_state_about_center(store, target, local_x, local_y, next_center)?;
+        scale_state_about_center(store, &mut target, local_x, local_y, next_center)?;
+        result.push((target, None));
     }
-    Ok(targets)
+    Ok(result)
 }

--- a/crates/noon/tests/family_state.rs
+++ b/crates/noon/tests/family_state.rs
@@ -96,7 +96,7 @@ fn dimension_matching_uses_aggregate_bounds_and_center_not_individual_leaf_sizes
 }
 
 #[test]
-fn topology_alias_foreign_and_rotated_stretch_rejections_are_atomic() {
+fn invalid_family_become_is_atomic_and_rotated_stretch_preserves_dimensions() {
     let scene = Scene::new();
     let source = family(&scene);
     let different = scene.family(&[]).unwrap();
@@ -112,16 +112,20 @@ fn topology_alias_foreign_and_rotated_stretch_rejections_are_atomic() {
     target
         .rotate(0.3, noon::ManimRotationPivot::Center)
         .unwrap();
-    assert!(source
+    source
         .become_family(
             &target,
             ManimBecomeOptions {
                 stretch: true,
+                match_center: true,
                 ..Default::default()
-            }
+            },
         )
-        .is_err());
-    assert_eq!(source.layout_bounds().unwrap(), saved);
+        .unwrap();
+    let after = source.layout_bounds().unwrap().unwrap();
+    let before = saved.unwrap();
+    close(after.width(), before.width());
+    close(after.height(), before.height());
     different
         .become_family(&different, Default::default())
         .unwrap();
@@ -169,11 +173,20 @@ fn paired_program_animates_and_restores_through_coherent_completion() {
         program.resume().unwrap(),
         LiveProgramStatus::Awaiting(_)
     ));
+    let center = |program: &noon::LiveProgram<noon::example_scenes::family_state::FamilyState>| {
+        let frame = program.session().frame();
+        frame
+            .render_geometry(0)
+            .unwrap()
+            .world_bounds(frame.render_transform(0))
+            .unwrap()
+            .center()
+    };
+    let initial = center(&program);
     program.drive_to(&mut callbacks, 0.2).unwrap();
-    close(
-        f64::from(program.session().frame().render_transform(0).translation.x),
-        -0.5,
-    );
+    let midpoint = center(&program);
+    close(f64::from(midpoint.x - initial.x), 0.5);
+    close(f64::from(midpoint.y - initial.y), 0.5);
     for time in [0.4, 0.6000000000000001] {
         assert!(matches!(
             program.drive_to(&mut callbacks, time).unwrap(),
@@ -183,10 +196,8 @@ fn paired_program_animates_and_restores_through_coherent_completion() {
         program.admit_publication(context).unwrap();
         program.resume().unwrap();
     }
-    close(
-        f64::from(program.session().frame().render_transform(0).translation.x),
-        -2.0,
-    );
+    close(f64::from(center(&program).x), -2.0);
+    close(f64::from(center(&program).y), 0.0);
 }
 
 #[test]

--- a/crates/noon/tests/rotated_become.rs
+++ b/crates/noon/tests/rotated_become.rs
@@ -1,0 +1,141 @@
+use noon::{ManimBecomeOptions, Scene, Vec2, VectorPath};
+
+fn near(a: (f64, f64), b: (f64, f64)) {
+    assert!(
+        (a.0 - b.0).abs() < 2e-6 && (a.1 - b.1).abs() < 2e-6,
+        "{a:?} != {b:?}"
+    );
+}
+fn resources(scene: &Scene) -> usize {
+    scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len()
+}
+fn options() -> ManimBecomeOptions {
+    ManimBecomeOptions {
+        stretch: true,
+        match_center: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn rotated_become_preserves_world_controls_identity_and_unchanged_resources() {
+    let scene = Scene::new();
+    let mut source = scene.rectangle(4., 1.).unwrap();
+    source.shift(-2., 1.).unwrap();
+    let mut target = scene.square(2.).unwrap();
+    target.rotate(0.37).unwrap();
+    target.shift(3., -1.).unwrap();
+    let original = target.state().unwrap();
+    let before = target.path_query().unwrap();
+    let origin = target.center().unwrap();
+    let scale = (
+        source.width().unwrap() / target.width().unwrap(),
+        source.height().unwrap() / target.height().unwrap(),
+    );
+    let center = source.center().unwrap();
+    let id = source.node_id();
+    let count = resources(&scene);
+    source.become_handle(&target, options()).unwrap();
+    let after = source.path_query().unwrap();
+    for i in 0..before.curve_count() {
+        for (a, b) in before
+            .curve_points(i)
+            .unwrap()
+            .into_iter()
+            .zip(after.curve_points(i).unwrap())
+        {
+            near(
+                b,
+                (
+                    center.0 + (a.0 - origin.0) * scale.0,
+                    center.1 + (a.1 - origin.1) * scale.1,
+                ),
+            );
+        }
+    }
+    assert_eq!(source.node_id(), id);
+    assert_eq!(target.state().unwrap(), original);
+    assert_eq!(resources(&scene), count + 1);
+    // A target with identical retained geometry and different paint keeps its
+    // resource and still commits the target style.
+    let mut painted = source.copy_handle().unwrap();
+    painted.set_fill(1., 0., 0., 1.).unwrap();
+    let content = source.state().unwrap().content;
+    source.become_handle(&painted, options()).unwrap();
+    assert_eq!(source.state().unwrap().content, content);
+    assert_eq!(
+        source.state().unwrap().style,
+        painted.state().unwrap().style
+    );
+    assert_eq!(resources(&scene), count + 1);
+}
+
+#[test]
+fn live_become_publishes_new_content_once_and_leaves_unrelated_objects_untouched() {
+    let mut scene = Scene::new();
+    let source = scene.rectangle(4., 1.).unwrap();
+    let mut target = scene.square(2.).unwrap();
+    target.rotate(0.37).unwrap();
+    let unrelated = scene.circle(1.).unwrap();
+    scene
+        .add_many(&[(&source).into(), (&unrelated).into()])
+        .unwrap();
+    let untouched = unrelated.state().unwrap();
+    let revision = scene.revision();
+    let mut session = scene.execution_session().unwrap();
+    let mut live = scene.live(&mut session);
+    live.become_mobject(&source, &target, options()).unwrap();
+    let layout = live.effective_layout(&source).unwrap();
+    near((layout.width, layout.height), (4., 1.));
+    assert_eq!(scene.revision(), revision.checked_next().unwrap());
+    assert_eq!(unrelated.state().unwrap(), untouched);
+    assert_eq!(session.frame().objects.len(), 2);
+    assert_eq!(session.last_patch_stats().full_seeks, 0);
+}
+
+#[test]
+fn unsupported_late_stroke_rolls_back_the_entire_family_and_resource_admission() {
+    let scene = Scene::new();
+    let mut source_a = scene.square(2.).unwrap();
+    source_a.shift(-2., 0.).unwrap();
+    let mut source_b = scene.square(2.).unwrap();
+    source_b.shift(2., 0.).unwrap();
+    let source = scene
+        .family(&[(&source_a).into(), (&source_b).into()])
+        .unwrap();
+    let mut a = scene.square(1.).unwrap();
+    a.rotate(0.4).unwrap();
+    a.shift(-1., 0.).unwrap();
+    let mut b = scene
+        .path(
+            VectorPath::new()
+                .move_to(Vec2::ZERO)
+                .line_to(Vec2::new(1., 0.))
+                .line_to(Vec2::new(1., 1.))
+                .close(),
+            noon_core::SemanticStyle {
+                stroke: Some(noon_core::SemanticPaint::Solid(noon_core::Color::WHITE)),
+                stroke_width: 0.04,
+                stroke_width_mode: noon_core::StrokeWidthMode::ScaleWithObject,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    b.rotate(0.4).unwrap();
+    b.shift(1., 0.).unwrap();
+    let target = scene.family(&[(&a).into(), (&b).into()]).unwrap();
+    let before = [source_a.state().unwrap(), source_b.state().unwrap()];
+    let revision = scene.revision();
+    let count = resources(&scene);
+    assert!(source.become_family(&target, options()).is_err());
+    assert_eq!(
+        [source_a.state().unwrap(), source_b.state().unwrap()],
+        before
+    );
+    assert_eq!(scene.revision(), revision);
+    assert_eq!(resources(&scene), count);
+}

--- a/parity/manim-v0.21/core-examples/family_state.py
+++ b/parity/manim-v0.21/core-examples/family_state.py
@@ -8,8 +8,8 @@ class OrdinaryFamilyState(Scene):
         nested = VGroup(a, b)
         family = VGroup(a, nested)
         family.save_state()
-        replacement = family.copy().shift(RIGHT).scale(1.5)
-        family.become(replacement, match_width=True)
+        replacement = family.copy().shift(RIGHT).scale(1.5).rotate(0.3)
+        family.become(replacement, stretch=True)
         assert family[0] is a and family[1][0] is a
         self.add(family)
         family.generate_target()

--- a/scripts/manim-differential.py
+++ b/scripts/manim-differential.py
@@ -886,6 +886,20 @@ def _manim_effective_reveal_path():
     return observations
 
 
+def _rotated_become(api):
+    source = api.Rectangle(width=4, height=1).shift(api.LEFT)
+    target = api.Square(side_length=2).rotate(.37).shift(api.RIGHT + api.UP)
+    source.become(target, stretch=True, match_center=True)
+    leaf = _morph_path_observation(source)
+    a = api.Square(side_length=.6).shift(2 * api.LEFT)
+    b = api.Square(side_length=.6)
+    family = api.VGroup(a, api.VGroup(a, b))
+    replacement = family.copy().rotate(.3).shift(api.RIGHT)
+    family.become(replacement, stretch=True)
+    return {"leaf": leaf, "family": [_morph_path_observation(obj) for obj in (a, b)],
+            "bounds": _object_observation(family)}
+
+
 def _world_stretch(api):
     shape = api.Square(side_length=2).rotate(.37).shift(api.RIGHT - api.UP)
     shape.stretch(-1.5, 0, about_point=2 * api.RIGHT)
@@ -1029,6 +1043,7 @@ def _point_matching(api):
 FIXTURES = [
     Fixture("effective_reveal_path", _noon_effective_reveal_path, _manim_effective_reveal_path, 1e-5),
     Fixture("effective_morph_path", _noon_effective_morph_path, _manim_effective_morph_path, 1e-5),
+    Fixture("rotated_become", lambda: _rotated_become(noon), lambda: _rotated_become(manim), 1e-5),
     Fixture("world_stretch", lambda: _world_stretch(noon), lambda: _world_stretch(manim), 1e-5),
     Fixture("path_alignment", lambda: _path_alignment(noon), lambda: _path_alignment(manim), 1e-5),
     Fixture("boolean_geometry", lambda: _boolean_geometry(noon), lambda: _boolean_geometry(manim), 1e-5),

--- a/scripts/shared-authoring-smoke.mjs
+++ b/scripts/shared-authoring-smoke.mjs
@@ -1705,11 +1705,19 @@ class SelectedAlignment(Scene):
   await startSampledSource(page, familyStateSource, "scene-shared-family-state");
   try {
     const canvas = page.locator("#scene-shared-family-state");
-    for (const [time, leftX, rightX, y] of [[0, -1, 1, 0], [0.2, -0.5, 1.5, 0.5], [0.4, -2, 0, 0], [0.6000000000000001, -2, 0, 0]]) {
+    // Aggregate bounds of two 0.6 squares, separated by 2, scaled 1.5 and
+    // rotated 0.3 before becoming the original 2.6-by-0.6 family.
+    const c = Math.cos(0.3), s = Math.sin(0.3);
+    const x = 1.5 * c * 2.6 / (3.9 * c + 0.9 * s);
+    const y = 1.5 * s * 0.6 / (3.9 * s + 0.9 * c);
+    for (const [time, leftX, rightX, leftY, rightY] of [
+      [0, -x, x, -y, y], [0.2, 0.5 - x, 0.5 + x, 0.5 - y, 0.5 + y],
+      [0.4, -2, 0, 0, 0], [0.6000000000000001, -2, 0, 0, 0],
+    ]) {
       await page.evaluate(time => window.sharedAuthoringSmoke.sampledProof.execution.sampleToAuthoredTime(time), time);
       const frame = await canvas.screenshot();
-      const left = renderedWorldPixel(frame, leftX, y);
-      const right = renderedWorldPixel(frame, rightX, y);
+      const left = renderedWorldPixel(frame, leftX, leftY);
+      const right = renderedWorldPixel(frame, rightX, rightY);
       assert.ok(left.red > 180 && left.blue < 50, `family state at ${time}s missed red member`);
       assert.ok(right.blue > 180 && right.red < 50, `family state at ${time}s missed blue member`);
     }

--- a/web/direct-execution-smoke-probe.js
+++ b/web/direct-execution-smoke-probe.js
@@ -647,7 +647,7 @@ async function directOrdinaryAffinePlayProof(expectedBackend) {
     throw new Error(`direct ordinary affine authored time is ${metrics.authoredTime}; expected 4`);
   }
   if (metrics.objectCount !== 1 || metrics.drawCalls <= 0) {
-    throw new Error(`direct ordinary affine produced invalid metrics ${JSON.stringify(metrics)}`);
+    throw new Error(`direct ordinary affine produced invalid renderer metrics ${JSON.stringify(metrics)}`);
   }
   if (endpointLuma < 250 || firstEndpointLuma > 60 || shiftedLuma > 60) {
     throw new Error(`direct ordinary affine did not render its x=5 endpoint ${JSON.stringify(metrics)}`);
@@ -1313,11 +1313,21 @@ async function directFamilyStateProof(expectedBackend) {
   try {
     renderer.resize(canvas.width, canvas.height);
     await presentDirectFrame(renderer);
-    for (const [time, leftX, rightX, y] of [[0, -1, 1, 0], [200, -0.5, 1.5, 0.5], [400, -2, 0, 0], [601, -2, 0, 0]]) {
+    // Aggregate bounds of two 0.6 squares, separated by 2, scaled 1.5 and
+    // rotated 0.3 before becoming the original 2.6-by-0.6 family.
+    const c = Math.cos(0.3), s = Math.sin(0.3);
+    const x = 1.5 * c * 2.6 / (3.9 * c + 0.9 * s);
+    const y = 1.5 * s * 0.6 / (3.9 * s + 0.9 * c);
+    for (const [time, leftX, rightX, leftY, rightY] of [
+      [0, -x, x, -y, y],
+      [200, 0.5 - x, 0.5 + x, 0.5 - y, 0.5 + y],
+      [400, -2, 0, 0, 0],
+      [601, -2, 0, 0, 0],
+    ]) {
       renderer.advanceDirectRealtime(time);
       await settleDirectPublication(renderer, time);
-      const left = await sampleRenderedColor(canvas, leftX, y);
-      const right = await sampleRenderedColor(canvas, rightX, y);
+      const left = await sampleRenderedColor(canvas, leftX, leftY);
+      const right = await sampleRenderedColor(canvas, rightX, rightY);
       if (!(left.red > 180 && left.blue < 50 && right.blue > 180 && right.red < 50)) {
         throw new Error(`direct family state at ${time}ms missed expected members: ${JSON.stringify({left, right})}`);
       }

--- a/web/python/examples/ordinary_family_state.py
+++ b/web/python/examples/ordinary_family_state.py
@@ -8,8 +8,8 @@ class OrdinaryFamilyState(Scene):
         nested = VGroup(a, b)
         family = VGroup(a, nested)
         family.save_state()
-        replacement = family.copy().shift(RIGHT).scale(1.5)
-        family.become(replacement, match_width=True)
+        replacement = family.copy().shift(RIGHT).scale(1.5).rotate(0.3)
+        family.become(replacement, stretch=True)
         assert family[0] is a and family[1][0] is a
         self.add(family)
         family.generate_target()


### PR DESCRIPTION
Advances #74 under #954. Rotated `become(..., stretch=True)` now fits target geometry to source world dimensions for individual objects and aliased families. Shared Rust preparation captures operands, computes aggregate fitting once, and publishes affine edits plus any required immutable path replacements through the existing atomic semantic transaction. Source identities/membership and detached target operands remain intact. Python uses its existing thin wrapper.

Ordinary affine replacements reuse target resources. World-axis shear creates paths only for affected leaves; already identical paths retain their resource while paint changes still publish. A failed late member or publication rolls back the whole prepared batch. Nonzero object-scaled stroke deformation retains its existing explicit rejection. No migration seam, frontend geometry engine or new runtime authority. Work is proportional to affected leaves and path curves.

Updated paired native Rust/direct-WASM, Python and pinned Manim family-state examples exercise rotated family replacement before ordinary target animation and restore. A semantic probe checks leaf controls, aliased-family controls and bounds. Tests cover world controls, target/identity preservation, live locality, atomic resource rollback, and paint-only resource reuse.

Validation: 15 focused native family/world-stretch/become tests passed; two Python family-state wrapper tests passed. Focused prepared-resource validation and the full local gate follow, then actual WASM/Python/browser and GitHub qualification. Depends on #1412; initially based on its branch to keep the diff reviewable.
