### PR TITLE
Select regular bundled face for native Text

### DIFF
--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -34,7 +34,7 @@ use noon_typst::{
     compile_typst_resource, compile_typst_resource_with_fonts, TypstMode, TypstResourceArtifact,
 };
 #[cfg(all(feature = "native-text", feature = "bundled-fonts"))]
-use swash::{FontRef, StringId, Stretch, Style as FontStyle, Weight};
+use swash::{FontRef, Stretch, StringId, Style as FontStyle, Weight};
 
 /// Typst's retained artifact is authored at 10pt, so its public Manim-style font size
 /// remains an object transform and does not alter glyph/cluster identity.
@@ -444,12 +444,8 @@ fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringErro
                 && attributes.style() == FontStyle::Normal
                 && attributes.stretch() == Stretch::NORMAL
             {
-                return NativeFontFace::new(
-                    Arc::<str>::from(family),
-                    Arc::<[u8]>::from(data),
-                    0,
-                )
-                .map_err(TextAuthoringError::NativeText);
+                return NativeFontFace::new(Arc::<str>::from(family), Arc::<[u8]>::from(data), 0)
+                    .map_err(TextAuthoringError::NativeText);
             }
         }
 

--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -34,7 +34,7 @@ use noon_typst::{
     compile_typst_resource, compile_typst_resource_with_fonts, TypstMode, TypstResourceArtifact,
 };
 #[cfg(all(feature = "native-text", feature = "bundled-fonts"))]
-use swash::{FontRef, StringId};
+use swash::{FontRef, StringId, Stretch, Style as FontStyle, Weight};
 
 /// Typst's retained artifact is authored at 10pt, so its public Manim-style font size
 /// remains an object transform and does not alter glyph/cluster identity.
@@ -422,17 +422,38 @@ impl Text {
 #[cfg(feature = "native-text")]
 fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringError> {
     #[cfg(feature = "bundled-fonts")]
-    for data in typst_assets::fonts() {
-        let Some(font) = FontRef::from_index(data, 0) else {
-            continue;
-        };
-        let matches = font.localized_strings().any(|name| {
-            matches!(
-                name.id(),
-                StringId::Family | StringId::TypographicFamily | StringId::WwsFamily
-            ) && name.to_string().eq_ignore_ascii_case(family)
-        });
-        if matches {
+    {
+        let mut fallback = None;
+        for data in typst_assets::fonts() {
+            let Some(font) = FontRef::from_index(data, 0) else {
+                continue;
+            };
+            let matches = font.localized_strings().any(|name| {
+                matches!(
+                    name.id(),
+                    StringId::Family | StringId::TypographicFamily | StringId::WwsFamily
+                ) && name.to_string().eq_ignore_ascii_case(family)
+            });
+            if !matches {
+                continue;
+            }
+
+            fallback.get_or_insert(data);
+            let attributes = font.attributes();
+            if attributes.weight() == Weight::NORMAL
+                && attributes.style() == FontStyle::Normal
+                && attributes.stretch() == Stretch::NORMAL
+            {
+                return NativeFontFace::new(
+                    Arc::<str>::from(family),
+                    Arc::<[u8]>::from(data),
+                    0,
+                )
+                .map_err(TextAuthoringError::NativeText);
+            }
+        }
+
+        if let Some(data) = fallback {
             return NativeFontFace::new(Arc::<str>::from(family), Arc::<[u8]>::from(data), 0)
                 .map_err(TextAuthoringError::NativeText);
         }

--- a/crates/noon/tests/native_text_font_face_selection.rs
+++ b/crates/noon/tests/native_text_font_face_selection.rs
@@ -1,0 +1,36 @@
+#![cfg(all(feature = "native-text", feature = "bundled-fonts"))]
+
+use noon::{integration::RetainedScene, Text};
+use swash::{FontRef, Stretch, Style, Weight};
+
+#[test]
+fn family_lookup_prefers_regular_upright_normal_stretch_face() {
+    let mut scene = RetainedScene::new();
+    scene
+        .add_text(Text::new("Noon").with_font("DejaVu Sans Mono"))
+        .unwrap();
+
+    let handle = scene.objects()[0]
+        .content
+        .text()
+        .expect("native Text must retain text content");
+    let resource = scene
+        .texts()
+        .get(handle)
+        .expect("native Text resource must remain retained");
+    let run = resource
+        .runs
+        .first()
+        .expect("plain native Text must have a glyph run");
+    let retained_font = scene
+        .fonts()
+        .get_for_face(&run.font)
+        .expect("glyph run must retain its exact font bytes");
+    let face = FontRef::from_index(retained_font.data.as_ref(), run.font.face_index as usize)
+        .expect("retained bundled font must be a valid OpenType face");
+    let attributes = face.attributes();
+
+    assert_eq!(attributes.weight(), Weight::NORMAL);
+    assert_eq!(attributes.style(), Style::Normal);
+    assert_eq!(attributes.stretch(), Stretch::NORMAL);
+}


### PR DESCRIPTION
## Summary

B4 native Text correctness prerequisite for #1376. Family-only bundled font lookup currently accepts the first matching family face. In `typst-assets` 0.15.1, `DejaVuSansMono-Bold.ttf` precedes `DejaVuSansMono.ttf`, so `Text(font="DejaVu Sans Mono")` silently resolves to Bold even though Manim/Pango resolves the normal upright face.

- prefer an exact normal-weight, upright, normal-stretch face among matching bundled family faces
- preserve the previous first-family-match behavior as a fallback when a family has no exact regular face
- add an integration regression that inspects the exact retained OpenType face selected for `DejaVu Sans Mono`

## Why this is separate from #1376

After #1414 corrected native Text point scaling, the pinned `text-range-colors` ManimCE v0.21 raster reached exact height parity (36 px vs 36 px) but Noon remained visibly heavier and 3 px wider. Both renderer backends produced the same Noon result. The remaining discrepancy is therefore shared font-face selection, not range-color semantics or renderer compensation.

This PR changes no renderer/frontend ownership, no raster thresholds, and does not implement arbitrary `t2w`/`t2s` styling. Those remain in the later shared styled-span slice.

Refs #83
Prerequisite for #1376
Part of #954