### PR TITLE
Animate the GroupSlicing gallery demo

### DIFF
--- a/parity/manim-v0.21/core-examples/group_slicing.py
+++ b/parity/manim-v0.21/core-examples/group_slicing.py
@@ -9,5 +9,4 @@ class GroupSlicing(Scene):
         family = VGroup(first, middle, last)
 
         self.add(*family)
-        family[1:].shift(UP * 0.75)
-        self.wait(1.0)
+        self.play(family[1:].animate(run_time=1.0).shift(UP * 0.75))

--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -110,7 +110,11 @@ const slicingEntry = readyEntries.find((entry) => entry.id === "compatible-group
 assert.ok(slicingEntry, "group slicing must be a ready compatibility example");
 assert.equal(slicingEntry.parity_fixture, "group-slicing");
 const slicingSource = await readFile(new URL(`./${slicingEntry.path}`, import.meta.url), "utf8");
-assert.match(slicingSource, /family\[1:\]\.shift\(UP \* 0\.75\)/);
+assert.match(
+  slicingSource,
+  /self\.play\(family\[1:\]\.animate\(run_time=1\.0\)\.shift\(UP \* 0\.75\)\)/,
+  "group slicing gallery example must visibly animate the selected shared members",
+);
 const slicingCanonical = await readFile(
   new URL("../parity/manim-v0.21/core-examples/group_slicing.py", import.meta.url),
   "utf8",

--- a/web/python/examples/manim_compatible_group_slicing.py
+++ b/web/python/examples/manim_compatible_group_slicing.py
@@ -9,5 +9,4 @@ class GroupSlicing(Scene):
         family = VGroup(first, middle, last)
 
         self.add(*family)
-        family[1:].shift(UP * 0.75)
-        self.wait(1.0)
+        self.play(family[1:].animate(run_time=1.0).shift(UP * 0.75))


### PR DESCRIPTION
## Scope

Make the Manim-compatible `GroupSlicing` gallery example visibly demonstrate slice aliasing instead of publishing only the post-mutation static state.

- replace the immediate `family[1:].shift(...)` plus `wait(1.0)` with a one-second `family[1:].animate(...).shift(...)` play;
- keep the canonical Manim v0.21 fixture import-only equivalent to the Noon gallery twin;
- keep the existing 1.0-second parity duration unchanged;
- strengthen the gallery guard so the example must use the animated slice form.

## Why

The existing example was semantically useful for parity but visually static: the slice mutation happened before timed playback, so the gallery showed only the final state. This version visibly shows the selected shared members moving while preserving the original slicing/aliasing contract.

## Validation

Branch base: `68de031ea891075aea0166dc5016265106c949e5`
Head: `674a226ec10d7e7a9e71bad8eacaad156229c05d`

GitHub Actions **PR Fast Gate** run `34513860616` passed. In particular:

- web preflight / updated gallery assertion passed;
- Rust format, lint, and fast unit tests passed;
- real browser **Manim-style authoring** passed with the sliced `VGroup` animation;
- primary **WebGPU rendering** passed.

The PR changes only the canonical fixture, gallery twin, and gallery assertion. Additional repository-wide product/cross-browser workflows may continue independently.