### PR TITLE
Add immutable raster image resource foundation

### DIFF
--- a/crates/noon-core/src/resources/image.rs
+++ b/crates/noon-core/src/resources/image.rs
@@ -248,8 +248,7 @@ fn expected_rgba8_len(width: u32, height: u32) -> Result<usize, RasterImageResou
         .checked_mul(u64::from(height))
         .and_then(|pixels| pixels.checked_mul(4))
         .ok_or(RasterImageResourceError::ImageTooLarge { width, height })?;
-    usize::try_from(pixels)
-        .map_err(|_| RasterImageResourceError::ImageTooLarge { width, height })
+    usize::try_from(pixels).map_err(|_| RasterImageResourceError::ImageTooLarge { width, height })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/noon-core/src/resources/image.rs
+++ b/crates/noon-core/src/resources/image.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     mem::size_of,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -54,7 +54,7 @@ pub struct RasterImageResourceHandle {
     pub version: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct RasterImageResourceKey {
     encoding: RasterImageEncoding,
     width: u32,
@@ -126,11 +126,11 @@ pub struct RasterImageResourceStats {
 /// allocation. This is resource identity only: semantic object identity, scene
 /// membership, transforms, opacity and GPU texture residency remain owned by
 /// their normal architecture layers.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct RasterImageResourceArena {
     namespace: u64,
     entries: Vec<RasterImageResourceEntry>,
-    handles_by_content: BTreeMap<RasterImageResourceKey, RasterImageResourceHandle>,
+    handles_by_content: HashMap<RasterImageResourceKey, RasterImageResourceHandle>,
     retained_bytes: usize,
     encoded_bytes: usize,
 }
@@ -140,9 +140,29 @@ impl Default for RasterImageResourceArena {
         Self {
             namespace: next_raster_image_resource_arena(),
             entries: Vec::new(),
-            handles_by_content: BTreeMap::new(),
+            handles_by_content: HashMap::new(),
             retained_bytes: 0,
             encoded_bytes: 0,
+        }
+    }
+}
+
+// A cloned arena is an independent resource owner. Payload allocations remain
+// shared through Arc, while every derived handle is rewritten to the clone's
+// namespace so stale/foreign provenance cannot alias the clone.
+impl Clone for RasterImageResourceArena {
+    fn clone(&self) -> Self {
+        let namespace = next_raster_image_resource_arena();
+        let mut handles_by_content = self.handles_by_content.clone();
+        for handle in handles_by_content.values_mut() {
+            handle.arena = namespace;
+        }
+        Self {
+            namespace,
+            entries: self.entries.clone(),
+            handles_by_content,
+            retained_bytes: self.retained_bytes,
+            encoded_bytes: self.encoded_bytes,
         }
     }
 }
@@ -150,16 +170,6 @@ impl Default for RasterImageResourceArena {
 impl RasterImageResourceArena {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Re-namespace an independently cloned owner while preserving shared immutable
-    /// payload allocations. Derived content indexes are rewritten to local handles.
-    pub(crate) fn fork_namespace(&mut self) -> u64 {
-        self.namespace = next_raster_image_resource_arena();
-        for handle in self.handles_by_content.values_mut() {
-            handle.arena = self.namespace;
-        }
-        self.namespace
     }
 
     /// Intern one already-prepared encoded image.
@@ -359,8 +369,7 @@ mod tests {
             .unwrap();
         let source_payload = source.get_shared(source_handle).unwrap();
 
-        let mut cloned = source.clone();
-        cloned.fork_namespace();
+        let cloned = source.clone();
         let cloned_handle = *cloned
             .handles_by_content
             .values()

--- a/crates/noon-core/src/resources/image.rs
+++ b/crates/noon-core/src/resources/image.rs
@@ -15,20 +15,7 @@ fn next_raster_image_resource_arena() -> u64 {
         .expect("raster image resource arena identity exhausted")
 }
 
-/// Encodings accepted by the Phase B raster-image resource boundary.
-///
-/// Decoding and encoded-header validation happen before or during resource
-/// installation. The retained resource stores the original immutable payload so
-/// browser/native preparation can derive backend-local decoded/texture state
-/// without making that state semantic authority.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum RasterImageEncoding {
-    Png,
-    Jpeg,
-    Webp,
-}
-
-/// Stable identity for one immutable encoded raster-image payload.
+/// Stable identity for one immutable canonical raster-image payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RasterImageResourceId(u64);
 
@@ -56,31 +43,26 @@ pub struct RasterImageResourceHandle {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct RasterImageResourceKey {
-    encoding: RasterImageEncoding,
     width: u32,
     height: u32,
-    data: Arc<[u8]>,
+    rgba8: Arc<[u8]>,
 }
 
-/// Immutable renderer/backend-neutral encoded image resource.
+/// Immutable renderer/backend-neutral canonical raster content.
 ///
-/// `width`/`height` are intrinsic dimensions established by the decoder/resource
-/// preparation boundary. This arena intentionally does not parse image formats;
-/// format-specific parsing belongs to the #79 loader/decoder follow-up and must
-/// occur off the frame path.
+/// File encodings such as PNG/JPEG/WebP and Python ndarray/PIL inputs are loader
+/// concerns. They normalize to tightly packed row-major RGBA8 before entering this
+/// retained arena, matching the pinned Manim model in which image behavior operates
+/// on a normalized RGBA pixel array. Renderer texture residency remains derived and
+/// disposable; it is not stored here.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RasterImageResource {
-    encoding: RasterImageEncoding,
     width: u32,
     height: u32,
-    data: Arc<[u8]>,
+    rgba8: Arc<[u8]>,
 }
 
 impl RasterImageResource {
-    pub const fn encoding(&self) -> RasterImageEncoding {
-        self.encoding
-    }
-
     pub const fn width(&self) -> u32 {
         self.width
     }
@@ -89,20 +71,19 @@ impl RasterImageResource {
         self.height
     }
 
-    pub fn data(&self) -> &[u8] {
-        self.data.as_ref()
+    pub fn rgba8(&self) -> &[u8] {
+        self.rgba8.as_ref()
     }
 
     pub fn retained_bytes(&self) -> usize {
-        size_of::<Self>().saturating_add(self.data.len())
+        size_of::<Self>().saturating_add(self.rgba8.len())
     }
 
     fn key(&self) -> RasterImageResourceKey {
         RasterImageResourceKey {
-            encoding: self.encoding,
             width: self.width,
             height: self.height,
-            data: self.data.clone(),
+            rgba8: self.rgba8.clone(),
         }
     }
 }
@@ -117,14 +98,14 @@ struct RasterImageResourceEntry {
 pub struct RasterImageResourceStats {
     pub live_resources: usize,
     pub retained_bytes: usize,
-    pub encoded_bytes: usize,
+    pub pixel_bytes: usize,
 }
 
-/// Content-deduplicating arena for immutable encoded raster images.
+/// Content-deduplicating arena for immutable canonical raster images.
 ///
-/// Equal encoding, intrinsic dimensions and encoded bytes share one retained
-/// allocation. This is resource identity only: semantic object identity, scene
-/// membership, transforms, opacity and GPU texture residency remain owned by
+/// Equal intrinsic dimensions and RGBA8 pixels share one retained allocation.
+/// This is resource identity only: semantic object identity, scene membership,
+/// transforms, opacity, sampling policy and GPU texture residency remain owned by
 /// their normal architecture layers.
 #[derive(Debug)]
 pub struct RasterImageResourceArena {
@@ -132,7 +113,7 @@ pub struct RasterImageResourceArena {
     entries: Vec<RasterImageResourceEntry>,
     handles_by_content: HashMap<RasterImageResourceKey, RasterImageResourceHandle>,
     retained_bytes: usize,
-    encoded_bytes: usize,
+    pixel_bytes: usize,
 }
 
 impl Default for RasterImageResourceArena {
@@ -142,7 +123,7 @@ impl Default for RasterImageResourceArena {
             entries: Vec::new(),
             handles_by_content: HashMap::new(),
             retained_bytes: 0,
-            encoded_bytes: 0,
+            pixel_bytes: 0,
         }
     }
 }
@@ -162,7 +143,7 @@ impl Clone for RasterImageResourceArena {
             entries: self.entries.clone(),
             handles_by_content,
             retained_bytes: self.retained_bytes,
-            encoded_bytes: self.encoded_bytes,
+            pixel_bytes: self.pixel_bytes,
         }
     }
 }
@@ -172,30 +153,29 @@ impl RasterImageResourceArena {
         Self::default()
     }
 
-    /// Intern one already-prepared encoded image.
+    /// Intern one already-normalized tightly packed RGBA8 image.
     ///
-    /// The caller supplies dimensions verified by its decoder/resource-preparation
-    /// boundary. Repeated identical content is allocation-free after lookup.
-    pub fn intern_encoded(
+    /// Repeated identical visual content is allocation-free after lookup. Invalid
+    /// dimensions/lengths fail before the arena changes.
+    pub fn intern_rgba8(
         &mut self,
-        encoding: RasterImageEncoding,
         width: u32,
         height: u32,
-        data: impl Into<Arc<[u8]>>,
+        rgba8: impl Into<Arc<[u8]>>,
     ) -> Result<RasterImageResourceHandle, RasterImageResourceError> {
-        if width == 0 || height == 0 {
-            return Err(RasterImageResourceError::InvalidDimensions { width, height });
-        }
-        let data = data.into();
-        if data.is_empty() {
-            return Err(RasterImageResourceError::EmptyPayload);
+        let expected = expected_rgba8_len(width, height)?;
+        let rgba8 = rgba8.into();
+        if rgba8.len() != expected {
+            return Err(RasterImageResourceError::InvalidPixelLength {
+                expected,
+                actual: rgba8.len(),
+            });
         }
 
         let resource = RasterImageResource {
-            encoding,
             width,
             height,
-            data,
+            rgba8,
         };
         let key = resource.key();
         if let Some(handle) = self.handles_by_content.get(&key).copied() {
@@ -215,7 +195,7 @@ impl RasterImageResourceArena {
         self.retained_bytes = self
             .retained_bytes
             .saturating_add(resource.retained_bytes());
-        self.encoded_bytes = self.encoded_bytes.saturating_add(resource.data.len());
+        self.pixel_bytes = self.pixel_bytes.saturating_add(resource.rgba8.len());
         self.entries.push(RasterImageResourceEntry {
             version: 0,
             value: resource,
@@ -247,7 +227,7 @@ impl RasterImageResourceArena {
         RasterImageResourceStats {
             live_resources: self.entries.len(),
             retained_bytes: self.retained_bytes,
-            encoded_bytes: self.encoded_bytes,
+            pixel_bytes: self.pixel_bytes,
         }
     }
 
@@ -260,19 +240,39 @@ impl RasterImageResourceArena {
     }
 }
 
+fn expected_rgba8_len(width: u32, height: u32) -> Result<usize, RasterImageResourceError> {
+    if width == 0 || height == 0 {
+        return Err(RasterImageResourceError::InvalidDimensions { width, height });
+    }
+    let pixels = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or(RasterImageResourceError::ImageTooLarge { width, height })?;
+    usize::try_from(pixels)
+        .map_err(|_| RasterImageResourceError::ImageTooLarge { width, height })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RasterImageResourceError {
-    EmptyPayload,
     InvalidDimensions { width: u32, height: u32 },
+    ImageTooLarge { width: u32, height: u32 },
+    InvalidPixelLength { expected: usize, actual: usize },
 }
 
 impl std::fmt::Display for RasterImageResourceError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::EmptyPayload => formatter.write_str("raster image payload is empty"),
             Self::InvalidDimensions { width, height } => write!(
                 formatter,
                 "raster image dimensions must be non-zero, got {width}x{height}",
+            ),
+            Self::ImageTooLarge { width, height } => write!(
+                formatter,
+                "raster image dimensions {width}x{height} exceed addressable RGBA8 storage",
+            ),
+            Self::InvalidPixelLength { expected, actual } => write!(
+                formatter,
+                "raster RGBA8 payload has {actual} bytes, expected {expected}",
             ),
         }
     }
@@ -284,61 +284,53 @@ impl std::error::Error for RasterImageResourceError {}
 mod tests {
     use super::*;
 
-    fn png_bytes() -> Arc<[u8]> {
-        Arc::from([0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a])
+    fn rgba(width: u32, height: u32, seed: u8) -> Arc<[u8]> {
+        let len = expected_rgba8_len(width, height).unwrap();
+        (0..len)
+            .map(|index| seed.wrapping_add(index as u8))
+            .collect::<Vec<_>>()
+            .into()
     }
 
     #[test]
     fn repeated_identical_image_reuses_one_resource() {
         let mut arena = RasterImageResourceArena::new();
-        let first = arena
-            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
-            .unwrap();
-        let second = arena
-            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
-            .unwrap();
+        let first = arena.intern_rgba8(320, 180, rgba(320, 180, 7)).unwrap();
+        let second = arena.intern_rgba8(320, 180, rgba(320, 180, 7)).unwrap();
 
         assert_eq!(first, second);
         assert_eq!(arena.len(), 1);
-        assert_eq!(arena.stats().encoded_bytes, png_bytes().len());
+        assert_eq!(arena.stats().pixel_bytes, 320 * 180 * 4);
+        assert_eq!(arena.get(first).unwrap().rgba8().len(), 320 * 180 * 4);
     }
 
     #[test]
-    fn metadata_participates_in_content_identity() {
+    fn intrinsic_dimensions_participate_in_content_identity() {
+        let bytes = rgba(2, 2, 11);
         let mut arena = RasterImageResourceArena::new();
-        let png = arena
-            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
-            .unwrap();
-        let jpeg = arena
-            .intern_encoded(RasterImageEncoding::Jpeg, 320, 180, png_bytes())
-            .unwrap();
-        let resized = arena
-            .intern_encoded(RasterImageEncoding::Png, 640, 360, png_bytes())
-            .unwrap();
+        let square = arena.intern_rgba8(2, 2, bytes.clone()).unwrap();
+        let row = arena.intern_rgba8(4, 1, bytes).unwrap();
 
-        assert_ne!(png, jpeg);
-        assert_ne!(png, resized);
-        assert_eq!(arena.len(), 3);
+        assert_ne!(square, row);
+        assert_eq!(arena.len(), 2);
     }
 
     #[test]
     fn invalid_resource_is_rejected_without_allocation() {
         let mut arena = RasterImageResourceArena::new();
         assert_eq!(
-            arena.intern_encoded(RasterImageEncoding::Png, 0, 10, png_bytes()),
+            arena.intern_rgba8(0, 10, Arc::<[u8]>::from([])),
             Err(RasterImageResourceError::InvalidDimensions {
                 width: 0,
                 height: 10,
             })
         );
         assert_eq!(
-            arena.intern_encoded(
-                RasterImageEncoding::Webp,
-                10,
-                10,
-                Arc::<[u8]>::from([]),
-            ),
-            Err(RasterImageResourceError::EmptyPayload)
+            arena.intern_rgba8(2, 2, Arc::<[u8]>::from([0; 15])),
+            Err(RasterImageResourceError::InvalidPixelLength {
+                expected: 16,
+                actual: 15,
+            })
         );
         assert!(arena.is_empty());
         assert_eq!(arena.stats(), RasterImageResourceStats::default());
@@ -348,12 +340,8 @@ mod tests {
     fn foreign_arena_handle_is_rejected() {
         let mut first = RasterImageResourceArena::new();
         let mut second = RasterImageResourceArena::new();
-        let a = first
-            .intern_encoded(RasterImageEncoding::Png, 32, 18, png_bytes())
-            .unwrap();
-        let b = second
-            .intern_encoded(RasterImageEncoding::Png, 32, 18, png_bytes())
-            .unwrap();
+        let a = first.intern_rgba8(4, 2, rgba(4, 2, 3)).unwrap();
+        let b = second.intern_rgba8(4, 2, rgba(4, 2, 3)).unwrap();
 
         assert_eq!((a.id, a.version), (b.id, b.version));
         assert_ne!(a.arena, b.arena);
@@ -364,9 +352,7 @@ mod tests {
     #[test]
     fn cloned_arena_is_renamespaced_but_shares_payload() {
         let mut source = RasterImageResourceArena::new();
-        let source_handle = source
-            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
-            .unwrap();
+        let source_handle = source.intern_rgba8(8, 4, rgba(8, 4, 19)).unwrap();
         let source_payload = source.get_shared(source_handle).unwrap();
 
         let cloned = source.clone();

--- a/crates/noon-core/src/resources/image.rs
+++ b/crates/noon-core/src/resources/image.rs
@@ -1,0 +1,376 @@
+use std::{
+    collections::BTreeMap,
+    mem::size_of,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+static NEXT_RASTER_IMAGE_RESOURCE_ARENA: AtomicU64 = AtomicU64::new(1);
+
+fn next_raster_image_resource_arena() -> u64 {
+    NEXT_RASTER_IMAGE_RESOURCE_ARENA
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .expect("raster image resource arena identity exhausted")
+}
+
+/// Encodings accepted by the Phase B raster-image resource boundary.
+///
+/// Decoding and encoded-header validation happen before or during resource
+/// installation. The retained resource stores the original immutable payload so
+/// browser/native preparation can derive backend-local decoded/texture state
+/// without making that state semantic authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RasterImageEncoding {
+    Png,
+    Jpeg,
+    Webp,
+}
+
+/// Stable identity for one immutable encoded raster-image payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RasterImageResourceId(u64);
+
+impl RasterImageResourceId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Versioned reference to one immutable raster-image resource.
+///
+/// This first B2 resource slice is append-only inside one arena, so live handles
+/// remain at version zero. Arena provenance prevents equal slot values from a
+/// cloned or unrelated scene store from aliasing one another.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RasterImageResourceHandle {
+    pub arena: u64,
+    pub id: RasterImageResourceId,
+    pub version: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct RasterImageResourceKey {
+    encoding: RasterImageEncoding,
+    width: u32,
+    height: u32,
+    data: Arc<[u8]>,
+}
+
+/// Immutable renderer/backend-neutral encoded image resource.
+///
+/// `width`/`height` are intrinsic dimensions established by the decoder/resource
+/// preparation boundary. This arena intentionally does not parse image formats;
+/// format-specific parsing belongs to the #79 loader/decoder follow-up and must
+/// occur off the frame path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RasterImageResource {
+    encoding: RasterImageEncoding,
+    width: u32,
+    height: u32,
+    data: Arc<[u8]>,
+}
+
+impl RasterImageResource {
+    pub const fn encoding(&self) -> RasterImageEncoding {
+        self.encoding
+    }
+
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+
+    pub fn data(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        size_of::<Self>().saturating_add(self.data.len())
+    }
+
+    fn key(&self) -> RasterImageResourceKey {
+        RasterImageResourceKey {
+            encoding: self.encoding,
+            width: self.width,
+            height: self.height,
+            data: self.data.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RasterImageResourceEntry {
+    version: u64,
+    value: Arc<RasterImageResource>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RasterImageResourceStats {
+    pub live_resources: usize,
+    pub retained_bytes: usize,
+    pub encoded_bytes: usize,
+}
+
+/// Content-deduplicating arena for immutable encoded raster images.
+///
+/// Equal encoding, intrinsic dimensions and encoded bytes share one retained
+/// allocation. This is resource identity only: semantic object identity, scene
+/// membership, transforms, opacity and GPU texture residency remain owned by
+/// their normal architecture layers.
+#[derive(Clone, Debug)]
+pub struct RasterImageResourceArena {
+    namespace: u64,
+    entries: Vec<RasterImageResourceEntry>,
+    handles_by_content: BTreeMap<RasterImageResourceKey, RasterImageResourceHandle>,
+    retained_bytes: usize,
+    encoded_bytes: usize,
+}
+
+impl Default for RasterImageResourceArena {
+    fn default() -> Self {
+        Self {
+            namespace: next_raster_image_resource_arena(),
+            entries: Vec::new(),
+            handles_by_content: BTreeMap::new(),
+            retained_bytes: 0,
+            encoded_bytes: 0,
+        }
+    }
+}
+
+impl RasterImageResourceArena {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Re-namespace an independently cloned owner while preserving shared immutable
+    /// payload allocations. Derived content indexes are rewritten to local handles.
+    pub(crate) fn fork_namespace(&mut self) -> u64 {
+        self.namespace = next_raster_image_resource_arena();
+        for handle in self.handles_by_content.values_mut() {
+            handle.arena = self.namespace;
+        }
+        self.namespace
+    }
+
+    /// Intern one already-prepared encoded image.
+    ///
+    /// The caller supplies dimensions verified by its decoder/resource-preparation
+    /// boundary. Repeated identical content is allocation-free after lookup.
+    pub fn intern_encoded(
+        &mut self,
+        encoding: RasterImageEncoding,
+        width: u32,
+        height: u32,
+        data: impl Into<Arc<[u8]>>,
+    ) -> Result<RasterImageResourceHandle, RasterImageResourceError> {
+        if width == 0 || height == 0 {
+            return Err(RasterImageResourceError::InvalidDimensions { width, height });
+        }
+        let data = data.into();
+        if data.is_empty() {
+            return Err(RasterImageResourceError::EmptyPayload);
+        }
+
+        let resource = RasterImageResource {
+            encoding,
+            width,
+            height,
+            data,
+        };
+        let key = resource.key();
+        if let Some(handle) = self.handles_by_content.get(&key).copied() {
+            return Ok(handle);
+        }
+
+        let id = RasterImageResourceId::new(
+            u64::try_from(self.entries.len())
+                .expect("Noon raster image resource ID space exhausted"),
+        );
+        let handle = RasterImageResourceHandle {
+            arena: self.namespace,
+            id,
+            version: 0,
+        };
+        let resource = Arc::new(resource);
+        self.retained_bytes = self
+            .retained_bytes
+            .saturating_add(resource.retained_bytes());
+        self.encoded_bytes = self.encoded_bytes.saturating_add(resource.data.len());
+        self.entries.push(RasterImageResourceEntry {
+            version: 0,
+            value: resource,
+        });
+        self.handles_by_content.insert(key, handle);
+        Ok(handle)
+    }
+
+    pub fn get(&self, handle: RasterImageResourceHandle) -> Option<&RasterImageResource> {
+        if handle.arena != self.namespace {
+            return None;
+        }
+        let entry = self.entries.get(handle.id.get() as usize)?;
+        (entry.version == handle.version).then_some(entry.value.as_ref())
+    }
+
+    pub fn get_shared(
+        &self,
+        handle: RasterImageResourceHandle,
+    ) -> Option<Arc<RasterImageResource>> {
+        if handle.arena != self.namespace {
+            return None;
+        }
+        let entry = self.entries.get(handle.id.get() as usize)?;
+        (entry.version == handle.version).then(|| entry.value.clone())
+    }
+
+    pub const fn stats(&self) -> RasterImageResourceStats {
+        RasterImageResourceStats {
+            live_resources: self.entries.len(),
+            retained_bytes: self.retained_bytes,
+            encoded_bytes: self.encoded_bytes,
+        }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RasterImageResourceError {
+    EmptyPayload,
+    InvalidDimensions { width: u32, height: u32 },
+}
+
+impl std::fmt::Display for RasterImageResourceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyPayload => formatter.write_str("raster image payload is empty"),
+            Self::InvalidDimensions { width, height } => write!(
+                formatter,
+                "raster image dimensions must be non-zero, got {width}x{height}",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RasterImageResourceError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn png_bytes() -> Arc<[u8]> {
+        Arc::from([0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a])
+    }
+
+    #[test]
+    fn repeated_identical_image_reuses_one_resource() {
+        let mut arena = RasterImageResourceArena::new();
+        let first = arena
+            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
+            .unwrap();
+        let second = arena
+            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(arena.len(), 1);
+        assert_eq!(arena.stats().encoded_bytes, png_bytes().len());
+    }
+
+    #[test]
+    fn metadata_participates_in_content_identity() {
+        let mut arena = RasterImageResourceArena::new();
+        let png = arena
+            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
+            .unwrap();
+        let jpeg = arena
+            .intern_encoded(RasterImageEncoding::Jpeg, 320, 180, png_bytes())
+            .unwrap();
+        let resized = arena
+            .intern_encoded(RasterImageEncoding::Png, 640, 360, png_bytes())
+            .unwrap();
+
+        assert_ne!(png, jpeg);
+        assert_ne!(png, resized);
+        assert_eq!(arena.len(), 3);
+    }
+
+    #[test]
+    fn invalid_resource_is_rejected_without_allocation() {
+        let mut arena = RasterImageResourceArena::new();
+        assert_eq!(
+            arena.intern_encoded(RasterImageEncoding::Png, 0, 10, png_bytes()),
+            Err(RasterImageResourceError::InvalidDimensions {
+                width: 0,
+                height: 10,
+            })
+        );
+        assert_eq!(
+            arena.intern_encoded(
+                RasterImageEncoding::Webp,
+                10,
+                10,
+                Arc::<[u8]>::from([]),
+            ),
+            Err(RasterImageResourceError::EmptyPayload)
+        );
+        assert!(arena.is_empty());
+        assert_eq!(arena.stats(), RasterImageResourceStats::default());
+    }
+
+    #[test]
+    fn foreign_arena_handle_is_rejected() {
+        let mut first = RasterImageResourceArena::new();
+        let mut second = RasterImageResourceArena::new();
+        let a = first
+            .intern_encoded(RasterImageEncoding::Png, 32, 18, png_bytes())
+            .unwrap();
+        let b = second
+            .intern_encoded(RasterImageEncoding::Png, 32, 18, png_bytes())
+            .unwrap();
+
+        assert_eq!((a.id, a.version), (b.id, b.version));
+        assert_ne!(a.arena, b.arena);
+        assert!(first.get(b).is_none());
+        assert!(second.get(a).is_none());
+    }
+
+    #[test]
+    fn cloned_arena_is_renamespaced_but_shares_payload() {
+        let mut source = RasterImageResourceArena::new();
+        let source_handle = source
+            .intern_encoded(RasterImageEncoding::Png, 320, 180, png_bytes())
+            .unwrap();
+        let source_payload = source.get_shared(source_handle).unwrap();
+
+        let mut cloned = source.clone();
+        cloned.fork_namespace();
+        let cloned_handle = *cloned
+            .handles_by_content
+            .values()
+            .next()
+            .expect("cloned content index contains the image");
+        let cloned_payload = cloned.get_shared(cloned_handle).unwrap();
+
+        assert_ne!(source_handle.arena, cloned_handle.arena);
+        assert!(cloned.get(source_handle).is_none());
+        assert!(source.get(cloned_handle).is_none());
+        assert!(Arc::ptr_eq(&source_payload, &cloned_payload));
+    }
+}

--- a/crates/noon-core/src/resources/mod.rs
+++ b/crates/noon-core/src/resources/mod.rs
@@ -1,4 +1,4 @@
-//! Immutable geometry, font and text resources and their versioned storage.
+//! Immutable geometry, font, image and text resources and their versioned storage.
 //!
 //! Semantic authoring and compiled snapshots share these resource contracts.
 //! Lookup and atomic replacement operate on resource handles; they do not own
@@ -9,6 +9,9 @@ pub use font::*;
 
 mod geometry;
 pub use geometry::*;
+
+mod image;
+pub use image::*;
 
 mod lookup;
 pub use lookup::*;


### PR DESCRIPTION
Advances #79 under #954 with a deliberately non-overlapping B2 raster-resource foundation.

This first slice adds a backend-neutral `RasterImageResourceArena` for canonical tightly-packed RGBA8 pixel payloads with exact visual-content deduplication, intrinsic-dimension metadata, stable arena-qualified handles, retained-byte/pixel-byte instrumentation, explicit validation errors, and clone/re-namespace tests that preserve shared immutable payload allocations. The resource contract is exported from `noon-core` but is not yet wired into semantic object content or rendering.

The canonical-pixel choice follows pinned ManimCE v0.21 `ImageMobject`: both file and ndarray inputs are normalized into an RGBA pixel array before image behavior. PNG/JPEG/WebP parsing/decoding therefore remains an off-frame loader/resource-preparation concern rather than renderer semantic state. Sampling/resampling policy also remains object/renderer-facing metadata, not part of immutable pixel identity.

Architecture boundary: this PR owns immutable resource identity/cache data only. It does **not** touch #78 SVG/path semantics, #1416 unequal-family Transform correspondence, renderer texture residency, public `ImageMobject`, URL/blob loading, or browser/native decoders. There is no migration seam or second scene/runtime/renderer authority.

Locality: repeated identical pixel content shares one immutable allocation; transform/style/runtime work is outside this resource contract and cannot cause image decoding or pixel duplication here. Content lookup uses a hash index so admission is linear in payload size rather than byte-wise tree comparison across the resource set.

Validation in this slice is focused Rust unit coverage for deduplication, dimension-sensitive identity, invalid admission atomicity, arena provenance, immutable payload sharing across cloned owners, and accounting. GitHub qualification provides the repository-level executable gate because this session has no mounted/networked Noon checkout.

Base at branch creation: `9064df5008800e13f5d3568fee354eaf5001854a`.

Follow-up after this foundation qualifies: SemanticStore/image-content ownership plus decoder/authoring integration, then retained renderer texture installation and browser/package-loading tests. SVG remains blocked on the active #78 path work rather than being mixed into this PR.