### PR TITLE
Add authored semantic family Transform intent

### DIFF
--- a/crates/noon-core/src/semantic_store/semantic_animations.rs
+++ b/crates/noon-core/src/semantic_store/semantic_animations.rs
@@ -279,6 +279,13 @@ pub enum SemanticAnimationIntent {
         /// Ordinary Transform leaves source priority unchanged.
         complete_priority: bool,
     },
+    /// Transform one semantic family toward another through compiler-derived visual
+    /// correspondence. The two family identities remain authored scene state;
+    /// unequal padding occurrences never receive semantic identities.
+    FamilyTransformTo {
+        source: SemanticNodeId,
+        target_state: SemanticNodeId,
+    },
     /// Temporarily scale and recolor one object around a shared activation center.
     /// The compiler captures the effective source and lowers a restoring track.
     Indicate {
@@ -358,6 +365,7 @@ pub enum SemanticAnimationIntent {
 impl SemanticAnimationIntent {
     pub const fn target(&self) -> Option<SemanticNodeId> {
         match self {
+            Self::FamilyTransformTo { source, .. } => Some(*source),
             Self::ObjectPropertyTrack { target, .. }
             | Self::TransformTo { target, .. }
             | Self::Indicate { target, .. }
@@ -377,7 +385,8 @@ impl SemanticAnimationIntent {
 
     pub const fn target_state(&self) -> Option<SemanticNodeId> {
         match self {
-            Self::TransformTo { target_state, .. } => Some(*target_state),
+            Self::TransformTo { target_state, .. }
+            | Self::FamilyTransformTo { target_state, .. } => Some(*target_state),
             Self::ObjectPropertyTrack { .. }
             | Self::Rotate { .. }
             | Self::Indicate { .. }
@@ -395,10 +404,22 @@ impl SemanticAnimationIntent {
         }
     }
 
+    /// Return the two authored family endpoints when this is a family Transform.
+    pub const fn family_transform(&self) -> Option<(SemanticNodeId, SemanticNodeId)> {
+        match self {
+            Self::FamilyTransformTo {
+                source,
+                target_state,
+            } => Some((*source, *target_state)),
+            _ => None,
+        }
+    }
+
     pub const fn composition_kind(&self) -> Option<SemanticAnimationCompositionKind> {
         match self {
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -419,6 +440,7 @@ impl SemanticAnimationIntent {
         match self {
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -779,6 +801,34 @@ impl SemanticStore {
                     interpolation,
 
                     complete_priority,
+                },
+                options,
+            )),
+        )
+    }
+
+    /// Insert one family Transform declaration without expanding semantic children.
+    ///
+    /// Both endpoints must be real semantic families. Correspondence and padding are
+    /// derived below the Semantic Scene and therefore allocate no synthetic members.
+    pub fn insert_semantic_family_transform_animation(
+        &mut self,
+        source: SemanticNodeId,
+        target_state: SemanticNodeId,
+        options: AnimationOptions,
+    ) -> Result<SemanticNodeId, SemanticAnimationError> {
+        self.set_last_mutation_writes(0);
+        self.semantic_family_members_checked(source)?;
+        self.semantic_family_members_checked(target_state)?;
+        if source == target_state {
+            return Err(SemanticAnimationError::SameTargetAndTargetState(source));
+        }
+        validate_authored_animation_options(options)?;
+        Ok(
+            self.insert_semantic_animation_state(SemanticAnimationState::new(
+                SemanticAnimationIntent::FamilyTransformTo {
+                    source,
+                    target_state,
                 },
                 options,
             )),

--- a/crates/noon-core/src/semantic_store/semantic_references.rs
+++ b/crates/noon-core/src/semantic_store/semantic_references.rs
@@ -349,6 +349,13 @@ fn outgoing_references(node: &SemanticNode) -> Vec<(SemanticNodeId, SemanticRefe
                 references.push((*target, SemanticReferenceKind::AnimationTarget));
                 references.push((*target_state, SemanticReferenceKind::AnimationTargetState));
             }
+            SemanticAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => {
+                references.push((*source, SemanticReferenceKind::AnimationTarget));
+                references.push((*target_state, SemanticReferenceKind::AnimationTargetState));
+            }
             SemanticAnimationIntent::Rotate { target, .. }
             | SemanticAnimationIntent::Indicate { target, .. }
             | SemanticAnimationIntent::DrawBorderThenFill { target, .. }

--- a/crates/noon-core/src/semantic_store/semantic_transaction.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction.rs
@@ -748,6 +748,27 @@ impl SemanticMutationTransaction {
         token
     }
 
+    /// Stage a family Transform without manufacturing semantic padding members.
+    pub fn create_family_transform_animation(
+        &mut self,
+        source: impl Into<SemanticTransactionNodeRef>,
+        target_state: impl Into<SemanticTransactionNodeRef>,
+        options: AnimationOptions,
+    ) -> SemanticLocalNodeToken {
+        let token = self.allocate_local_node_token();
+        self.mutations.push(SemanticMutation::AddAnimation {
+            token,
+            animation: SemanticTransactionAnimation::new(
+                SemanticTransactionAnimationIntent::FamilyTransformTo {
+                    source: source.into(),
+                    target_state: target_state.into(),
+                },
+                options,
+            ),
+        });
+        token
+    }
+
     /// Stage a centered 2D angular-path rotation declaration.
     pub fn create_rotate_animation(
         &mut self,

--- a/crates/noon-core/src/semantic_store/semantic_transaction/animation_addition.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction/animation_addition.rs
@@ -36,6 +36,10 @@ pub enum SemanticTransactionAnimationIntent {
 
         complete_priority: bool,
     },
+    FamilyTransformTo {
+        source: SemanticTransactionNodeRef,
+        target_state: SemanticTransactionNodeRef,
+    },
     Indicate {
         target: SemanticTransactionNodeRef,
         scale_factor: f64,
@@ -110,6 +114,10 @@ impl SemanticTransactionAnimationIntent {
                 target_state,
                 ..
             } => Some([Some(*target), Some(*target_state), None]),
+            Self::FamilyTransformTo {
+                source,
+                target_state,
+            } => Some([Some(*source), Some(*target_state), None]),
             Self::Rotate { target, .. }
             | Self::Indicate { target, .. }
             | Self::DrawBorderThenFill { target, .. }
@@ -135,6 +143,7 @@ impl SemanticTransactionAnimationIntent {
             Self::Composition { children, .. } => children.as_slice(),
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -206,6 +215,13 @@ impl SemanticTransactionAnimation {
                 interpolation: *interpolation,
 
                 complete_priority: *complete_priority,
+            },
+            SemanticAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => SemanticTransactionAnimationIntent::FamilyTransformTo {
+                source: (*source).into(),
+                target_state: (*target_state).into(),
             },
             SemanticAnimationIntent::Rotate {
                 target,
@@ -339,6 +355,13 @@ impl SemanticTransactionAnimation {
                 interpolation: *interpolation,
 
                 complete_priority: *complete_priority,
+            },
+            SemanticTransactionAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => SemanticAnimationIntent::FamilyTransformTo {
+                source: resolve_node_ref(*source, committed),
+                target_state: resolve_node_ref(*target_state, committed),
             },
             SemanticTransactionAnimationIntent::Rotate {
                 target,
@@ -561,6 +584,29 @@ pub(super) fn preflight_transaction_animation(
                         SemanticMutationTransactionError::SamePendingAnimationTargetAndTargetState {
                             index,
                             node: *target,
+                        }
+                    }
+                });
+            }
+        }
+        SemanticTransactionAnimationIntent::FamilyTransformTo {
+            source,
+            target_state,
+        } => {
+            catalog.ensure_family(*source, index)?;
+            catalog.ensure_family(*target_state, index)?;
+            if source == target_state {
+                return Err(match source {
+                    SemanticTransactionNodeRef::Existing(node) => {
+                        SemanticMutationTransactionError::SameAnimationTargetAndTargetState {
+                            index,
+                            node: *node,
+                        }
+                    }
+                    SemanticTransactionNodeRef::Pending(_) => {
+                        SemanticMutationTransactionError::SamePendingAnimationTargetAndTargetState {
+                            index,
+                            node: *source,
                         }
                     }
                 });
@@ -791,6 +837,12 @@ pub(super) fn commit_add_animation(
                 options,
             )
             .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
+        SemanticAnimationIntent::FamilyTransformTo {
+            source,
+            target_state,
+        } => store
+            .insert_semantic_family_transform_animation(*source, *target_state, options)
+            .expect("preflighted semantic family Transform insertion must remain valid while transaction owns the store"),
         SemanticAnimationIntent::Rotate { target, angle, hold_origin } => store
             .insert_semantic_rotate_animation_with_origin_constraint(*target, *angle, *hold_origin, options)
             .expect("preflighted semantic Rotate insertion must remain valid while transaction owns the store"),

--- a/crates/noon-core/tests/family_transform_intent.rs
+++ b/crates/noon-core/tests/family_transform_intent.rs
@@ -1,0 +1,126 @@
+use noon_core::{
+    AnimationOptions, SemanticAnimationIntent, SemanticMutationImpact, SemanticMutationTransaction,
+    SemanticObjectState, SemanticStore, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore) -> noon_core::SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+
+fn family(
+    store: &mut SemanticStore,
+    members: &[noon_core::SemanticNodeId],
+) -> noon_core::SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+#[test]
+fn family_transform_is_one_authored_intent_without_padding_or_topology_change() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store);
+    let s1 = object(&mut store);
+    let t0 = object(&mut store);
+    let t1 = object(&mut store);
+    let t2 = object(&mut store);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1, t2]);
+    let source_before = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+    let target_before = store
+        .semantic_family_members_checked(target)
+        .unwrap()
+        .to_vec();
+    let before_len = store.len();
+
+    let animation = store
+        .insert_semantic_family_transform_animation(
+            source,
+            target,
+            AnimationOptions::new().run_time(2.0),
+        )
+        .unwrap();
+
+    assert_eq!(store.len(), before_len + 1);
+    let state = store.semantic_animation_state(animation).unwrap();
+    assert_eq!(state.intent().target(), Some(source));
+    assert_eq!(state.intent().target_state(), Some(target));
+    assert_eq!(state.intent().family_transform(), Some((source, target)));
+    assert!(matches!(
+        state.intent(),
+        SemanticAnimationIntent::FamilyTransformTo {
+            source: actual_source,
+            target_state: actual_target,
+        } if *actual_source == source && *actual_target == target
+    ));
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_before
+    );
+    assert_eq!(
+        store.semantic_family_members_checked(target).unwrap(),
+        target_before
+    );
+}
+
+#[test]
+fn family_transform_transaction_adds_only_the_animation_node() {
+    let mut store = SemanticStore::new();
+    let s = object(&mut store);
+    let t0 = object(&mut store);
+    let t1 = object(&mut store);
+    let source = family(&mut store, &[s]);
+    let target = family(&mut store, &[t0, t1]);
+    let before_len = store.len();
+    let source_before = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new().run_time(1.5),
+    );
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.len(), before_len + 1);
+    assert!(matches!(
+        result.impacts(),
+        [SemanticMutationImpact::AnimationAdded { .. }]
+    ));
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_before
+    );
+}
+
+#[test]
+fn family_transform_rejects_object_endpoint_atomically() {
+    let mut store = SemanticStore::new();
+    let source_object = object(&mut store);
+    let target_leaf = object(&mut store);
+    let target = family(&mut store, &[target_leaf]);
+    let revision = store.scene_revision();
+    let len = store.len();
+
+    assert!(store
+        .insert_semantic_family_transform_animation(source_object, target, AnimationOptions::new(),)
+        .is_err());
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.len(), len);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.create_family_transform_animation(source_object, target, AnimationOptions::new());
+    assert!(transaction.apply(&mut store).is_err());
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.len(), len);
+}


### PR DESCRIPTION
## Summary

Adds the authored Semantic Scene carrier for B3 unequal-family `Transform`, stacked on #1426.

- adds `SemanticAnimationIntent::FamilyTransformTo { source, target_state }` as one real authored animation declaration;
- both endpoints are real semantic families; no padding object/family nodes are created;
- adds the equivalent transaction vocabulary and `create_family_transform_animation(...)` constructor;
- preflights both endpoints as families and rejects same-endpoint declarations before allocation/publication;
- records source/target-state semantic references through the existing reference graph;
- treats family Transform as a leaf animation intent with source/target-state accessors, while correspondence remains compiler-derived below the Semantic Scene.

## Qualification

The exact production tree was qualified fail-fast before reconstruction:

- `cargo fmt --all -- --check` — passed;
- `cargo test -p noon-core --test family_transform_intent` — 3 passed, 0 failed;
- `cargo test -p noon-core semantic_animation --lib` — 14 passed, 0 failed.

The tested production blobs were then rebuilt as connector-authored commit `f9014bf6afee63493f807773650ebbedc60102f0` directly on #1426 exact head `334693e127390dc6fe8622d06e7a058c34abf798` so regular PR CI can qualify the linear stack. Net diff is exactly five core/test files; all temporary patch workflows/scripts are absent.

## Scope / remaining B3 work

This PR owns authored meaning only. It does **not** assign an execution object ID or expand semantic children. The next stack layer projects this intent through the existing composition scheduler into a family-Transform timing record with no `ObjectId`; activation will then combine that timing with #1421 correspondence and #1425/#1426 transient display publication/rendering.

Persistent unequal topology reconciliation remains exclusively explicit `become()` from #1416.

Refs #82.