### PR TITLE
Fix native Text point-to-scene scale

### DIFF
--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -40,10 +40,11 @@ use swash::{FontRef, StringId};
 /// remains an object transform and does not alter glyph/cluster identity.
 #[cfg(feature = "typst")]
 pub const SCALE_FACTOR_PER_FONT_POINT: f32 = 1.0 / 960.0;
-/// Native text is shaped at its requested point size, so only the point-to-scene
-/// conversion belongs in the object transform.
+/// Swash reports its requested size in device pixels while Manim's public native
+/// Text font size is point-based. Convert 72 typographic points per scene-inch here;
+/// the renderer must not compensate for this semantic unit conversion.
 #[cfg(feature = "native-text")]
-pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 96.0;
+pub const NATIVE_POINT_TO_SCENE_SCALE: f32 = 1.0 / 72.0;
 #[cfg(feature = "typst")]
 pub const DEFAULT_TYPST_FONT_SIZE: f32 = 48.0;
 #[cfg(feature = "native-text")]


### PR DESCRIPTION
## Summary

Fix the native `Text` point-to-scene conversion used by the retained text path. Swash shapes at the requested font size, while Manim's public `Text.font_size` is point-based; converting with `1/96` made native Text approximately 3/4 of ManimCE's rendered size. Use `1/72` for the point-to-scene conversion instead.

This is a prerequisite correctness fix for #1376's pinned `text-range-colors` raster qualification. That fixture currently renders successfully on both WebGPU and WebGL but reports reference bounds of about 372x36 px versus Noon's 281x27 px, including an exact 4/3 height ratio. No range-color semantics, Python/WASM styling logic, renderer thresholds, or raster tolerances are changed here.

## Architecture / scope

- Shared Rust text presentation conversion only.
- Semantic/resource identity and shaped glyph/cluster data are unchanged.
- No new frontend state or renderer authority.
- No threshold relaxation.
- #1376 remains the range-color slice and will be restacked/requalified after this lands.

Refs #83, #954, #1376.