### PR TITLE
Fix native Text regular-face selection

### DIFF
--- a/crates/noon/src/text_authoring.rs
+++ b/crates/noon/src/text_authoring.rs
@@ -34,7 +34,7 @@ use noon_typst::{
     compile_typst_resource, compile_typst_resource_with_fonts, TypstMode, TypstResourceArtifact,
 };
 #[cfg(all(feature = "native-text", feature = "bundled-fonts"))]
-use swash::{FontRef, StringId};
+use swash::{FontRef, Stretch, StringId, Style as FontStyle, Weight};
 
 /// Typst's retained artifact is authored at 10pt, so its public Manim-style font size
 /// remains an object transform and does not alter glyph/cluster identity.
@@ -422,17 +422,38 @@ impl Text {
 #[cfg(feature = "native-text")]
 fn bundled_native_font(family: &str) -> Result<NativeFontFace, TextAuthoringError> {
     #[cfg(feature = "bundled-fonts")]
-    for data in typst_assets::fonts() {
-        let Some(font) = FontRef::from_index(data, 0) else {
-            continue;
-        };
-        let matches = font.localized_strings().any(|name| {
-            matches!(
-                name.id(),
-                StringId::Family | StringId::TypographicFamily | StringId::WwsFamily
-            ) && name.to_string().eq_ignore_ascii_case(family)
-        });
-        if matches {
+    {
+        let mut fallback = None;
+        for data in typst_assets::fonts() {
+            let Some(font) = FontRef::from_index(data, 0) else {
+                continue;
+            };
+            let matches = font.localized_strings().any(|name| {
+                matches!(
+                    name.id(),
+                    StringId::Family | StringId::TypographicFamily | StringId::WwsFamily
+                ) && name.to_string().eq_ignore_ascii_case(family)
+            });
+            if !matches {
+                continue;
+            }
+            if fallback.is_none() {
+                fallback = Some(data);
+            }
+
+            // Asset order is not a font-selection policy: typst-assets currently
+            // lists bold DejaVu Sans Mono before regular. Unstyled Manim Text asks
+            // Pango for normal stretch, weight, and style, so prefer that face here.
+            let attributes = font.attributes();
+            if attributes.stretch() == Stretch::NORMAL
+                && attributes.weight() == Weight::NORMAL
+                && attributes.style() == FontStyle::Normal
+            {
+                return NativeFontFace::new(Arc::<str>::from(family), Arc::<[u8]>::from(data), 0)
+                    .map_err(TextAuthoringError::NativeText);
+            }
+        }
+        if let Some(data) = fallback {
             return NativeFontFace::new(Arc::<str>::from(family), Arc::<[u8]>::from(data), 0)
                 .map_err(TextAuthoringError::NativeText);
         }
@@ -705,6 +726,17 @@ mod tests {
         assert_eq!(resource.source.as_ref(), "Native Noon");
         assert!(!scene.fonts().is_empty());
         assert!(scene.objects()[0].content.geometry().is_none());
+    }
+
+    #[test]
+    fn bundled_native_text_prefers_regular_face_over_asset_order() {
+        let font = bundled_native_font(DEFAULT_NATIVE_TEXT_FONT_FAMILY).unwrap();
+        let font = FontRef::from_index(font.data.as_ref(), font.face_index as usize).unwrap();
+        let attributes = font.attributes();
+
+        assert_eq!(attributes.stretch(), Stretch::NORMAL);
+        assert_eq!(attributes.weight(), Weight::NORMAL);
+        assert_eq!(attributes.style(), FontStyle::Normal);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix a native `Text` baseline bug exposed by #1376's pinned ManimCE v0.21 raster fixture. Bundled font lookup previously matched only the family name, so the first matching Typst asset won. For `DejaVu Sans Mono`, the bundled asset order places a bold face before regular, causing ordinary unstyled `Text` to render visibly heavier than Manim/Pango.

- prefer the normal stretch/weight/style face for unstyled bundled native Text
- preserve the previous first-family-match fallback when no exact normal face exists
- add a regression proving the default bundled DejaVu Sans Mono face is regular
- no renderer changes, no raster-threshold changes, no frontend-owned state

## Evidence

After #1414 corrected the 1/72 point conversion, #1376's remaining raster mismatch is small but visually weight-specific: the reference foreground has 3988 pixels while Noon has 5679, with the same 36px raster height and only +3px ink width. Both WebGPU and WebGL produce the same result. The remaining ratchet failure is `bounds_delta_px=3 > 2` and `differing_ratio=0.007351... > 0.006`.

This PR keeps that baseline font-selection fix separate from #1376's range-color semantics. After merge, #1376 will be restacked and its pinned raster rerun unchanged.

Refs #83
Prerequisite for #1376
Part of #954