### PR TITLE
Reconcile unequal family become without importing target identity

### DIFF
--- a/crates/noon/src/state_replacement.rs
+++ b/crates/noon/src/state_replacement.rs
@@ -1,5 +1,8 @@
 //! Shared object/family become preparation and atomic semantic state replacement.
-use std::{collections::HashMap, rc::Rc};
+use std::{
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 use crate::{
     semantic_mobject::{
@@ -8,7 +11,10 @@ use crate::{
     },
     AuthoringError, Mobject, MobjectFamily,
 };
-use noon_core::{Bounds2D64, SemanticMutationTransaction, SemanticObjectState, SemanticStore};
+use noon_core::{
+    Bounds2D64, SemanticMutationTransaction, SemanticNodeCreation, SemanticNodeId,
+    SemanticNodeKind, SemanticObjectState, SemanticStore, SemanticTransactionNodeRef, VectorPath,
+};
 
 /// Pair through the same topology/alias contract as ordinary family Transform.
 /// All captures and fitting succeed before a caller can publish any edit.
@@ -23,11 +29,11 @@ pub(crate) fn prepare_family_become<E: From<AuthoringError>>(
     }
     source.validate()?;
     target.validate()?;
-    let pairs = match source
+    let pairing = source
         .integration_store()
         .borrow()
-        .ordered_family_leaf_pairs(source.node_id(), target.node_id())
-    {
+        .ordered_family_leaf_pairs(source.node_id(), target.node_id());
+    let pairs = match pairing {
         Ok(pairs) => pairs,
         Err(noon_core::SemanticFamilyPairingError::Empty) => {
             return crate::path_editing::PreparedPathEdits::prepare(
@@ -35,6 +41,12 @@ pub(crate) fn prepare_family_become<E: From<AuthoringError>>(
                 Vec::new(),
             )
             .map_err(E::from)
+        }
+        Err(
+            noon_core::SemanticFamilyPairingError::TopologyMismatch { .. }
+            | noon_core::SemanticFamilyPairingError::AliasMismatch { .. },
+        ) => {
+            return prepare_persistent_family_reconcile(source, target, options, capture);
         }
         Err(error) => return Err(AuthoringError::from(error).into()),
     };
@@ -54,7 +66,7 @@ pub(crate) fn prepare_family_become<E: From<AuthoringError>>(
     let targets = prepare_become_states(&store, &sources, targets, options)?;
     let mut transaction = SemanticMutationTransaction::new();
     let mut replacements = Vec::new();
-    let mut staged = HashMap::<noon_core::SemanticNodeId, SemanticObjectState>::new();
+    let mut staged = HashMap::<SemanticNodeId, SemanticObjectState>::new();
     for ((source, target_id), (mut target, path)) in pairs.into_iter().zip(targets) {
         // Plain Manim become reads a shared target after preceding leaf writes.
         // Matching options copy the target first, so those reads stay captured.
@@ -79,10 +91,278 @@ pub(crate) fn prepare_family_become<E: From<AuthoringError>>(
     )
 }
 
+#[derive(Clone)]
+enum PersistentTargetNode {
+    Object,
+    Family {
+        members: Vec<SemanticNodeId>,
+        z_index: f64,
+    },
+}
+
+/// Persistent `become()` reconciliation is intentionally separate from Transform
+/// pairing. The target graph is a preflight template: target semantic identities
+/// are never imported into the receiver. Compatible receiver identities are reused
+/// once, while additional topology is allocated only through transaction-local
+/// pending references.
+struct PersistentFamilyReconcile<'a> {
+    store: &'a SemanticStore,
+    target_states: &'a HashMap<SemanticNodeId, (SemanticObjectState, Option<VectorPath>)>,
+    transaction: SemanticMutationTransaction,
+    target_to_receiver: HashMap<SemanticNodeId, SemanticTransactionNodeRef>,
+    source_to_target: HashMap<SemanticNodeId, SemanticNodeId>,
+    existing_leaf_pairs: Vec<(SemanticNodeId, SemanticNodeId)>,
+}
+
+impl<'a> PersistentFamilyReconcile<'a> {
+    fn new(
+        store: &'a SemanticStore,
+        target_states: &'a HashMap<SemanticNodeId, (SemanticObjectState, Option<VectorPath>)>,
+    ) -> Self {
+        Self {
+            store,
+            target_states,
+            transaction: SemanticMutationTransaction::new(),
+            target_to_receiver: HashMap::new(),
+            source_to_target: HashMap::new(),
+            existing_leaf_pairs: Vec::new(),
+        }
+    }
+
+    fn target_node(&self, target: SemanticNodeId) -> Result<PersistentTargetNode, AuthoringError> {
+        let node = self.store.node(target).ok_or_else(|| {
+            AuthoringError::from(noon_core::SemanticSceneOperationError::UnknownNode(target))
+        })?;
+        match node.kind() {
+            SemanticNodeKind::AuthoringObject => Ok(PersistentTargetNode::Object),
+            SemanticNodeKind::Family(presentation) => Ok(PersistentTargetNode::Family {
+                members: node.members_iter().collect(),
+                z_index: presentation.z_index,
+            }),
+            _ => Err(AuthoringError::from(
+                noon_core::SemanticSceneOperationError::NotSemanticAuthoringNode(target),
+            )),
+        }
+    }
+
+    fn reusable_candidate(
+        &self,
+        candidate: Option<SemanticNodeId>,
+        target: &PersistentTargetNode,
+    ) -> Option<SemanticNodeId> {
+        let candidate = candidate?;
+        if self.source_to_target.contains_key(&candidate) {
+            return None;
+        }
+        let node = self.store.node(candidate)?;
+        let compatible = matches!(
+            (node.kind(), target),
+            (
+                SemanticNodeKind::AuthoringObject,
+                PersistentTargetNode::Object
+            ) | (
+                SemanticNodeKind::Family(_),
+                PersistentTargetNode::Family { .. }
+            )
+        );
+        compatible.then_some(candidate)
+    }
+
+    fn reconcile_node(
+        &mut self,
+        candidate: Option<SemanticNodeId>,
+        target: SemanticNodeId,
+    ) -> Result<SemanticTransactionNodeRef, AuthoringError> {
+        if let Some(mapped) = self.target_to_receiver.get(&target) {
+            return Ok(*mapped);
+        }
+        let target_node = self.target_node(target)?;
+        let reusable = self.reusable_candidate(candidate, &target_node);
+        match target_node {
+            PersistentTargetNode::Object => {
+                let receiver = if let Some(source) = reusable {
+                    self.source_to_target.insert(source, target);
+                    self.existing_leaf_pairs.push((source, target));
+                    SemanticTransactionNodeRef::Existing(source)
+                } else {
+                    let (state, path) = self.target_states.get(&target).ok_or_else(|| {
+                        AuthoringError::from(
+                            noon_core::SemanticSceneOperationError::NotSemanticAuthoringNode(
+                                target,
+                            ),
+                        )
+                    })?;
+                    // Existing path replacement preparation addresses committed
+                    // semantic IDs. Do not publish a half-correct pending object if
+                    // a rotated non-uniform fit needs a freshly admitted path.
+                    if path.is_some() {
+                        return Err(AuthoringError::Unsupported(
+                            crate::UnsupportedAuthoringOperation::RotatedDimensionStretch,
+                        ));
+                    }
+                    SemanticTransactionNodeRef::Pending(
+                        self.transaction
+                            .create_node(SemanticNodeCreation::object(state.clone())),
+                    )
+                };
+                self.target_to_receiver.insert(target, receiver);
+                Ok(receiver)
+            }
+            PersistentTargetNode::Family { members, z_index } => {
+                let (receiver, reused) = if let Some(source) = reusable {
+                    self.source_to_target.insert(source, target);
+                    (SemanticTransactionNodeRef::Existing(source), Some(source))
+                } else {
+                    let pending = self.transaction.create_node(SemanticNodeCreation::family());
+                    if z_index != 0.0 {
+                        self.transaction.set_z_index(pending, z_index);
+                    }
+                    (SemanticTransactionNodeRef::Pending(pending), None)
+                };
+                // Publish the mapping before descending so aliases in the target
+                // DAG converge on exactly one receiver-owned identity.
+                self.target_to_receiver.insert(target, receiver);
+                if let Some(source) = reused {
+                    self.reconcile_existing_family(source, &members)?;
+                } else {
+                    for target_member in members {
+                        let member = self.reconcile_node(None, target_member)?;
+                        self.transaction.add_member(receiver, member);
+                    }
+                }
+                Ok(receiver)
+            }
+        }
+    }
+
+    fn reconcile_existing_family(
+        &mut self,
+        source: SemanticNodeId,
+        target_members: &[SemanticNodeId],
+    ) -> Result<(), AuthoringError> {
+        let current = self
+            .store
+            .semantic_family_members_checked(source)
+            .map_err(AuthoringError::from)?;
+        let mut desired = Vec::with_capacity(target_members.len());
+        for (index, &target_member) in target_members.iter().enumerate() {
+            desired.push(self.reconcile_node(current.get(index).copied(), target_member)?);
+        }
+
+        let desired_existing: HashSet<_> = desired
+            .iter()
+            .filter_map(|member| member.existing())
+            .collect();
+        let current_set: HashSet<_> = current.iter().copied().collect();
+        for member in current.iter().copied() {
+            if !desired_existing.contains(&member) {
+                self.transaction.remove_member(source, member);
+            }
+        }
+        for member in desired
+            .iter()
+            .copied()
+            .filter_map(|member| member.existing())
+        {
+            if !current_set.contains(&member) {
+                self.transaction.add_member(source, member);
+            }
+        }
+
+        // First establish the relative order of all committed identities. Pending
+        // additions can then be inserted before the next committed target member;
+        // multiple pending members sharing the same anchor retain target order.
+        for member in desired
+            .iter()
+            .copied()
+            .filter_map(|member| member.existing())
+        {
+            self.transaction.reorder_member(source, member, None);
+        }
+        for (index, member) in desired.iter().copied().enumerate() {
+            if member.existing().is_some() {
+                continue;
+            }
+            self.transaction.add_member(source, member);
+            if let Some(before) = desired[index + 1..]
+                .iter()
+                .find_map(|candidate| candidate.existing())
+            {
+                self.transaction
+                    .reorder_member(source, member, Some(before));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn prepare_persistent_family_reconcile<E: From<AuthoringError>>(
+    source: &MobjectFamily,
+    target: &MobjectFamily,
+    options: ManimBecomeOptions,
+    mut capture: impl FnMut(&Mobject) -> Result<SemanticObjectState, E>,
+) -> Result<crate::path_editing::PreparedPathEdits, E> {
+    let (source_leaves, target_leaves) = {
+        let store = source.integration_store().borrow();
+        (
+            store
+                .ordered_leaf_nodes(source.node_id())
+                .map_err(AuthoringError::from)?,
+            store
+                .ordered_leaf_nodes(target.node_id())
+                .map_err(AuthoringError::from)?,
+        )
+    };
+    let mut source_states = Vec::with_capacity(source_leaves.len());
+    for source_id in source_leaves {
+        source_states.push(capture(&Mobject::from_node(
+            Rc::clone(source.integration_store()),
+            source_id,
+        )?)?);
+    }
+    let mut captured_targets = Vec::with_capacity(target_leaves.len());
+    for &target_id in &target_leaves {
+        captured_targets.push(capture(&Mobject::from_node(
+            Rc::clone(source.integration_store()),
+            target_id,
+        )?)?);
+    }
+
+    let store = source.integration_store().borrow();
+    let fitted_targets = prepare_become_states(&store, &source_states, captured_targets, options)?;
+    let target_states: HashMap<_, _> = target_leaves.into_iter().zip(fitted_targets).collect();
+    let mut reconcile = PersistentFamilyReconcile::new(&store, &target_states);
+    let root = reconcile.reconcile_node(Some(source.node_id()), target.node_id())?;
+    debug_assert_eq!(root.existing(), Some(source.node_id()));
+
+    let mut transaction = reconcile.transaction;
+    let mut replacements = Vec::new();
+    for (source_id, target_id) in reconcile.existing_leaf_pairs {
+        let (target_state, path) = target_states
+            .get(&target_id)
+            .expect("target leaf was captured during persistent become preflight")
+            .clone();
+        let previous = store
+            .semantic_object_state_checked(source_id)
+            .map_err(AuthoringError::from)?;
+        if let Some(path) = path {
+            replacements.push((source_id, target_state, path));
+        } else {
+            stage_state_changes(&mut transaction, source_id, previous, &target_state);
+        }
+    }
+    Ok(
+        crate::path_editing::PreparedPathEdits::prepare(&store, replacements)?
+            .with_transaction(transaction),
+    )
+}
+
 impl MobjectFamily {
-    /// Replace family presentation while preserving member and alias identities.
+    /// Persistently become another family while preserving receiver ownership.
     /// Uses authored state; live execution uses `LiveSession::become_family`.
-    /// Different topology is rejected by the shared family pairing contract.
+    /// Matching topology preserves existing identities. Unequal topology is
+    /// reconciled atomically: compatible receiver identities are reused, new
+    /// receiver-owned nodes get fresh IDs at commit, and target IDs never transfer.
     pub fn become_family(
         &self,
         target: &Self,
@@ -112,7 +392,7 @@ pub struct ManimBecomeOptions {
 
 pub(crate) fn prepare_become(
     store: &SemanticStore,
-    node: noon_core::SemanticNodeId,
+    node: SemanticNodeId,
     source: &SemanticObjectState,
     target: SemanticObjectState,
     options: ManimBecomeOptions,
@@ -146,7 +426,7 @@ pub(crate) fn prepare_become_states(
     source: &[SemanticObjectState],
     targets: Vec<SemanticObjectState>,
     options: ManimBecomeOptions,
-) -> Result<Vec<(SemanticObjectState, Option<noon_core::VectorPath>)>, AuthoringError> {
+) -> Result<Vec<(SemanticObjectState, Option<VectorPath>)>, AuthoringError> {
     fn bounds(
         store: &SemanticStore,
         states: &[SemanticObjectState],

--- a/crates/noon/tests/family_state.rs
+++ b/crates/noon/tests/family_state.rs
@@ -12,6 +12,14 @@ fn leaves(family: &MobjectFamily) -> Vec<noon::SemanticNodeId> {
         .unwrap()
 }
 
+fn direct_members(family: &MobjectFamily) -> Vec<noon::SemanticNodeId> {
+    family
+        .integration_store()
+        .borrow()
+        .semantic_family_members_checked(family.node_id())
+        .unwrap()
+}
+
 fn family(scene: &Scene) -> MobjectFamily {
     let a = scene.square(1.0).unwrap();
     let mut b = scene.rectangle(1.0, 2.0).unwrap();
@@ -58,6 +66,71 @@ fn family_become_and_restore_preserve_alias_identity_and_share_content() {
 }
 
 #[test]
+fn unequal_family_become_reuses_receiver_identity_and_never_imports_target_ids() {
+    let scene = Scene::new();
+    let source_leaf = scene.square(1.0).unwrap();
+    let source = scene.family(&[(&source_leaf).into()]).unwrap();
+    let source_root = source.node_id();
+    let first_target = scene.circle(2.0).unwrap();
+    let mut second_target = scene.rectangle(3.0, 1.0).unwrap();
+    second_target.shift(4.0, 1.0).unwrap();
+    let target = scene
+        .family(&[(&first_target).into(), (&second_target).into()])
+        .unwrap();
+    let target_ids = leaves(&target);
+    let target_states: Vec<_> = target_ids
+        .iter()
+        .map(|&id| {
+            scene
+                .integration_store()
+                .borrow()
+                .semantic_object_state_checked(id)
+                .unwrap()
+                .clone()
+        })
+        .collect();
+    let revision = scene.revision();
+
+    source.become_family(&target, Default::default()).unwrap();
+
+    assert_eq!(source.node_id(), source_root);
+    assert_eq!(scene.revision(), revision.checked_next().unwrap());
+    let receiver_ids = leaves(&source);
+    assert_eq!(receiver_ids.len(), 2);
+    assert_eq!(receiver_ids[0], source_leaf.node_id());
+    assert!(!target_ids.contains(&receiver_ids[0]));
+    assert!(!target_ids.contains(&receiver_ids[1]));
+    assert_ne!(receiver_ids[1], source_leaf.node_id());
+    let receiver_states: Vec<_> = receiver_ids
+        .iter()
+        .map(|&id| {
+            scene
+                .integration_store()
+                .borrow()
+                .semantic_object_state_checked(id)
+                .unwrap()
+                .clone()
+        })
+        .collect();
+    assert_eq!(receiver_states, target_states);
+    assert_eq!(leaves(&target), target_ids);
+
+    // Contracting topology only changes membership. Detached receiver-owned
+    // descendants retain valid identities for any other handles/aliases.
+    let empty = scene.family(&[]).unwrap();
+    let expanded_ids = receiver_ids.clone();
+    let revision = scene.revision();
+    source.become_family(&empty, Default::default()).unwrap();
+    assert_eq!(source.node_id(), source_root);
+    assert!(leaves(&source).is_empty());
+    assert_eq!(scene.revision(), revision.checked_next().unwrap());
+    let store = scene.integration_store().borrow();
+    for id in expanded_ids {
+        assert!(store.node(id).is_some());
+    }
+}
+
+#[test]
 fn dimension_matching_uses_aggregate_bounds_and_center_not_individual_leaf_sizes() {
     let scene = Scene::new();
     let source = family(&scene);
@@ -99,15 +172,12 @@ fn dimension_matching_uses_aggregate_bounds_and_center_not_individual_leaf_sizes
 fn invalid_family_become_is_atomic_and_rotated_stretch_preserves_dimensions() {
     let scene = Scene::new();
     let source = family(&scene);
-    let different = scene.family(&[]).unwrap();
     let foreign = family(&Scene::new());
     let saved = source.layout_bounds().unwrap();
     let revision = scene.revision();
-    for target in [&different, &foreign] {
-        assert!(source.become_family(target, Default::default()).is_err());
-        assert_eq!(source.layout_bounds().unwrap(), saved);
-        assert_eq!(scene.revision(), revision);
-    }
+    assert!(source.become_family(&foreign, Default::default()).is_err());
+    assert_eq!(source.layout_bounds().unwrap(), saved);
+    assert_eq!(scene.revision(), revision);
     let target = family(&scene);
     target
         .rotate(0.3, noon::ManimRotationPivot::Center)
@@ -126,9 +196,10 @@ fn invalid_family_become_is_atomic_and_rotated_stretch_preserves_dimensions() {
     let before = saved.unwrap();
     close(after.width(), before.width());
     close(after.height(), before.height());
-    different
-        .become_family(&different, Default::default())
-        .unwrap();
+    let empty = scene.family(&[]).unwrap();
+    let revision = scene.revision();
+    empty.become_family(&empty, Default::default()).unwrap();
+    assert_eq!(scene.revision(), revision);
 }
 
 #[test]
@@ -201,7 +272,7 @@ fn paired_program_animates_and_restores_through_coherent_completion() {
 }
 
 #[test]
-fn pairing_memoizes_shared_family_dags_and_rejects_different_family_aliases() {
+fn pairing_memoizes_shared_family_dags_and_persistent_become_reconciles_alias_shape() {
     let scene = Scene::new();
     let a = scene.square(1.0).unwrap();
     let mut root = scene.family(&[(&a).into()]).unwrap();
@@ -226,9 +297,22 @@ fn pairing_memoizes_shared_family_dags_and_rejects_different_family_aliases() {
         .unwrap();
     copied_right.remove((&copied_shared).into()).unwrap();
     copied_right.add((&distinct).into()).unwrap();
-    assert!(source
+    let revision = scene.revision();
+
+    source
         .become_family(target.root(), Default::default())
-        .is_err());
+        .unwrap();
+
+    assert_eq!(scene.revision(), revision.checked_next().unwrap());
+    assert_eq!(leaves(&source), [a.node_id()]);
+    let right_member = direct_members(&right)[0];
+    assert_ne!(right_member, shared.node_id());
+    assert_ne!(right_member, distinct.node_id());
+    let store = scene.integration_store().borrow();
+    assert_eq!(
+        store.semantic_family_members_checked(right_member).unwrap(),
+        [a.node_id()]
+    );
 }
 
 #[test]

--- a/docs/phase-b-parallel-work-tracks.md
+++ b/docs/phase-b-parallel-work-tracks.md
@@ -42,6 +42,12 @@ A downstream feature lane may consume a B1 primitive when the relevant behavior 
 
 B2, B3, B4, and B6 do not need to wait for every B1 case to close. They wait only for the B1 primitives they actually consume.
 
+#### B1.4 family state/alignment handoff
+
+Unequal family topology has two deliberately separate contracts. Animation-side padding/alignment is derived correspondence and must not create Semantic Scene IDs or mutate authored membership merely to interpolate. Explicit persistent family `become`, by contrast, may reconcile authored topology, but the receiver owns the resulting identities and the entire topology/state change publishes through one semantic transaction. `ordered_family_leaf_pairs()` remains the strict animation-pairing primitive; persistent reconciliation does not weaken it.
+
+The focused application/qualification rules are recorded in [`unequal-family-become.md`](unequal-family-become.md). Downstream B3 work may therefore implement unequal visual Transform correspondence without waiting for persistent synthetic members, while B1.4 persistent `become` owns receiver-root preservation, fresh receiver IDs for genuinely new topology, target-ID non-transfer, alias reconciliation, and atomic publication.
+
 ### BH2 — retained path/content resource contract
 
 Owned by B2/#76/#77/#78/#79.

--- a/docs/unequal-family-become.md
+++ b/docs/unequal-family-become.md
@@ -1,0 +1,94 @@
+# Unequal family topology: alignment versus persistent `become()`
+
+## Status and authority
+
+This is a focused B1.4 compatibility/implementation note for #74 and the Phase B umbrella #954. It applies the ownership, identity, authored/effective-state, and atomic-publication rules in [`architecture.md`](architecture.md); it does **not** define a second architecture, scene model, roadmap, or compatibility oracle. If this note conflicts with `architecture.md` or an owning issue, those sources win.
+
+Manim Community v0.21.x remains the compatibility oracle for supported common 2D Python behavior. Noon intentionally does not copy Manim's Python object graph or use its internal family-padding objects as semantic identity.
+
+## Decision
+
+Manim-style family alignment may duplicate, fade, or otherwise synthesize family members so unequal structures can participate in visual interpolation. In Noon those members are **derived animation/presentation correspondence**, not authored objects.
+
+Synthetic alignment members therefore:
+
+- are not Semantic Scene nodes;
+- receive no scene-global semantic `NodeId`;
+- are not independently addressable through language wrappers;
+- do not change authored family membership merely because an animation needs equal interpolation cardinality;
+- disappear with the derived animation/effective state that required them.
+
+This keeps a visual matching device from becoming a second identity system.
+
+## Operation split
+
+| Operation | Where unequal-family correspondence lives | Persistent semantic topology |
+| --- | --- | --- |
+| `Transform` / family target-state interpolation | Derived execution/runtime animation correspondence | Unchanged during interpolation |
+| `ReplacementTransform` | Derived correspondence during interpolation | Real source/target lifecycle change is committed atomically at completion |
+| `always_redraw`-style regeneration | Effective presentation/resource state | No per-frame semantic ID or membership churn |
+| Explicit persistent `Group.become()` / family `become` | Semantic Scene reconciliation | Receiver topology is persistently reconciled in one semantic transaction |
+
+The implementation details used by Manim to achieve a visual result do not force Noon to publish synthetic children into authored state.
+
+## Persistent identity contract
+
+For explicit persistent unequal-topology `become()`:
+
+1. The receiver root semantic ID survives.
+2. Target descendant IDs are never transferred, stolen, or aliased into the receiver.
+3. Compatible receiver descendants are reused deterministically in authoritative target/member order when one existing identity can represent that target node.
+4. A target alias maps to exactly one receiver-owned identity across the reconciled family DAG.
+5. If one receiver alias would need to represent two distinct target nodes, the first compatible mapping may retain the receiver identity and later distinct target nodes receive fresh receiver-owned identities.
+6. Genuinely new receiver descendants use transaction-local pending references and receive permanent semantic IDs only if the complete transaction commits.
+7. Removed family edges do not imply node deletion. Detached descendants remain valid when other handles or aliases still reference them.
+8. Membership, ordering, object state/content, and new-node publication are one atomic semantic transaction. Any preflight or commit failure publishes none of them.
+9. Frontends must observe post-`become()` children from Semantic Scene membership/order. A Python wrapper must not retain a second authoritative submobject list or invent IDs for synthesized alignment members.
+
+These rules intentionally provide stronger and more explicit identity semantics than Manim's visual padding mechanism while preserving compatible visible behavior.
+
+## Transform pairing remains strict
+
+`SemanticStore::ordered_family_leaf_pairs()` continues to mean **structurally equivalent semantic-family pairing for animation/Transform preparation**. Persistent unequal-topology `become()` must use a separate reconciliation path rather than weakening that pairing function.
+
+This separation is important: allowing a persistent mutation to reconcile authored topology does not make synthetic Transform padding authored truth.
+
+## Atomic reconciliation shape
+
+Conceptually, for a receiver with one child becoming a two-child target:
+
+```text
+before                     target template
+receiver R                 target T
+└─ A (#receiver-a)          ├─ X (#target-x)
+                           └─ Y (#target-y)
+
+one prepared semantic transaction
+
+R keeps its root ID
+├─ A' (#receiver-a)         reused receiver identity, target X state
+└─ B' (#fresh)              fresh receiver-owned identity, target Y state
+
+#fresh != #target-y
+```
+
+The target remains unchanged. If the receiver later contracts, obsolete receiver membership edges are removed atomically; the detached objects are not implicitly destroyed.
+
+## Current bounded implementation seam
+
+The persistent path reuses the ordinary semantic transaction's pending-node creation plus membership/order mutations. It does not reserve IDs during preflight and does not use rollback state in Python.
+
+State fitting still uses the shared `ManimBecomeOptions` preparation. A rare unequal-topology case that both requires a **new pending receiver leaf** and requires path materialization for a non-representable rotated non-uniform stretch currently fails closed before publication; extending atomic path-resource admission to pending node refs is the bounded follow-up for that case. Equal-topology rotated replacement continues to use the existing retained-path replacement path.
+
+## Qualification expectations
+
+B1.4 qualification should keep separate evidence for:
+
+- strict animation pairing versus persistent topology reconciliation;
+- expansion and contraction in one scene revision;
+- receiver-root and reusable-child identity preservation;
+- fresh receiver IDs for added topology and non-transfer of target IDs;
+- target alias preservation and source-alias splitting when the target requires it;
+- failure atomicity, including foreign/stale handles and unsupported pending-path materialization;
+- post-reconciliation member lookup through semantic membership/order;
+- later animation work proving unequal Transform alignment remains derived/effective rather than authored topology.


### PR DESCRIPTION
## Ownership

B1.4 / #74 under Phase B umbrella #954. #1413 is merged; this PR is now rebased directly onto `master` as one four-file feature commit.

## Decision

Manim-style unequal-family padding is visual correspondence, not semantic identity. `ordered_family_leaf_pairs()` therefore remains strict for Transform/animation preparation. Only explicit persistent family `become` reconciles authored topology.

Persistent reconciliation preserves the receiver root, reuses compatible receiver descendants deterministically, creates genuinely new receiver-owned nodes through transaction-local pending refs, never transfers target descendant IDs, preserves target aliasing, splits receiver aliases when distinct target topology requires it, and publishes topology + state in one semantic transaction.

`Transform`, `ReplacementTransform`, and `always_redraw` synthetic alignment remains a derived/effective animation concern and must not create Semantic Scene IDs.

## Changes

- add a separate persistent topology reconciler in `state_replacement.rs` without weakening strict family pairing;
- atomically combine pending node creation, membership removal/addition/order, and existing object-state replacement;
- add expansion/contraction, target-ID non-transfer, detached-node lifetime, and alias-shape reconciliation regressions;
- document the B1.4 identity/alignment decision in `docs/unequal-family-become.md` and the Phase B handoff overlay.

## Bounded limitation

A rare unequal-topology case that requires both a newly pending receiver leaf and retained-path materialization for a non-representable rotated non-uniform stretch currently fails closed before publication. Equal-topology rotated replacement continues to use #1413's retained-path path. Extending path-resource admission to pending node refs is a bounded follow-up rather than weakening atomicity.

## Validation

The rebuilt four-file feature tree passed the PR Fast Gate (Rust tests, fmt/clippy, browser/Manim authoring, SVG and WebGPU), Native Host Smoke, provider isolation, architecture/layer ratchets, playground product/cross-browser checks, agent foundation and agent discovery. The final ancestry-only restack onto merged `master` preserves that tree byte-for-byte and changes no feature content. No Python rollback/state mirror or sequential observable mutation is introduced.