### PR TITLE
Propagate loaded runtime provenance through shared preview runner

### DIFF
--- a/tools/noon-mcp/test/docker-runner-smoke.mjs
+++ b/tools/noon-mcp/test/docker-runner-smoke.mjs
@@ -15,6 +15,21 @@ const config = await loadPreviewRuntimeConfig({
 });
 const source = await readFile(path.join(repoRoot, "web/python/examples/manim_parity_square_to_circle.py"), "utf8");
 const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const runtimeBuildIdentity = JSON.parse(await readFile(
+  path.join(repoRoot, "web/runtime-build-identity.json"), "utf8"));
+assert.equal(runtimeBuildIdentity.schema, 1);
+assert.match(runtimeBuildIdentity.buildId, /^[0-9a-f]{64}$/);
+assert.ok(runtimeBuildIdentity.sourceRevision === null || /^[0-9a-f]{40}$/.test(runtimeBuildIdentity.sourceRevision));
+for (const [name, descriptor] of Object.entries(runtimeBuildIdentity.files)) {
+  assert.match(descriptor.sha256, /^[0-9a-f]{64}$/, `${name} must have a SHA-256 identity`);
+  const bytes = await readFile(path.join(repoRoot, "web", descriptor.path));
+  assert.equal(hash(bytes), descriptor.sha256, `${name} manifest hash must match the exact built bytes`);
+}
+
+function assertObservedBuildIdentity(sample, label) {
+  assert.deepEqual(sample.buildIdentity, runtimeBuildIdentity,
+    `${label} must report the runtime identity observed by the browser worker`);
+}
 
 async function deterministicRun(label) {
   const session = new DockerPreviewSession(config);
@@ -25,6 +40,7 @@ async function deterministicRun(label) {
     assert.equal(initial.frame.rendererBackend, "WebGL2");
     assert.equal(initial.image.mimeType, "image/png");
     assert.ok(initial.imageData.length > 1000);
+    assertObservedBuildIdentity(initial, `${label} initial frame`);
 
     const one = await session.sample(1);
     const middle = await session.sample(1.5);
@@ -35,6 +51,7 @@ async function deterministicRun(label) {
       assert.equal(sample.frame.publishedTime, time);
       assert.equal(sample.frame.rendererBackend, "WebGL2");
       assert.ok(sample.imageData.length > 1000);
+      assertObservedBuildIdentity(sample, `${label} sample ${time}`);
     }
     const hashes = [initial, one, middle, final].map((sample) => hash(sample.imageData));
     assert.notEqual(hashes[0], hashes[1], "Create must change the preview image");
@@ -44,6 +61,7 @@ async function deterministicRun(label) {
     const inspected = await session.inspect();
     assert.equal(inspected.frame.requestedTime, 3);
     assert.equal(inspected.image.sha256, hashes[3]);
+    assertObservedBuildIdentity(inspected, `${label} inspection`);
     return { label, hashes, last: inspected };
   } finally {
     const closed = await session.close(`${label} complete`);
@@ -74,6 +92,8 @@ try {
     ok: true,
     firstHashes: first.hashes,
     freshHashes: fresh.hashes,
+    buildId: runtimeBuildIdentity.buildId,
+    sourceRevision: runtimeBuildIdentity.sourceRevision,
     cancelElapsedMs: elapsedMs,
     cleanup: closed.cleanup,
   }));

--- a/web/agent-preview-host.js
+++ b/web/agent-preview-host.js
@@ -1,4 +1,4 @@
-import { PythonAuthoringClient } from "./authoring-client.js";
+import { ProvenancedPythonAuthoringClient } from "./provenanced-authoring-client.js";
 import { AuthoringExecutionClient } from "./authoring-execution-client.js";
 import { SemanticPreviewSession } from "./semantic-preview-session.js";
 
@@ -14,7 +14,7 @@ async function open(source, loopDurationSeconds = 4) {
   if (closed) throw new Error("agent preview host is closed");
   if (preview !== null) throw new Error("agent preview host opens one scene per page");
   preview = new SemanticPreviewSession({
-    createAuthoringClient: () => new PythonAuthoringClient(),
+    createAuthoringClient: () => new ProvenancedPythonAuthoringClient(),
     createExecutionClient: (options) => new AuthoringExecutionClient(canvas, options),
   });
   const snapshot = await preview.open(source, { loopDurationSeconds });


### PR DESCRIPTION
Advances #1197 R4 by connecting the already-qualified loaded-build provenance path to the already-qualified persistent Docker preview runner. This is intentionally a thin integration slice and does not touch #1420's active runner/artifact composition files or MCP registration.

## Changes

- `web/agent-preview-host.js` now constructs `ProvenancedPythonAuthoringClient` instead of the legacy `PythonAuthoringClient`, so `SemanticPreviewSession` snapshots expose the build identity verified by the browser worker.
- `tools/noon-mcp/test/docker-runner-smoke.mjs` now proves the real isolated runner receives that same identity on open/sample/inspect, matches the generated `runtime-build-identity.json`, and that the manifest hashes match the exact built worker/WASM/glue/verifier bytes.
- Existing deterministic frame, cancellation, container cleanup, and fresh-run recovery assertions remain intact.

## Architecture boundary

No new scene/runtime/renderer/session authority. The host still delegates semantic execution to `SemanticPreviewSession`; provenance is observation only. No artifact-store composition, CLI, or MCP tool registration is added here.

## Qualification

This branch starts from post-#1377 master `380610396063ce792ad8aa395124f00bf5836905`. Repository CI/self-review only per `AGENTS.override.md`; keep draft until exact-head gates complete.