### PR TITLE
Align MCP sampling quota with retained frame budget

### DIFF
--- a/tools/noon-mcp/src/rendering-contract.mjs
+++ b/tools/noon-mcp/src/rendering-contract.mjs
@@ -8,7 +8,11 @@ import * as z from "zod/v4";
 export const RENDERING_CONTRACT_VERSION = 1;
 export const MAX_RENDER_SOURCE_BYTES = 1_000_000;
 export const MAX_RENDER_TIME_SECONDS = 600;
-export const MAX_RENDER_SAMPLES_PER_CALL = 64;
+// AgentPreviewService retains 32 frames per session by default and open_scene
+// publishes the initial frame. A single sample_frames request therefore admits
+// at most 31 additional frames; the service separately preflights remaining
+// capacity across repeated calls before any forward-only advancement.
+export const MAX_RENDER_SAMPLES_PER_CALL = 31;
 
 const sessionHandle = z.string()
   .min(16)

--- a/tools/noon-mcp/test/rendering-contract.test.mjs
+++ b/tools/noon-mcp/test/rendering-contract.test.mjs
@@ -46,7 +46,12 @@ test("open scene accepts only bounded source and loop duration", () => {
 });
 
 test("sample frames requires an opaque session and monotonic bounded forward schedule", () => {
+  assert.equal(MAX_RENDER_SAMPLES_PER_CALL, 31,
+    "one call plus open_scene's initial frame must fit the default 32-frame retention budget");
   assert.equal(accepts("noon_sample_frames", { session, times: [0, 0.5, 0.5, 4] }), true);
+  assert.equal(accepts("noon_sample_frames", {
+    session, times: Array(MAX_RENDER_SAMPLES_PER_CALL).fill(0),
+  }), true);
   for (const invalid of [
     { session: "short", times: [0] },
     { session: "scene with spaces 123456789", times: [0] },


### PR DESCRIPTION
Advances #1197/#1198 by closing the prepared-contract quota seam before rendering tools are registered.

`AgentPreviewService` retains 32 frames per session by default and `open_scene` publishes the initial frame. This contract-only slice therefore caps one `sample_frames` request at 31 additional frames. The service remains authoritative for remaining-session capacity across repeated calls and preflights that capacity before forward-only advancement.

Changes are limited to the still-inert `rendering-contract.mjs` schema and its unit test. No server registration, execution, session, artifact, renderer, runtime, or provenance implementation is changed.

Base: current master `75754b04832b7d2b326dfa20954ab01d9c75f186`. Repository CI/self-review only per `AGENTS.override.md`; keep draft until exact-head gates are green.