### PR TITLE
Project family Transform through shared scheduler

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_schedule.rs
@@ -28,6 +28,7 @@ pub struct SemanticAnimationScheduleProjection {
     run_time: f64,
     leaves: Vec<SemanticScheduledAnimationLeaf>,
     scalar_leaves: Vec<SemanticScheduledScalarLeaf>,
+    family_transforms: Vec<SemanticScheduledFamilyTransform>,
 }
 
 impl SemanticAnimationScheduleProjection {
@@ -51,12 +52,16 @@ impl SemanticAnimationScheduleProjection {
         &self.scalar_leaves
     }
 
+    pub fn family_transforms(&self) -> &[SemanticScheduledFamilyTransform] {
+        &self.family_transforms
+    }
+
     pub fn len(&self) -> usize {
-        self.leaves.len() + self.scalar_leaves.len()
+        self.leaves.len() + self.scalar_leaves.len() + self.family_transforms.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.leaves.is_empty() && self.scalar_leaves.is_empty()
+        self.leaves.is_empty() && self.scalar_leaves.is_empty() && self.family_transforms.is_empty()
     }
 }
 
@@ -136,6 +141,19 @@ pub struct SemanticScheduledScalarLeaf {
     pub options: ResolvedAnimationOptions,
 }
 
+/// One scheduled family Transform. It carries shared timing and authored family
+/// references, but deliberately no stable execution object identity.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticScheduledFamilyTransform {
+    pub finish_time_map: CompositionTimeMap,
+    pub animation: SemanticNodeId,
+    pub source: SemanticNodeId,
+    pub target_state: SemanticNodeId,
+    pub timing: TrackTiming,
+    pub time_map: CompositionTimeMap,
+    pub options: ResolvedAnimationOptions,
+}
+
 /// Compiler scheduling result for an animation graph held by one prepared semantic transaction.
 ///
 /// References remain transaction-local until the caller commits the prepared transaction. This
@@ -148,6 +166,7 @@ pub struct PreparedSemanticAnimationScheduleProjection {
     run_time: f64,
     leaves: Vec<PreparedSemanticScheduledAnimationLeaf>,
     scalar_leaves: Vec<PreparedSemanticScheduledScalarLeaf>,
+    family_transforms: Vec<PreparedSemanticScheduledFamilyTransform>,
 }
 
 impl PreparedSemanticAnimationScheduleProjection {
@@ -171,12 +190,16 @@ impl PreparedSemanticAnimationScheduleProjection {
         &self.scalar_leaves
     }
 
+    pub fn family_transforms(&self) -> &[PreparedSemanticScheduledFamilyTransform] {
+        &self.family_transforms
+    }
+
     pub fn len(&self) -> usize {
-        self.leaves.len() + self.scalar_leaves.len()
+        self.leaves.len() + self.scalar_leaves.len() + self.family_transforms.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.leaves.is_empty() && self.scalar_leaves.is_empty()
+        self.leaves.is_empty() && self.scalar_leaves.is_empty() && self.family_transforms.is_empty()
     }
 }
 
@@ -247,6 +270,18 @@ pub struct PreparedSemanticScheduledScalarLeaf {
     pub animation: SemanticTransactionNodeRef,
     pub signal: SemanticNodeId,
     pub target: f64,
+    pub timing: TrackTiming,
+    pub time_map: CompositionTimeMap,
+    pub options: ResolvedAnimationOptions,
+}
+
+/// Transaction-local scheduled family Transform with no execution object identity.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedSemanticScheduledFamilyTransform {
+    pub finish_time_map: CompositionTimeMap,
+    pub animation: SemanticTransactionNodeRef,
+    pub source: SemanticTransactionNodeRef,
+    pub target_state: SemanticTransactionNodeRef,
     pub timing: TrackTiming,
     pub time_map: CompositionTimeMap,
     pub options: ResolvedAnimationOptions,
@@ -544,6 +579,7 @@ pub fn lower_semantic_animation_schedule(
 
     let mut leaves = Vec::new();
     let mut scalar_leaves = Vec::new();
+    let mut family_transforms = Vec::new();
     for leaf in projection.leaves {
         match leaf {
             ScheduledAnimationLeaf::Object {
@@ -580,6 +616,23 @@ pub fn lower_semantic_animation_schedule(
                 time_map,
                 options,
             }),
+            ScheduledAnimationLeaf::FamilyTransform {
+                finish_time_map,
+                animation,
+                source,
+                target_state,
+                timing,
+                time_map,
+                options,
+            } => family_transforms.push(SemanticScheduledFamilyTransform {
+                finish_time_map,
+                animation,
+                source,
+                target_state,
+                timing,
+                time_map,
+                options,
+            }),
         }
     }
     Ok(SemanticAnimationScheduleProjection {
@@ -588,6 +641,7 @@ pub fn lower_semantic_animation_schedule(
         run_time: projection.run_time,
         leaves,
         scalar_leaves,
+        family_transforms,
     })
 }
 
@@ -612,6 +666,7 @@ pub fn lower_prepared_semantic_animation_schedule(
         .map_err(prepared_schedule_error)?;
     let mut leaves = Vec::new();
     let mut scalar_leaves = Vec::new();
+    let mut family_transforms = Vec::new();
     for leaf in projection.leaves {
         match leaf {
             ScheduledAnimationLeaf::Object {
@@ -648,6 +703,23 @@ pub fn lower_prepared_semantic_animation_schedule(
                 time_map,
                 options,
             }),
+            ScheduledAnimationLeaf::FamilyTransform {
+                finish_time_map,
+                animation,
+                source,
+                target_state,
+                timing,
+                time_map,
+                options,
+            } => family_transforms.push(PreparedSemanticScheduledFamilyTransform {
+                finish_time_map,
+                animation,
+                source,
+                target_state,
+                timing,
+                time_map,
+                options,
+            }),
         }
     }
     Ok(PreparedSemanticAnimationScheduleProjection {
@@ -656,6 +728,7 @@ pub fn lower_prepared_semantic_animation_schedule(
         run_time: projection.run_time,
         leaves,
         scalar_leaves,
+        family_transforms,
     })
 }
 
@@ -807,6 +880,10 @@ struct AnimationDeclaration<R> {
 
 #[derive(Clone, Debug)]
 enum AnimationDeclarationIntent<R> {
+    FamilyTransformTo {
+        source: R,
+        target_state: R,
+    },
     TransformTo {
         target: R,
         target_state: R,
@@ -957,6 +1034,21 @@ impl AnimationScheduleLookup for PublishedAnimationLookup<'_> {
         let intent = match state.intent() {
             SemanticAnimationIntent::ObjectPropertyTrack { .. } => {
                 return Err(SemanticAnimationError::InvalidObjectPropertyTrack);
+            }
+            SemanticAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => {
+                self.store
+                    .semantic_family_members_checked(*source)
+                    .map_err(SemanticAnimationError::Target)?;
+                self.store
+                    .semantic_family_members_checked(*target_state)
+                    .map_err(SemanticAnimationError::Target)?;
+                AnimationDeclarationIntent::FamilyTransformTo {
+                    source: *source,
+                    target_state: *target_state,
+                }
             }
             SemanticAnimationIntent::TransformTo {
                 target,
@@ -1198,6 +1290,13 @@ impl AnimationScheduleLookup for PreparedAnimationLookup<'_, '_> {
                             PreparedSemanticAnimationLookupError::InitialObjectPropertyTrack,
                         );
                     }
+                    SemanticAnimationIntent::FamilyTransformTo {
+                        source,
+                        target_state,
+                    } => AnimationDeclarationIntent::FamilyTransformTo {
+                        source: (*source).into(),
+                        target_state: (*target_state).into(),
+                    },
                     SemanticAnimationIntent::TransformTo {
                         target,
                         target_state,
@@ -1323,6 +1422,13 @@ impl AnimationScheduleLookup for PreparedAnimationLookup<'_, '_> {
                             PreparedSemanticAnimationLookupError::InitialObjectPropertyTrack,
                         );
                     }
+                    SemanticTransactionAnimationIntent::FamilyTransformTo {
+                        source,
+                        target_state,
+                    } => AnimationDeclarationIntent::FamilyTransformTo {
+                        source: *source,
+                        target_state: *target_state,
+                    },
                     SemanticTransactionAnimationIntent::TransformTo {
                         target,
                         target_state,
@@ -1437,6 +1543,7 @@ impl AnimationScheduleLookup for PreparedAnimationLookup<'_, '_> {
             }
         };
         match &intent {
+            AnimationDeclarationIntent::FamilyTransformTo { .. } => {}
             AnimationDeclarationIntent::TransformTo {
                 target,
                 target_state,
@@ -1534,6 +1641,15 @@ struct AnimationScheduleProjection<R> {
 
 #[derive(Clone, Debug)]
 enum ScheduledAnimationLeaf<R> {
+    FamilyTransform {
+        finish_time_map: CompositionTimeMap,
+        animation: R,
+        source: R,
+        target_state: R,
+        timing: TrackTiming,
+        time_map: CompositionTimeMap,
+        options: ResolvedAnimationOptions,
+    },
     Object {
         finish_time_map: CompositionTimeMap,
         animation: R,
@@ -1682,6 +1798,11 @@ struct PlannedAnimation<R> {
 #[derive(Clone, Debug)]
 enum PlannedAnimationKind<R> {
     Wait,
+    FamilyTransform {
+        source: R,
+        target_state: R,
+        options: ResolvedAnimationOptions,
+    },
     Leaf {
         target: R,
         execution_object_id: ObjectId,
@@ -1719,6 +1840,23 @@ where
         .map_err(|error| AnimationSchedulePlanError::Lookup { animation, error })?;
 
     match state.intent {
+        AnimationDeclarationIntent::FamilyTransformTo {
+            source,
+            target_state,
+        } => {
+            let options =
+                resolve_animation_options(AnimationDefaults::MANIM, state.options, play_options)
+                    .map_err(|error| AnimationSchedulePlanError::Options { animation, error })?;
+            Ok(PlannedAnimation {
+                animation,
+                run_time: options.run_time,
+                kind: PlannedAnimationKind::FamilyTransform {
+                    source,
+                    target_state,
+                    options,
+                },
+            })
+        }
         AnimationDeclarationIntent::TransformTo {
             target,
             target_state,
@@ -2329,6 +2467,19 @@ fn collect_leaves<R: Copy>(
 ) {
     match &plan.kind {
         PlannedAnimationKind::Wait => {}
+        PlannedAnimationKind::FamilyTransform {
+            source,
+            target_state,
+            options,
+        } => leaves.push(ScheduledAnimationLeaf::FamilyTransform {
+            finish_time_map: finish_time_map.clone(),
+            animation: plan.animation,
+            source: *source,
+            target_state: *target_state,
+            timing: TrackTiming::new(root_start_time, root_run_time, options.rate_func),
+            time_map: CompositionTimeMap::from_steps(steps.clone()),
+            options: *options,
+        }),
         PlannedAnimationKind::Leaf {
             target,
             execution_object_id,

--- a/crates/noon-compile/tests/family_transform_schedule.rs
+++ b/crates/noon-compile/tests/family_transform_schedule.rs
@@ -1,0 +1,169 @@
+use noon_compile::{
+    lower_prepared_semantic_animation_schedule, lower_semantic_animation_schedule,
+    SemanticExecutionIndex,
+};
+use noon_core::{
+    AnimationOptions, RateFunction, SemanticMutationTransaction, SemanticObjectState,
+    SemanticStore, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore, radius: f32) -> noon_core::SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn family(
+    store: &mut SemanticStore,
+    members: &[noon_core::SemanticNodeId],
+) -> noon_core::SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+fn index(store: &SemanticStore) -> SemanticExecutionIndex {
+    let mut index = SemanticExecutionIndex::new();
+    index.lower_scene(store).unwrap();
+    index
+}
+
+#[test]
+fn published_family_transform_owns_timing_without_execution_object_identity() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 1.0);
+    let s1 = object(&mut store, 0.7);
+    let t0 = object(&mut store, 0.4);
+    let t1 = object(&mut store, 0.5);
+    let t2 = object(&mut store, 0.6);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1, t2]);
+    store.attach_to_scene(source).unwrap();
+    let animation = store
+        .insert_semantic_family_transform_animation(
+            source,
+            target,
+            AnimationOptions::new()
+                .run_time(2.5)
+                .rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+    let source_before = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+    let target_before = store
+        .semantic_family_members_checked(target)
+        .unwrap()
+        .to_vec();
+    let revision = store.scene_revision();
+
+    let schedule = lower_semantic_animation_schedule(
+        &store,
+        &index(&store),
+        animation,
+        3.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+
+    assert!(schedule.leaves().is_empty());
+    assert!(schedule.scalar_leaves().is_empty());
+    assert_eq!(schedule.family_transforms().len(), 1);
+    assert_eq!(schedule.len(), 1);
+    let family = &schedule.family_transforms()[0];
+    assert_eq!(family.animation, animation);
+    assert_eq!(family.source, source);
+    assert_eq!(family.target_state, target);
+    assert_eq!(family.timing.start_time, 3.0);
+    assert_eq!(family.timing.duration, 2.5);
+    assert_eq!(family.options.rate_func, RateFunction::Linear);
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_before
+    );
+    assert_eq!(
+        store.semantic_family_members_checked(target).unwrap(),
+        target_before
+    );
+}
+
+#[test]
+fn prepared_family_transform_uses_same_scheduler_without_object_id_lookup() {
+    let mut store = SemanticStore::new();
+    let source_leaf = object(&mut store, 1.0);
+    let target_leaf = object(&mut store, 2.0);
+    let source = family(&mut store, &[source_leaf]);
+    let target = family(&mut store, &[target_leaf]);
+    store.attach_to_scene(source).unwrap();
+    let index = index(&store);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    let animation = transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new()
+            .run_time(1.25)
+            .rate_func(RateFunction::Linear),
+    );
+    let prepared = transaction.prepare(&mut store).unwrap();
+    let schedule = lower_prepared_semantic_animation_schedule(
+        &prepared,
+        &index,
+        animation,
+        4.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+
+    assert!(schedule.leaves().is_empty());
+    assert!(schedule.scalar_leaves().is_empty());
+    assert_eq!(schedule.family_transforms().len(), 1);
+    let family = &schedule.family_transforms()[0];
+    assert_eq!(family.source.existing(), Some(source));
+    assert_eq!(family.target_state.existing(), Some(target));
+    assert_eq!(family.timing.start_time, 4.0);
+    assert_eq!(family.timing.duration, 1.25);
+}
+
+#[test]
+fn family_transform_in_sequence_uses_existing_composition_time_map() {
+    let mut store = SemanticStore::new();
+    let s = object(&mut store, 1.0);
+    let t = object(&mut store, 2.0);
+    let source = family(&mut store, &[s]);
+    let target = family(&mut store, &[t]);
+    store.attach_to_scene(source).unwrap();
+
+    let transform = store
+        .insert_semantic_family_transform_animation(
+            source,
+            target,
+            AnimationOptions::new()
+                .run_time(2.0)
+                .rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+    let wait = store.insert_semantic_wait_animation(1.0).unwrap();
+    let sequence = store
+        .insert_semantic_sequence_animation(
+            &[transform, wait],
+            AnimationOptions::new().rate_func(RateFunction::Linear),
+        )
+        .unwrap();
+
+    let schedule = lower_semantic_animation_schedule(
+        &store,
+        &index(&store),
+        sequence,
+        5.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+    assert_eq!(schedule.family_transforms().len(), 1);
+    let family = &schedule.family_transforms()[0];
+    assert!(!family.time_map.is_identity());
+    assert_eq!(family.timing.start_time, 5.0);
+    assert_eq!(family.timing.duration, schedule.run_time());
+}

--- a/crates/noon-core/src/semantic_store/semantic_animations.rs
+++ b/crates/noon-core/src/semantic_store/semantic_animations.rs
@@ -279,6 +279,13 @@ pub enum SemanticAnimationIntent {
         /// Ordinary Transform leaves source priority unchanged.
         complete_priority: bool,
     },
+    /// Transform one semantic family toward another through compiler-derived visual
+    /// correspondence. The two family identities remain authored scene state;
+    /// unequal padding occurrences never receive semantic identities.
+    FamilyTransformTo {
+        source: SemanticNodeId,
+        target_state: SemanticNodeId,
+    },
     /// Temporarily scale and recolor one object around a shared activation center.
     /// The compiler captures the effective source and lowers a restoring track.
     Indicate {
@@ -358,6 +365,7 @@ pub enum SemanticAnimationIntent {
 impl SemanticAnimationIntent {
     pub const fn target(&self) -> Option<SemanticNodeId> {
         match self {
+            Self::FamilyTransformTo { source, .. } => Some(*source),
             Self::ObjectPropertyTrack { target, .. }
             | Self::TransformTo { target, .. }
             | Self::Indicate { target, .. }
@@ -377,7 +385,8 @@ impl SemanticAnimationIntent {
 
     pub const fn target_state(&self) -> Option<SemanticNodeId> {
         match self {
-            Self::TransformTo { target_state, .. } => Some(*target_state),
+            Self::TransformTo { target_state, .. }
+            | Self::FamilyTransformTo { target_state, .. } => Some(*target_state),
             Self::ObjectPropertyTrack { .. }
             | Self::Rotate { .. }
             | Self::Indicate { .. }
@@ -395,10 +404,22 @@ impl SemanticAnimationIntent {
         }
     }
 
+    /// Return the two authored family endpoints when this is a family Transform.
+    pub const fn family_transform(&self) -> Option<(SemanticNodeId, SemanticNodeId)> {
+        match self {
+            Self::FamilyTransformTo {
+                source,
+                target_state,
+            } => Some((*source, *target_state)),
+            _ => None,
+        }
+    }
+
     pub const fn composition_kind(&self) -> Option<SemanticAnimationCompositionKind> {
         match self {
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -419,6 +440,7 @@ impl SemanticAnimationIntent {
         match self {
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -779,6 +801,34 @@ impl SemanticStore {
                     interpolation,
 
                     complete_priority,
+                },
+                options,
+            )),
+        )
+    }
+
+    /// Insert one family Transform declaration without expanding semantic children.
+    ///
+    /// Both endpoints must be real semantic families. Correspondence and padding are
+    /// derived below the Semantic Scene and therefore allocate no synthetic members.
+    pub fn insert_semantic_family_transform_animation(
+        &mut self,
+        source: SemanticNodeId,
+        target_state: SemanticNodeId,
+        options: AnimationOptions,
+    ) -> Result<SemanticNodeId, SemanticAnimationError> {
+        self.set_last_mutation_writes(0);
+        self.semantic_family_members_checked(source)?;
+        self.semantic_family_members_checked(target_state)?;
+        if source == target_state {
+            return Err(SemanticAnimationError::SameTargetAndTargetState(source));
+        }
+        validate_authored_animation_options(options)?;
+        Ok(
+            self.insert_semantic_animation_state(SemanticAnimationState::new(
+                SemanticAnimationIntent::FamilyTransformTo {
+                    source,
+                    target_state,
                 },
                 options,
             )),

--- a/crates/noon-core/src/semantic_store/semantic_references.rs
+++ b/crates/noon-core/src/semantic_store/semantic_references.rs
@@ -349,6 +349,13 @@ fn outgoing_references(node: &SemanticNode) -> Vec<(SemanticNodeId, SemanticRefe
                 references.push((*target, SemanticReferenceKind::AnimationTarget));
                 references.push((*target_state, SemanticReferenceKind::AnimationTargetState));
             }
+            SemanticAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => {
+                references.push((*source, SemanticReferenceKind::AnimationTarget));
+                references.push((*target_state, SemanticReferenceKind::AnimationTargetState));
+            }
             SemanticAnimationIntent::Rotate { target, .. }
             | SemanticAnimationIntent::Indicate { target, .. }
             | SemanticAnimationIntent::DrawBorderThenFill { target, .. }

--- a/crates/noon-core/src/semantic_store/semantic_transaction.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction.rs
@@ -748,6 +748,27 @@ impl SemanticMutationTransaction {
         token
     }
 
+    /// Stage a family Transform without manufacturing semantic padding members.
+    pub fn create_family_transform_animation(
+        &mut self,
+        source: impl Into<SemanticTransactionNodeRef>,
+        target_state: impl Into<SemanticTransactionNodeRef>,
+        options: AnimationOptions,
+    ) -> SemanticLocalNodeToken {
+        let token = self.allocate_local_node_token();
+        self.mutations.push(SemanticMutation::AddAnimation {
+            token,
+            animation: SemanticTransactionAnimation::new(
+                SemanticTransactionAnimationIntent::FamilyTransformTo {
+                    source: source.into(),
+                    target_state: target_state.into(),
+                },
+                options,
+            ),
+        });
+        token
+    }
+
     /// Stage a centered 2D angular-path rotation declaration.
     pub fn create_rotate_animation(
         &mut self,

--- a/crates/noon-core/src/semantic_store/semantic_transaction/animation_addition.rs
+++ b/crates/noon-core/src/semantic_store/semantic_transaction/animation_addition.rs
@@ -36,6 +36,10 @@ pub enum SemanticTransactionAnimationIntent {
 
         complete_priority: bool,
     },
+    FamilyTransformTo {
+        source: SemanticTransactionNodeRef,
+        target_state: SemanticTransactionNodeRef,
+    },
     Indicate {
         target: SemanticTransactionNodeRef,
         scale_factor: f64,
@@ -110,6 +114,10 @@ impl SemanticTransactionAnimationIntent {
                 target_state,
                 ..
             } => Some([Some(*target), Some(*target_state), None]),
+            Self::FamilyTransformTo {
+                source,
+                target_state,
+            } => Some([Some(*source), Some(*target_state), None]),
             Self::Rotate { target, .. }
             | Self::Indicate { target, .. }
             | Self::DrawBorderThenFill { target, .. }
@@ -135,6 +143,7 @@ impl SemanticTransactionAnimationIntent {
             Self::Composition { children, .. } => children.as_slice(),
             Self::ObjectPropertyTrack { .. }
             | Self::TransformTo { .. }
+            | Self::FamilyTransformTo { .. }
             | Self::Indicate { .. }
             | Self::DrawBorderThenFill { .. }
             | Self::PassingFlash { .. }
@@ -206,6 +215,13 @@ impl SemanticTransactionAnimation {
                 interpolation: *interpolation,
 
                 complete_priority: *complete_priority,
+            },
+            SemanticAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => SemanticTransactionAnimationIntent::FamilyTransformTo {
+                source: (*source).into(),
+                target_state: (*target_state).into(),
             },
             SemanticAnimationIntent::Rotate {
                 target,
@@ -339,6 +355,13 @@ impl SemanticTransactionAnimation {
                 interpolation: *interpolation,
 
                 complete_priority: *complete_priority,
+            },
+            SemanticTransactionAnimationIntent::FamilyTransformTo {
+                source,
+                target_state,
+            } => SemanticAnimationIntent::FamilyTransformTo {
+                source: resolve_node_ref(*source, committed),
+                target_state: resolve_node_ref(*target_state, committed),
             },
             SemanticTransactionAnimationIntent::Rotate {
                 target,
@@ -561,6 +584,29 @@ pub(super) fn preflight_transaction_animation(
                         SemanticMutationTransactionError::SamePendingAnimationTargetAndTargetState {
                             index,
                             node: *target,
+                        }
+                    }
+                });
+            }
+        }
+        SemanticTransactionAnimationIntent::FamilyTransformTo {
+            source,
+            target_state,
+        } => {
+            catalog.ensure_family(*source, index)?;
+            catalog.ensure_family(*target_state, index)?;
+            if source == target_state {
+                return Err(match source {
+                    SemanticTransactionNodeRef::Existing(node) => {
+                        SemanticMutationTransactionError::SameAnimationTargetAndTargetState {
+                            index,
+                            node: *node,
+                        }
+                    }
+                    SemanticTransactionNodeRef::Pending(_) => {
+                        SemanticMutationTransactionError::SamePendingAnimationTargetAndTargetState {
+                            index,
+                            node: *source,
                         }
                     }
                 });
@@ -791,6 +837,12 @@ pub(super) fn commit_add_animation(
                 options,
             )
             .expect("preflighted semantic animation insertion must remain valid while transaction owns the store"),
+        SemanticAnimationIntent::FamilyTransformTo {
+            source,
+            target_state,
+        } => store
+            .insert_semantic_family_transform_animation(*source, *target_state, options)
+            .expect("preflighted semantic family Transform insertion must remain valid while transaction owns the store"),
         SemanticAnimationIntent::Rotate { target, angle, hold_origin } => store
             .insert_semantic_rotate_animation_with_origin_constraint(*target, *angle, *hold_origin, options)
             .expect("preflighted semantic Rotate insertion must remain valid while transaction owns the store"),

--- a/crates/noon-core/tests/family_transform_intent.rs
+++ b/crates/noon-core/tests/family_transform_intent.rs
@@ -1,0 +1,126 @@
+use noon_core::{
+    AnimationOptions, SemanticAnimationIntent, SemanticMutationImpact, SemanticMutationTransaction,
+    SemanticObjectState, SemanticStore, StoredGeometry,
+};
+
+fn object(store: &mut SemanticStore) -> noon_core::SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle {
+        radius: 1.0,
+    }))
+}
+
+fn family(
+    store: &mut SemanticStore,
+    members: &[noon_core::SemanticNodeId],
+) -> noon_core::SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+#[test]
+fn family_transform_is_one_authored_intent_without_padding_or_topology_change() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store);
+    let s1 = object(&mut store);
+    let t0 = object(&mut store);
+    let t1 = object(&mut store);
+    let t2 = object(&mut store);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1, t2]);
+    let source_before = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+    let target_before = store
+        .semantic_family_members_checked(target)
+        .unwrap()
+        .to_vec();
+    let before_len = store.len();
+
+    let animation = store
+        .insert_semantic_family_transform_animation(
+            source,
+            target,
+            AnimationOptions::new().run_time(2.0),
+        )
+        .unwrap();
+
+    assert_eq!(store.len(), before_len + 1);
+    let state = store.semantic_animation_state(animation).unwrap();
+    assert_eq!(state.intent().target(), Some(source));
+    assert_eq!(state.intent().target_state(), Some(target));
+    assert_eq!(state.intent().family_transform(), Some((source, target)));
+    assert!(matches!(
+        state.intent(),
+        SemanticAnimationIntent::FamilyTransformTo {
+            source: actual_source,
+            target_state: actual_target,
+        } if *actual_source == source && *actual_target == target
+    ));
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_before
+    );
+    assert_eq!(
+        store.semantic_family_members_checked(target).unwrap(),
+        target_before
+    );
+}
+
+#[test]
+fn family_transform_transaction_adds_only_the_animation_node() {
+    let mut store = SemanticStore::new();
+    let s = object(&mut store);
+    let t0 = object(&mut store);
+    let t1 = object(&mut store);
+    let source = family(&mut store, &[s]);
+    let target = family(&mut store, &[t0, t1]);
+    let before_len = store.len();
+    let source_before = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new().run_time(1.5),
+    );
+    let result = transaction.apply(&mut store).unwrap();
+
+    assert_eq!(store.len(), before_len + 1);
+    assert!(matches!(
+        result.impacts(),
+        [SemanticMutationImpact::AnimationAdded { .. }]
+    ));
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_before
+    );
+}
+
+#[test]
+fn family_transform_rejects_object_endpoint_atomically() {
+    let mut store = SemanticStore::new();
+    let source_object = object(&mut store);
+    let target_leaf = object(&mut store);
+    let target = family(&mut store, &[target_leaf]);
+    let revision = store.scene_revision();
+    let len = store.len();
+
+    assert!(store
+        .insert_semantic_family_transform_animation(source_object, target, AnimationOptions::new(),)
+        .is_err());
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.len(), len);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    transaction.create_family_transform_animation(source_object, target, AnimationOptions::new());
+    assert!(transaction.apply(&mut store).is_err());
+    assert_eq!(store.scene_revision(), revision);
+    assert_eq!(store.len(), len);
+}


### PR DESCRIPTION
## Summary

Atomic integration of the B3 authored family-Transform intent (#1429) plus its required scheduler projection.

This PR is intentionally retargeted directly to `master` rather than landing #1429 alone. The authored `FamilyTransformTo` enum addition makes the pre-existing scheduler matches non-exhaustive until this scheduler layer is present; therefore the two logical slices must land as one compilable integration unit.

### Authored intent from #1429

- adds `SemanticAnimationIntent::FamilyTransformTo { source, target_state }` and equivalent transaction vocabulary;
- both endpoints are real semantic families; no padding semantic nodes are created;
- records source/target-state semantic references and validates family endpoints;
- adds focused semantic-intent regressions.

### Scheduler layer

- projects authored `FamilyTransformTo` through the existing recursive animation scheduler;
- adds published and prepared family-Transform timing records carrying source family, target-state family, root timing/time-map, finish map, and resolved options;
- deliberately carries **no stable execution `ObjectId`** for the family Transform record;
- uses the same composition scheduling/time-map recursion as object/scalar leaves;
- adds focused published/prepared/nested-sequence scheduling regressions.

## Architecture

The integration adds authored meaning plus execution-plan timing only. It does not allocate padding `SemanticNodeId`s, execution `ObjectId`s, stable renderer slots, or persistent topology. Identity-free correspondence/publication/render preparation remains owned by the already-landed #1421/#1425/#1426 layers. Persistent unequal topology reconciliation remains explicit `become()` from #1416.

## Why combined

Standalone #1429 is intentionally not mergeable as a product state: its historical workspace/product baseline fails with three non-exhaustive matches in `animation_schedule.rs` for `FamilyTransformTo`. #1430 is exactly the missing scheduler projection. Historical #1430 Product Gate failed while building the **#1429 baseline**, before building the candidate, for those same three non-exhaustive matches. Retargeting this PR to healthy `master` allows the actual 7-file atomic integration to be qualified normally.

## Current exact tree

- base: current `master` `968022149f2f7e3ecfdd5d21f987d72ac5bf7d64`;
- head: `341ee210d307cba1ba3a9f6e8f8957fb4853dbbe`;
- 2 clean logical commits, 7 files, +581/-5;
- all seven files were proven unchanged on master relative to their original B3 parents before exact blob replay.

After this lands, #1429 will be closed as superseded by this atomic integration and the stack advances to #1431.

Refs #82
Refs #1429.