### PR TITLE
Compose preview sessions with retained frame evidence

### DIFF
--- a/tools/noon-mcp/src/preview-service.mjs
+++ b/tools/noon-mcp/src/preview-service.mjs
@@ -5,6 +5,7 @@ import { FrameArtifactStore } from "../../../scripts/agent-preview-artifacts.mjs
 import { createDockerPreviewSessionFactory } from "./preview-runner.mjs";
 
 const DEFAULT_MAX_FRAMES_PER_SESSION = 32;
+const REGISTRY_LIMIT_KEYS = new Set(["maxScopes", "maxSessions", "maxSessionsPerScope"]);
 
 /**
  * Transport-neutral ownership for preview execution plus retained frame evidence.
@@ -36,6 +37,9 @@ export class AgentPreviewService {
     }
     if (!plainRecord(registryLimits) || !plainRecord(artifactLimits)) {
       throw new TypeError("preview service limits must be plain records");
+    }
+    if (Reflect.ownKeys(registryLimits).some((key) => !REGISTRY_LIMIT_KEYS.has(key))) {
+      throw new TypeError("unknown preview session registry limit");
     }
     if (Object.hasOwn(artifactLimits, "maxFramesPerScope")) {
       throw new TypeError("configure retained frame count with maxFramesPerSession");
@@ -94,10 +98,8 @@ export class AgentPreviewService {
   async sampleFrames(scopeCapability, sessionId, times, options = {}) {
     const { scope, entry } = this.#entry(scopeCapability, sessionId);
     const sampleOptions = options ?? {};
-    const normalized = sampleTimes(times, entry.lastRequestedTime);
-    if (normalized.length > this.#maxFramesPerSession - entry.frameCount) {
-      throw new RangeError("preview retained frame limit exceeded");
-    }
+    const remaining = this.#maxFramesPerSession - entry.frameCount;
+    const normalized = sampleTimes(times, entry.lastRequestedTime, remaining);
     throwIfAborted(sampleOptions.signal);
 
     const results = [];
@@ -299,10 +301,11 @@ function publicSnapshot(value) {
   return Object.freeze(snapshot);
 }
 
-function sampleTimes(times, lowerBound) {
+function sampleTimes(times, lowerBound, maxCount) {
   if (!Array.isArray(times) || times.length === 0) {
     throw new TypeError("sample times must be a non-empty array");
   }
+  if (times.length > maxCount) throw new RangeError("preview retained frame limit exceeded");
   let previous = lowerBound;
   return times.map((value) => {
     if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {

--- a/tools/noon-mcp/src/preview-service.mjs
+++ b/tools/noon-mcp/src/preview-service.mjs
@@ -67,6 +67,7 @@ export class AgentPreviewService {
     const { sessionId, snapshot: capture } = opened;
     let artifactScope = null;
     try {
+      this.#assertScopeCurrent(scopeCapability, scope);
       throwIfAborted(openOptions.signal);
       artifactScope = this.#artifacts.openScope({
         sessionId,
@@ -75,11 +76,13 @@ export class AgentPreviewService {
       });
       const artifact = artifactScope.putFrame(artifactFrame(capture));
       throwIfAborted(openOptions.signal);
+      this.#assertScopeCurrent(scopeCapability, scope);
       scope.sessions.set(sessionId, {
         artifactScope,
         lastArtifact: artifact,
         frameCount: 1,
         lastRequestedTime: artifact.provenance.requestedTime,
+        busy: false,
       });
       return Object.freeze({ sessionId, snapshot: publicSnapshot(capture), artifact });
     } catch (error) {
@@ -97,36 +100,41 @@ export class AgentPreviewService {
 
   async sampleFrames(scopeCapability, sessionId, times, options = {}) {
     const { scope, entry } = this.#entry(scopeCapability, sessionId);
+    if (entry.busy) throw new Error("preview service operation already in progress");
     const sampleOptions = options ?? {};
     const remaining = this.#maxFramesPerSession - entry.frameCount;
     const normalized = sampleTimes(times, entry.lastRequestedTime, remaining);
-    throwIfAborted(sampleOptions.signal);
+    entry.busy = true;
+    try {
+      throwIfAborted(sampleOptions.signal);
+      const results = [];
+      for (const timeSeconds of normalized) {
+        let capture;
+        try {
+          capture = await this.#registry.sample(scopeCapability, sessionId, timeSeconds, sampleOptions);
+          throwIfAborted(sampleOptions.signal);
+        } catch (error) {
+          await this.#reconcileFailedOperation(scopeCapability, scope, sessionId, entry, error,
+            errorMessage(error, "preview sample failed"));
+          throw error;
+        }
 
-    const results = [];
-    for (const timeSeconds of normalized) {
-      let capture;
-      try {
-        capture = await this.#registry.sample(scopeCapability, sessionId, timeSeconds, sampleOptions);
-        throwIfAborted(sampleOptions.signal);
-      } catch (error) {
-        await this.#reconcileFailedOperation(scopeCapability, scope, sessionId, entry, error,
-          errorMessage(error, "preview sample failed"));
-        throw error;
+        try {
+          const artifact = entry.artifactScope.putFrame(artifactFrame(capture));
+          entry.lastArtifact = artifact;
+          entry.frameCount += 1;
+          entry.lastRequestedTime = artifact.provenance.requestedTime;
+          results.push(Object.freeze({ snapshot: publicSnapshot(capture), artifact }));
+        } catch (error) {
+          await this.#retirePreserving(scopeCapability, scope, sessionId, entry, error,
+            errorMessage(error, "preview artifact publication failed"));
+          throw error;
+        }
       }
-
-      try {
-        const artifact = entry.artifactScope.putFrame(artifactFrame(capture));
-        entry.lastArtifact = artifact;
-        entry.frameCount += 1;
-        entry.lastRequestedTime = artifact.provenance.requestedTime;
-        results.push(Object.freeze({ snapshot: publicSnapshot(capture), artifact }));
-      } catch (error) {
-        await this.#retirePreserving(scopeCapability, scope, sessionId, entry, error,
-          errorMessage(error, "preview artifact publication failed"));
-        throw error;
-      }
+      return Object.freeze(results);
+    } finally {
+      if (scope.sessions.get(sessionId) === entry) entry.busy = false;
     }
-    return Object.freeze(results);
   }
 
   inspect(scopeCapability, sessionId) {
@@ -254,6 +262,12 @@ export class AgentPreviewService {
     const scope = this.#scopes.get(capability);
     if (!scope || scope.closed) throw new Error("stale preview service scope capability");
     return scope;
+  }
+
+  #assertScopeCurrent(capability, scope) {
+    if (this.#disposed || scope.closed || this.#scopes.get(capability) !== scope) {
+      throw new Error("preview service scope closed during operation");
+    }
   }
 
   #assertLive() {

--- a/tools/noon-mcp/src/preview-service.mjs
+++ b/tools/noon-mcp/src/preview-service.mjs
@@ -1,0 +1,339 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { AgentPreviewSessionRegistry } from "../../../scripts/agent-preview-sessions.mjs";
+import { FrameArtifactStore } from "../../../scripts/agent-preview-artifacts.mjs";
+import { createDockerPreviewSessionFactory } from "./preview-runner.mjs";
+
+const DEFAULT_MAX_FRAMES_PER_SESSION = 32;
+
+/**
+ * Transport-neutral ownership for preview execution plus retained frame evidence.
+ *
+ * Execution/session authority remains in AgentPreviewSessionRegistry and the
+ * supplied preview-session factory. Frame ownership remains in FrameArtifactStore.
+ * This layer only keeps the private association between those two capabilities.
+ * It does not expose MCP, CLI, scene/runtime, renderer, or seek semantics.
+ */
+export class AgentPreviewService {
+  #registry;
+  #artifacts;
+  #scopes = new Map();
+  #maxFramesPerSession;
+  #disposed = false;
+  #disposePromise = null;
+
+  constructor({ createSession, isolationConfig, registryLimits = {}, artifactLimits = {},
+    maxFramesPerSession = DEFAULT_MAX_FRAMES_PER_SESSION } = {}) {
+    if (createSession === undefined) {
+      if (!isolationConfig || typeof isolationConfig !== "object") {
+        throw new TypeError("preview service requires createSession or Docker isolationConfig");
+      }
+      createSession = createDockerPreviewSessionFactory(isolationConfig);
+    }
+    if (typeof createSession !== "function") throw new TypeError("createSession must be a function");
+    if (!Number.isSafeInteger(maxFramesPerSession) || maxFramesPerSession <= 0 || maxFramesPerSession > 65_536) {
+      throw new RangeError("maxFramesPerSession must be a positive bounded integer");
+    }
+    if (!plainRecord(registryLimits) || !plainRecord(artifactLimits)) {
+      throw new TypeError("preview service limits must be plain records");
+    }
+    if (Object.hasOwn(artifactLimits, "maxFramesPerScope")) {
+      throw new TypeError("configure retained frame count with maxFramesPerSession");
+    }
+    this.#maxFramesPerSession = maxFramesPerSession;
+    this.#registry = new AgentPreviewSessionRegistry({ createSession, ...registryLimits });
+    this.#artifacts = new FrameArtifactStore({
+      limits: { ...artifactLimits, maxFramesPerScope: maxFramesPerSession },
+    });
+  }
+
+  openScope() {
+    this.#assertLive();
+    const capability = this.#registry.openScope();
+    this.#scopes.set(capability, { closed: false, sessions: new Map() });
+    return capability;
+  }
+
+  async open(scopeCapability, source, options = {}) {
+    const scope = this.#scope(scopeCapability);
+    if (typeof source !== "string") throw new TypeError("preview source must be text");
+    const sourceSha256 = createHash("sha256").update(source, "utf8").digest("hex");
+    const openOptions = options ?? {};
+    const opened = await this.#registry.open(scopeCapability, source, openOptions);
+    const { sessionId, snapshot: capture } = opened;
+    let artifactScope = null;
+    try {
+      throwIfAborted(openOptions.signal);
+      artifactScope = this.#artifacts.openScope({
+        sessionId,
+        sourceSha256,
+        build: artifactBuild(capture?.buildIdentity),
+      });
+      const artifact = artifactScope.putFrame(artifactFrame(capture));
+      throwIfAborted(openOptions.signal);
+      scope.sessions.set(sessionId, {
+        artifactScope,
+        lastArtifact: artifact,
+        frameCount: 1,
+        lastRequestedTime: artifact.provenance.requestedTime,
+      });
+      return Object.freeze({ sessionId, snapshot: publicSnapshot(capture), artifact });
+    } catch (error) {
+      artifactScope?.close();
+      await cleanupPreserving(error,
+        () => this.#registry.close(scopeCapability, sessionId, errorMessage(error, "preview publication failed")));
+      throw error;
+    }
+  }
+
+  async sample(scopeCapability, sessionId, timeSeconds, options = {}) {
+    const frames = await this.sampleFrames(scopeCapability, sessionId, [timeSeconds], options);
+    return frames[0];
+  }
+
+  async sampleFrames(scopeCapability, sessionId, times, options = {}) {
+    const { scope, entry } = this.#entry(scopeCapability, sessionId);
+    const sampleOptions = options ?? {};
+    const normalized = sampleTimes(times, entry.lastRequestedTime);
+    if (normalized.length > this.#maxFramesPerSession - entry.frameCount) {
+      throw new RangeError("preview retained frame limit exceeded");
+    }
+    throwIfAborted(sampleOptions.signal);
+
+    const results = [];
+    for (const timeSeconds of normalized) {
+      let capture;
+      try {
+        capture = await this.#registry.sample(scopeCapability, sessionId, timeSeconds, sampleOptions);
+        throwIfAborted(sampleOptions.signal);
+      } catch (error) {
+        await this.#reconcileFailedOperation(scopeCapability, scope, sessionId, entry, error,
+          errorMessage(error, "preview sample failed"));
+        throw error;
+      }
+
+      try {
+        const artifact = entry.artifactScope.putFrame(artifactFrame(capture));
+        entry.lastArtifact = artifact;
+        entry.frameCount += 1;
+        entry.lastRequestedTime = artifact.provenance.requestedTime;
+        results.push(Object.freeze({ snapshot: publicSnapshot(capture), artifact }));
+      } catch (error) {
+        await this.#retirePreserving(scopeCapability, scope, sessionId, entry, error,
+          errorMessage(error, "preview artifact publication failed"));
+        throw error;
+      }
+    }
+    return Object.freeze(results);
+  }
+
+  inspect(scopeCapability, sessionId) {
+    const { entry } = this.#entry(scopeCapability, sessionId);
+    const snapshot = this.#registry.inspect(scopeCapability, sessionId);
+    return Object.freeze({
+      snapshot: publicSnapshot(snapshot),
+      artifact: entry.lastArtifact,
+      retainedFrames: entry.frameCount,
+      maxRetainedFrames: this.#maxFramesPerSession,
+    });
+  }
+
+  getArtifact(scopeCapability, sessionId, artifactId) {
+    const { entry } = this.#entry(scopeCapability, sessionId);
+    return entry.artifactScope.getFrame(artifactId);
+  }
+
+  async close(scopeCapability, sessionId, reason = "preview session closed") {
+    const { scope, entry } = this.#entry(scopeCapability, sessionId);
+    let result;
+    let failure = null;
+    try {
+      result = await this.#registry.close(scopeCapability, sessionId, reason);
+    } catch (error) {
+      failure = error;
+    } finally {
+      entry.artifactScope.close();
+      scope.sessions.delete(sessionId);
+    }
+    if (failure) throw failure;
+    return publicSnapshot(result);
+  }
+
+  async closeScope(scopeCapability, reason = "preview transport disconnected") {
+    const scope = this.#scope(scopeCapability);
+    scope.closed = true;
+    let result;
+    let failure = null;
+    try {
+      result = await this.#registry.closeScope(scopeCapability, reason);
+    } catch (error) {
+      failure = error;
+    } finally {
+      for (const entry of scope.sessions.values()) entry.artifactScope.close();
+      scope.sessions.clear();
+      this.#scopes.delete(scopeCapability);
+    }
+    if (failure) throw failure;
+    return result;
+  }
+
+  dispose(reason = "preview service shutdown") {
+    if (this.#disposePromise) return this.#disposePromise;
+    if (this.#disposed) return Promise.resolve(Object.freeze([]));
+    this.#disposed = true;
+    this.#disposePromise = (async () => {
+      let result;
+      let failure = null;
+      try {
+        result = await this.#registry.dispose(reason);
+      } catch (error) {
+        failure = error;
+      } finally {
+        for (const scope of this.#scopes.values()) {
+          for (const entry of scope.sessions.values()) entry.artifactScope.close();
+          scope.sessions.clear();
+          scope.closed = true;
+        }
+        this.#scopes.clear();
+        this.#artifacts.dispose();
+      }
+      if (failure) throw failure;
+      return result;
+    })();
+    return this.#disposePromise;
+  }
+
+  get stats() {
+    return Object.freeze({
+      scopes: this.#scopes.size,
+      sessions: this.#registry.counts.sessions,
+      artifacts: this.#artifacts.stats(),
+      maxFramesPerSession: this.#maxFramesPerSession,
+      disposed: this.#disposed,
+    });
+  }
+
+  async #reconcileFailedOperation(scopeCapability, scope, sessionId, entry, error, reason) {
+    let stale = false;
+    let snapshot = null;
+    try { snapshot = this.#registry.inspect(scopeCapability, sessionId); }
+    catch { stale = true; }
+    if (stale) {
+      this.#releaseLocal(scope, sessionId, entry);
+      return;
+    }
+    if (snapshot?.state === "closed" || snapshot?.state === "failed") {
+      await this.#retirePreserving(scopeCapability, scope, sessionId, entry, error, reason);
+    }
+  }
+
+  async #retirePreserving(scopeCapability, scope, sessionId, entry, error, reason) {
+    await cleanupPreserving(error, () => this.#registry.close(scopeCapability, sessionId, reason));
+    this.#releaseLocal(scope, sessionId, entry);
+  }
+
+  #releaseLocal(scope, sessionId, entry) {
+    entry.artifactScope.close();
+    if (scope.sessions.get(sessionId) === entry) scope.sessions.delete(sessionId);
+  }
+
+  #entry(scopeCapability, sessionId) {
+    const scope = this.#scope(scopeCapability);
+    if (typeof sessionId !== "string" || sessionId.length === 0) {
+      throw new TypeError("preview session ID must be non-empty");
+    }
+    const entry = scope.sessions.get(sessionId);
+    if (!entry) throw new Error("stale or cross-scope preview session ID");
+    return { scope, entry };
+  }
+
+  #scope(capability) {
+    this.#assertLive();
+    const scope = this.#scopes.get(capability);
+    if (!scope || scope.closed) throw new Error("stale preview service scope capability");
+    return scope;
+  }
+
+  #assertLive() {
+    if (this.#disposed) throw new Error("preview service is disposed");
+  }
+}
+
+function artifactBuild(identity) {
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) {
+    throw new Error("preview capture lacks observed runtime build identity");
+  }
+  const files = identity.files;
+  if (!files || typeof files !== "object" || Array.isArray(files) ||
+      typeof files.worker?.sha256 !== "string" || typeof files.wasm?.sha256 !== "string" ||
+      typeof identity.buildId !== "string") {
+    throw new Error("preview capture has incomplete observed runtime build identity");
+  }
+  return {
+    engineRevision: identity.sourceRevision ?? null,
+    wasmSha256: files.wasm.sha256,
+    workerSha256: files.worker.sha256,
+    buildId: identity.buildId,
+  };
+}
+
+function artifactFrame(capture) {
+  if (!capture || typeof capture !== "object" || !Buffer.isBuffer(capture.imageData)) {
+    throw new Error("preview capture lacks owned PNG bytes");
+  }
+  const frame = capture.frame;
+  if (!frame || typeof frame !== "object") throw new Error("preview capture lacks frame metadata");
+  return {
+    png: capture.imageData,
+    requestedTime: frame.requestedTime,
+    publishedTime: frame.publishedTime,
+    backend: frame.rendererBackend,
+    sceneRevision: null,
+    frameRevision: null,
+  };
+}
+
+function publicSnapshot(value) {
+  if (!value || typeof value !== "object") return value;
+  const { imageData: _imageData, ...snapshot } = value;
+  return Object.freeze(snapshot);
+}
+
+function sampleTimes(times, lowerBound) {
+  if (!Array.isArray(times) || times.length === 0) {
+    throw new TypeError("sample times must be a non-empty array");
+  }
+  let previous = lowerBound;
+  return times.map((value) => {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new RangeError("preview sample time must be finite and nonnegative");
+    }
+    if (value < previous) throw new RangeError("preview playback cannot move backwards");
+    previous = value;
+    return value;
+  });
+}
+
+function throwIfAborted(signal) {
+  if (!signal?.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  throw new Error(typeof signal.reason === "string" && signal.reason.trim() ? signal.reason : "preview operation canceled");
+}
+
+async function cleanupPreserving(primaryError, cleanup) {
+  try { await cleanup(); }
+  catch (cleanupError) {
+    if (primaryError && typeof primaryError === "object") {
+      primaryError.cleanupError = errorMessage(cleanupError, "preview cleanup failed");
+    }
+  }
+}
+
+function errorMessage(error, fallback) {
+  return error instanceof Error && error.message ? error.message : String(error ?? fallback);
+}
+
+function plainRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value));
+}

--- a/tools/noon-mcp/test/preview-service.test.mjs
+++ b/tools/noon-mcp/test/preview-service.test.mjs
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { deflateSync } from "node:zlib";
+import { AgentPreviewService } from "../src/preview-service.mjs";
+
+function chunk(kind, bytes = Buffer.alloc(0)) {
+  const body = Buffer.concat([Buffer.from(kind), bytes]);
+  let crc = 0xffffffff;
+  for (const byte of body) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  const header = Buffer.alloc(4), trailer = Buffer.alloc(4);
+  header.writeUInt32BE(bytes.length);
+  trailer.writeUInt32BE((crc ^ 0xffffffff) >>> 0);
+  return Buffer.concat([header, body, trailer]);
+}
+
+function image(width = 2, height = 1) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width); header.writeUInt32BE(height, 4);
+  header[8] = 8; header[9] = 6;
+  const pixels = Buffer.alloc((width * 4 + 1) * height, 0);
+  return Buffer.concat([Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    chunk("IHDR", header), chunk("IDAT", deflateSync(pixels)), chunk("IEND")]);
+}
+
+const PNG = image();
+const BUILD_IDENTITY = Object.freeze({
+  schema: 1,
+  sourceRevision: "a".repeat(40),
+  files: Object.freeze({
+    worker: Object.freeze({ sha256: "b".repeat(64) }),
+    wasm: Object.freeze({ sha256: "c".repeat(64) }),
+    glue: Object.freeze({ sha256: "d".repeat(64) }),
+    verifier: Object.freeze({ sha256: "e".repeat(64) }),
+  }),
+  buildId: "fixture-build",
+});
+
+function capture(time, buildIdentity = BUILD_IDENTITY) {
+  return Object.freeze({
+    state: "ready",
+    sourceState: "running",
+    authoredDuration: 4,
+    frame: Object.freeze({
+      requestedTime: time,
+      publishedTime: time + 0.01,
+      rendererBackend: "webgl2",
+      objectCount: 1,
+      drawCalls: 1,
+    }),
+    image: Object.freeze({ mimeType: "image/png", byteLength: PNG.length }),
+    buildIdentity,
+    imageData: Buffer.from(PNG),
+  });
+}
+
+function snapshotOf(value) {
+  const { imageData: _imageData, ...snapshot } = value;
+  return Object.freeze(snapshot);
+}
+
+class FakeSession {
+  #control;
+  #snapshot = Object.freeze({ state: "new", frame: null, image: null });
+
+  constructor(control) { this.#control = control; }
+  get snapshot() { return this.#snapshot; }
+
+  async open(source) {
+    this.#control.opened.push(source);
+    if (this.#control.openError) throw this.#control.openError;
+    const result = capture(0, this.#control.buildIdentity);
+    this.#snapshot = snapshotOf(result);
+    return result;
+  }
+
+  async sample(time) {
+    this.#control.sampled.push(time);
+    if (this.#control.sampleErrorAt === time) {
+      if (this.#control.fatalSampleError) {
+        this.#snapshot = Object.freeze({ ...this.#snapshot, state: "closed", error: "fixture fatal sample" });
+      }
+      throw new Error("fixture sample failed");
+    }
+    const result = capture(time, this.#control.buildIdentity);
+    this.#snapshot = snapshotOf(result);
+    return result;
+  }
+
+  async close(reason) {
+    this.#control.closed.push(reason);
+    this.#snapshot = Object.freeze({ ...this.#snapshot, state: "closed" });
+    return this.#snapshot;
+  }
+}
+
+function setup({ maxFramesPerSession = 32, artifactLimits = {}, session = {} } = {}) {
+  const controls = [];
+  const service = new AgentPreviewService({
+    maxFramesPerSession,
+    artifactLimits,
+    createSession: () => {
+      const control = {
+        opened: [], sampled: [], closed: [], buildIdentity: BUILD_IDENTITY,
+        openError: null, sampleErrorAt: null, fatalSampleError: false,
+        ...session,
+      };
+      controls.push(control);
+      return new FakeSession(control);
+    },
+  });
+  return { service, scope: service.openScope(), controls };
+}
+
+test("open binds submitted source, observed build and actual PNG to one opaque session", async () => {
+  const { service, scope, controls } = setup();
+  const source = "from noon import *\nSquare()";
+  const opened = await service.open(scope, source);
+  assert.match(opened.sessionId, /^[0-9a-f-]{36}$/);
+  assert.equal(Object.hasOwn(opened.snapshot, "imageData"), false);
+  assert.equal(controls[0].opened[0], source);
+  assert.deepEqual(opened.artifact.provenance.build, {
+    engineRevision: "a".repeat(40),
+    wasmSha256: "c".repeat(64),
+    workerSha256: "b".repeat(64),
+    buildId: "fixture-build",
+  });
+  assert.equal(opened.artifact.provenance.sourceSha256,
+    createHash("sha256").update(source, "utf8").digest("hex"));
+  assert.equal(opened.artifact.provenance.requestedTime, 0);
+  assert.equal(opened.artifact.provenance.backend, "webgl2");
+  assert.equal(opened.artifact.provenance.sceneRevision, null);
+  assert.equal(opened.artifact.provenance.frameRevision, null);
+
+  const first = service.getArtifact(scope, opened.sessionId, opened.artifact.id);
+  assert.deepEqual(first.png, PNG);
+  first.png.fill(0);
+  assert.deepEqual(service.getArtifact(scope, opened.sessionId, opened.artifact.id).png, PNG);
+  assert.equal(service.stats.sessions, 1);
+  assert.equal(service.stats.artifacts.artifacts, 1);
+});
+
+test("batch sampling preflights ordering and retained-frame budget before advancing", async () => {
+  const { service, scope, controls } = setup({ maxFramesPerSession: 4 });
+  const opened = await service.open(scope, "scene()");
+
+  await assert.rejects(service.sampleFrames(scope, opened.sessionId, [1, 0.5]), /cannot move backwards/);
+  await assert.rejects(service.sampleFrames(scope, opened.sessionId, [0.5, 1, 1.5, 2]), /retained frame limit/);
+  assert.deepEqual(controls[0].sampled, []);
+
+  const frames = await service.sampleFrames(scope, opened.sessionId, [0.5, 1, 1]);
+  assert.deepEqual(controls[0].sampled, [0.5, 1, 1]);
+  assert.deepEqual(frames.map((entry) => entry.artifact.provenance.requestedTime), [0.5, 1, 1]);
+  assert.equal(service.inspect(scope, opened.sessionId).retainedFrames, 4);
+  await assert.rejects(service.sample(scope, opened.sessionId, 2), /retained frame limit/);
+  assert.deepEqual(controls[0].sampled, [0.5, 1, 1]);
+});
+
+test("missing observed build identity rejects open and retires the execution session", async () => {
+  const { service, scope, controls } = setup({ session: { buildIdentity: null } });
+  await assert.rejects(service.open(scope, "scene()"), /lacks observed runtime build identity/);
+  assert.equal(controls.length, 1);
+  assert.equal(controls[0].closed.length, 1);
+  assert.equal(service.stats.sessions, 0);
+  assert.equal(service.stats.artifacts.scopes, 0);
+  assert.equal(service.stats.artifacts.artifacts, 0);
+});
+
+test("artifact admission failure after a sample fails closed instead of leaving advanced live state", async () => {
+  const { service, scope, controls } = setup({
+    maxFramesPerSession: 4,
+    artifactLimits: { maxTotalBytes: PNG.length },
+  });
+  const opened = await service.open(scope, "scene()");
+  await assert.rejects(service.sample(scope, opened.sessionId, 0.5), /retained byte limit/);
+  assert.deepEqual(controls[0].sampled, [0.5]);
+  assert.equal(controls[0].closed.length, 1);
+  assert.equal(service.stats.sessions, 0);
+  assert.equal(service.stats.artifacts.artifacts, 0);
+  assert.throws(() => service.inspect(scope, opened.sessionId), /stale or cross-scope/);
+});
+
+test("fatal session failures revoke artifacts while recoverable session errors preserve them", async () => {
+  const recoverable = setup({ session: { sampleErrorAt: 0.5 } });
+  const a = await recoverable.service.open(recoverable.scope, "scene()");
+  await assert.rejects(recoverable.service.sample(recoverable.scope, a.sessionId, 0.5), /fixture sample failed/);
+  assert.equal(recoverable.service.stats.sessions, 1);
+  assert.ok(recoverable.service.getArtifact(recoverable.scope, a.sessionId, a.artifact.id));
+  assert.ok(await recoverable.service.sample(recoverable.scope, a.sessionId, 1));
+
+  const fatal = setup({ session: { sampleErrorAt: 0.5, fatalSampleError: true } });
+  const b = await fatal.service.open(fatal.scope, "scene()");
+  await assert.rejects(fatal.service.sample(fatal.scope, b.sessionId, 0.5), /fixture sample failed/);
+  assert.equal(fatal.service.stats.sessions, 0);
+  assert.equal(fatal.service.stats.artifacts.artifacts, 0);
+  assert.throws(() => fatal.service.getArtifact(fatal.scope, b.sessionId, b.artifact.id), /stale or cross-scope/);
+});
+
+test("session and artifact capabilities remain scope-local and close revokes both", async () => {
+  const { service, scope, controls } = setup();
+  const other = service.openScope();
+  const opened = await service.open(scope, "scene()");
+  assert.throws(() => service.inspect(other, opened.sessionId), /stale or cross-scope/);
+  assert.throws(() => service.getArtifact(other, opened.sessionId, opened.artifact.id), /stale or cross-scope/);
+
+  const closed = await service.close(scope, opened.sessionId, "fixture complete");
+  assert.equal(closed.state, "closed");
+  assert.equal(controls[0].closed.length, 1);
+  assert.equal(service.stats.sessions, 0);
+  assert.equal(service.stats.artifacts.artifacts, 0);
+  assert.throws(() => service.inspect(scope, opened.sessionId), /stale or cross-scope/);
+});
+
+test("closeScope and dispose await session cleanup and release every retained artifact", async () => {
+  const { service, scope, controls } = setup();
+  const first = await service.open(scope, "first()");
+  const second = await service.open(scope, "second()");
+  assert.notEqual(first.sessionId, second.sessionId);
+  assert.equal(service.stats.artifacts.artifacts, 2);
+
+  await service.closeScope(scope, "transport gone");
+  assert.equal(controls[0].closed.length, 1);
+  assert.equal(controls[1].closed.length, 1);
+  assert.equal(service.stats.sessions, 0);
+  assert.equal(service.stats.artifacts.artifacts, 0);
+  assert.throws(() => service.inspect(scope, first.sessionId), /stale preview service scope/);
+
+  const next = service.openScope();
+  await service.open(next, "third()");
+  await service.dispose("fixture shutdown");
+  assert.equal(controls[2].closed.length, 1);
+  assert.equal(service.stats.disposed, true);
+  assert.equal(service.stats.artifacts.disposed, true);
+  assert.throws(() => service.openScope(), /preview service is disposed/);
+});

--- a/tools/noon-mcp/test/preview-service.test.mjs
+++ b/tools/noon-mcp/test/preview-service.test.mjs
@@ -80,6 +80,7 @@ class FakeSession {
 
   async sample(time) {
     this.#control.sampled.push(time);
+    if (this.#control.sampleBarrier) await this.#control.sampleBarrier;
     if (this.#control.sampleErrorAt === time) {
       if (this.#control.fatalSampleError) {
         this.#snapshot = Object.freeze({ ...this.#snapshot, state: "closed", error: "fixture fatal sample" });
@@ -106,7 +107,7 @@ function setup({ maxFramesPerSession = 32, artifactLimits = {}, session = {} } =
     createSession: () => {
       const control = {
         opened: [], sampled: [], closed: [], buildIdentity: BUILD_IDENTITY,
-        openError: null, sampleErrorAt: null, fatalSampleError: false,
+        openError: null, sampleErrorAt: null, fatalSampleError: false, sampleBarrier: null,
         ...session,
       };
       controls.push(control);
@@ -158,6 +159,27 @@ test("batch sampling preflights ordering and retained-frame budget before advanc
   assert.equal(service.inspect(scope, opened.sessionId).retainedFrames, 4);
   await assert.rejects(service.sample(scope, opened.sessionId, 2), /retained frame limit/);
   assert.deepEqual(controls[0].sampled, [0.5, 1, 1]);
+});
+
+test("overlapping composition requests reject before entering the shared session", async () => {
+  let releaseSample;
+  const sampleBarrier = new Promise((resolve) => { releaseSample = resolve; });
+  const { service, scope, controls } = setup({ session: { sampleBarrier } });
+  const opened = await service.open(scope, "scene()");
+
+  const first = service.sample(scope, opened.sessionId, 0.5);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(controls[0].sampled, [0.5]);
+
+  await assert.rejects(service.sample(scope, opened.sessionId, 1), /preview service operation already in progress/);
+  assert.deepEqual(controls[0].sampled, [0.5]);
+  assert.equal(service.inspect(scope, opened.sessionId).retainedFrames, 1);
+
+  releaseSample();
+  const completed = await first;
+  assert.equal(completed.artifact.provenance.requestedTime, 0.5);
+  assert.equal(service.inspect(scope, opened.sessionId).retainedFrames, 2);
+  assert.equal(service.stats.sessions, 1);
 });
 
 test("missing observed build identity rejects open and retires the execution session", async () => {

--- a/tools/noon-mcp/test/preview-service.test.mjs
+++ b/tools/noon-mcp/test/preview-service.test.mjs
@@ -173,7 +173,7 @@ test("overlapping composition requests reject before entering the shared session
 
   await assert.rejects(service.sample(scope, opened.sessionId, 1), /preview service operation already in progress/);
   assert.deepEqual(controls[0].sampled, [0.5]);
-  assert.equal(service.inspect(scope, opened.sessionId).retainedFrames, 1);
+  assert.equal(service.stats.artifacts.artifacts, 1);
 
   releaseSample();
   const completed = await first;

--- a/tools/noon-mcp/test/preview-service.test.mjs
+++ b/tools/noon-mcp/test/preview-service.test.mjs
@@ -37,7 +37,7 @@ const BUILD_IDENTITY = Object.freeze({
     glue: Object.freeze({ sha256: "d".repeat(64) }),
     verifier: Object.freeze({ sha256: "e".repeat(64) }),
   }),
-  buildId: "fixture-build",
+  buildId: "f".repeat(64),
 });
 
 function capture(time, buildIdentity = BUILD_IDENTITY) {
@@ -128,7 +128,7 @@ test("open binds submitted source, observed build and actual PNG to one opaque s
     engineRevision: "a".repeat(40),
     wasmSha256: "c".repeat(64),
     workerSha256: "b".repeat(64),
-    buildId: "fixture-build",
+    buildId: "f".repeat(64),
   });
   assert.equal(opened.artifact.provenance.sourceSha256,
     createHash("sha256").update(source, "utf8").digest("hex"));


### PR DESCRIPTION
Advances #1197 R4 integration without touching #1377's active provenance files and without registering #1198 MCP rendering tools.

## Scope

Adds one transport-neutral `AgentPreviewService` that composes already-landed ownership instead of replacing it:

- `AgentPreviewSessionRegistry` remains the sole opaque session/scope/serialization/cancellation authority;
- `DockerPreviewSession` remains the default real execution owner through `createDockerPreviewSessionFactory`;
- `FrameArtifactStore` remains the sole retained PNG/artifact owner;
- this layer keeps only the private association between a registry session and its artifact capability.

`open` hashes the exact submitted UTF-8 source, requires observed loaded runtime build identity, publishes the initial captured PNG into the artifact store, and fails closed/cleans the runner if provenance or artifact admission fails. `sampleFrames` preflights ordering and the retained-frame count before any forward-only advancement, then publishes each real capture; dynamic publication failure retires the whole session and its retained evidence rather than leaving advanced live state. `inspect`, scoped artifact lookup, explicit close, transport disconnect, and service shutdown preserve the already-landed scope/stale-handle and awaited-cleanup rules.

The default retained-frame budget remains 32 including the initial frame. That deliberately exposes the existing #1266/#1198 quota seam instead of silently accepting the prepared MCP schema's current 64-sample maximum. MCP registration must align its batch limit with the service budget (or land an explicit retention/reservation policy) before exposure.

## Provenance dependency

Current master’s #1386 host still uses `PythonAuthoringClient`, so real Docker captures do not yet contain `buildIdentity`. This service intentionally rejects such publication and closes the session. #1377 owns the attested loaded worker/WASM/build identity; after it lands, the runner host should consume `ProvenancedPythonAuthoringClient`, at which point this service maps observed `sourceRevision`, worker SHA-256, WASM SHA-256, and `buildId` into the existing artifact provenance schema. No supplied checkout metadata is accepted as a substitute.

## Tests

Adds focused unit coverage for:
- exact submitted-source SHA + observed-build + actual PNG binding;
- batch ordering/count preflight before session advancement;
- fail-closed cleanup when build identity is missing;
- fail-closed cleanup when artifact storage rejects an already-captured frame;
- recoverable vs fatal session failure reconciliation;
- cross-scope session/artifact rejection and explicit close;
- awaited disconnect/shutdown cleanup.

No local pass is claimed: this environment cannot clone GitHub, so executable qualification is delegated to the repository’s exact-head CI. Keep this PR draft until those checks are green and #1377’s interface is settled.

## Boundaries

No scene graph, scheduler, renderer, seek, patch protocol, second session registry, second artifact store, MCP registration, CLI, or provenance implementation is introduced here. No automated/Codex review is requested or relied upon per `AGENTS.override.md`.