### PR TITLE
Prepare activation-effective family Transform correspondence

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_payload.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload.rs
@@ -1,5 +1,6 @@
 mod affine;
 mod family_transform;
+mod family_transform_activation;
 mod prepared_composition;
 mod scheduled_captures;
 mod text_write;
@@ -7,6 +8,7 @@ mod transform_payload;
 
 pub use affine::*;
 pub use family_transform::*;
+pub use family_transform_activation::*;
 pub use prepared_composition::*;
 pub use text_write::*;
 pub use transform_payload::*;

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_activation.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_activation.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+use noon_core::{
+    ObjectId, PreparedSemanticMutationTransaction, SemanticNodeId, SemanticTransactionNodeRef,
+};
+
+use super::super::{PreparedSemanticAnimationScheduleProjection, SemanticExecutionIndex};
+use super::affine::EffectiveAnimationProperties;
+use super::family_transform::{
+    derive_family_transform_correspondence, FamilyTransformCorrespondenceError,
+};
+
+/// One activation-time family Transform occurrence before execution publication.
+///
+/// The source/target fields are real authored leaf identities. `source_padding` and
+/// `target_padding` describe a renderer-derived occurrence only; they do not allocate
+/// semantic or execution identity. `source_execution_object_id` is the existing source
+/// leaf's stable execution row and serves only as the effective-state capture/ordering
+/// anchor for a derived source copy.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedFamilyTransformOccurrence {
+    pub animation: SemanticTransactionNodeRef,
+    pub source: SemanticNodeId,
+    pub target_state: SemanticNodeId,
+    pub source_execution_object_id: ObjectId,
+    pub source_padding: bool,
+    pub target_padding: bool,
+    pub occurrence_index: u32,
+    pub timing: noon_core::TrackTiming,
+    pub time_map: noon_core::CompositionTimeMap,
+    pub finish_time_map: noon_core::CompositionTimeMap,
+    pub options: noon_core::ResolvedAnimationOptions,
+    pub effective_source: EffectiveAnimationProperties,
+}
+
+/// Compiler-owned activation projection for every family Transform in one prepared
+/// animation graph. It is pure preparation data: no Semantic Scene mutation, runtime
+/// patch, derived display row, or completion state is published here.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PreparedFamilyTransformActivationProjection {
+    occurrences: Vec<PreparedFamilyTransformOccurrence>,
+}
+
+impl PreparedFamilyTransformActivationProjection {
+    pub fn occurrences(&self) -> &[PreparedFamilyTransformOccurrence] {
+        &self.occurrences
+    }
+
+    pub fn len(&self) -> usize {
+        self.occurrences.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.occurrences.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PreparedFamilyTransformActivationError {
+    PendingFamilyEndpoint {
+        animation: SemanticTransactionNodeRef,
+        endpoint: SemanticTransactionNodeRef,
+    },
+    Correspondence {
+        animation: SemanticTransactionNodeRef,
+        error: FamilyTransformCorrespondenceError,
+    },
+    MissingExecutionSource {
+        animation: SemanticTransactionNodeRef,
+        source: SemanticNodeId,
+    },
+    MissingEffectiveSource {
+        animation: SemanticTransactionNodeRef,
+        source: SemanticNodeId,
+        execution_object_id: ObjectId,
+    },
+    TooManyOccurrences(usize),
+}
+
+impl std::fmt::Display for PreparedFamilyTransformActivationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PendingFamilyEndpoint { animation, endpoint } => write!(
+                formatter,
+                "prepared family Transform {animation:?} retains pending family endpoint {endpoint:?}"
+            ),
+            Self::Correspondence { animation, error } => write!(
+                formatter,
+                "prepared family Transform {animation:?} correspondence failed: {error}"
+            ),
+            Self::MissingExecutionSource { animation, source } => write!(
+                formatter,
+                "prepared family Transform {animation:?} source leaf {}:{} is not in the stable execution index",
+                source.slot(),
+                source.generation()
+            ),
+            Self::MissingEffectiveSource {
+                animation,
+                source,
+                execution_object_id,
+            } => write!(
+                formatter,
+                "prepared family Transform {animation:?} source leaf {}:{} has no activation-effective execution state for object {}",
+                source.slot(),
+                source.generation(),
+                execution_object_id.get()
+            ),
+            Self::TooManyOccurrences(count) => write!(
+                formatter,
+                "prepared family Transform has {count} occurrences, exceeding u32 occurrence indexing"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PreparedFamilyTransformActivationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Correspondence { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Combine shared family scheduling with compiler-derived correspondence and capture
+/// each distinct source leaf's coherent effective value exactly once.
+///
+/// Family endpoints used by the current live-session API are existing semantic
+/// families. Pending endpoints fail closed here rather than receiving guessed identity.
+/// Repeated source padding occurrences deliberately reuse the same captured effective
+/// source value; independent visual evolution is introduced only by the later
+/// identity-free derived-display materializer.
+pub fn prepare_family_transform_activations<F>(
+    prepared: &PreparedSemanticMutationTransaction<'_>,
+    index: &SemanticExecutionIndex,
+    schedule: &PreparedSemanticAnimationScheduleProjection,
+    mut effective_properties: F,
+) -> Result<PreparedFamilyTransformActivationProjection, PreparedFamilyTransformActivationError>
+where
+    F: FnMut(ObjectId) -> Option<EffectiveAnimationProperties>,
+{
+    let mut captures = HashMap::<ObjectId, EffectiveAnimationProperties>::new();
+    let mut occurrences = Vec::new();
+
+    for family in schedule.family_transforms() {
+        let source_family = existing_endpoint(family.animation, family.source)?;
+        let target_family = existing_endpoint(family.animation, family.target_state)?;
+        let correspondence =
+            derive_family_transform_correspondence(prepared.store(), source_family, target_family)
+                .map_err(
+                    |error| PreparedFamilyTransformActivationError::Correspondence {
+                        animation: family.animation,
+                        error,
+                    },
+                )?;
+
+        for correspondence_member in correspondence.occurrences() {
+            let source = correspondence_member.source();
+            let execution_object_id = index.execution_object_id(source).ok_or(
+                PreparedFamilyTransformActivationError::MissingExecutionSource {
+                    animation: family.animation,
+                    source,
+                },
+            )?;
+            let effective_source = if let Some(captured) = captures.get(&execution_object_id) {
+                *captured
+            } else {
+                let captured = effective_properties(execution_object_id).ok_or(
+                    PreparedFamilyTransformActivationError::MissingEffectiveSource {
+                        animation: family.animation,
+                        source,
+                        execution_object_id,
+                    },
+                )?;
+                captures.insert(execution_object_id, captured);
+                captured
+            };
+            let occurrence_index = u32::try_from(occurrences.len()).map_err(|_| {
+                PreparedFamilyTransformActivationError::TooManyOccurrences(occurrences.len())
+            })?;
+            occurrences.push(PreparedFamilyTransformOccurrence {
+                animation: family.animation,
+                source,
+                target_state: correspondence_member.target(),
+                source_execution_object_id: execution_object_id,
+                source_padding: correspondence_member.source_is_padding(),
+                target_padding: correspondence_member.target_is_padding(),
+                occurrence_index,
+                timing: family.timing,
+                time_map: family.time_map.clone(),
+                finish_time_map: family.finish_time_map.clone(),
+                options: family.options,
+                effective_source,
+            });
+        }
+    }
+
+    Ok(PreparedFamilyTransformActivationProjection { occurrences })
+}
+
+fn existing_endpoint(
+    animation: SemanticTransactionNodeRef,
+    endpoint: SemanticTransactionNodeRef,
+) -> Result<SemanticNodeId, PreparedFamilyTransformActivationError> {
+    endpoint.existing().ok_or(
+        PreparedFamilyTransformActivationError::PendingFamilyEndpoint {
+            animation,
+            endpoint,
+        },
+    )
+}

--- a/crates/noon-compile/tests/family_transform_activation.rs
+++ b/crates/noon-compile/tests/family_transform_activation.rs
@@ -1,0 +1,163 @@
+use std::cell::Cell;
+
+use noon_compile::{
+    lower_prepared_semantic_animation_schedule, prepare_family_transform_activations,
+    EffectiveAnimationProperties, SemanticExecutionIndex,
+};
+use noon_core::{
+    AnimationOptions, ObjectId, RateFunction, SemanticMutationTransaction, SemanticObjectState,
+    SemanticStore, StoredGeometry, Style, Transform2D, Vec2,
+};
+
+fn object(store: &mut SemanticStore, radius: f32) -> noon_core::SemanticNodeId {
+    store.insert_semantic_object(SemanticObjectState::new(StoredGeometry::Circle { radius }))
+}
+
+fn family(
+    store: &mut SemanticStore,
+    members: &[noon_core::SemanticNodeId],
+) -> noon_core::SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+fn index(store: &SemanticStore) -> SemanticExecutionIndex {
+    let mut index = SemanticExecutionIndex::new();
+    index.lower_scene(store).unwrap();
+    index
+}
+
+fn effective(object: ObjectId) -> EffectiveAnimationProperties {
+    EffectiveAnimationProperties {
+        z_index: 0.0,
+        transform: Transform2D {
+            translation: Vec2::new(object.get() as f32, -(object.get() as f32)),
+            ..Transform2D::IDENTITY
+        },
+        style: Style::default(),
+        appearance: 1.0,
+        reveal: 1.0,
+    }
+}
+
+#[test]
+fn expansion_reuses_one_effective_capture_for_repeated_source_occurrence() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 1.0);
+    let s1 = object(&mut store, 0.8);
+    let t0 = object(&mut store, 0.4);
+    let t1 = object(&mut store, 0.5);
+    let t2 = object(&mut store, 0.6);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1, t2]);
+    store.attach_to_scene(source).unwrap();
+    let execution = index(&store);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    let animation = transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new()
+            .run_time(2.0)
+            .rate_func(RateFunction::Linear),
+    );
+    let prepared = transaction.prepare(&mut store).unwrap();
+    let schedule = lower_prepared_semantic_animation_schedule(
+        &prepared,
+        &execution,
+        animation,
+        3.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+
+    let samples = Cell::new(0_u32);
+    let activation =
+        prepare_family_transform_activations(&prepared, &execution, &schedule, |object| {
+            samples.set(samples.get() + 1);
+            Some(effective(object))
+        })
+        .unwrap();
+
+    assert_eq!(activation.len(), 3);
+    assert_eq!(
+        samples.get(),
+        2,
+        "each distinct source row is captured once"
+    );
+    let occurrences = activation.occurrences();
+    assert_eq!(occurrences[0].source, s0);
+    assert_eq!(occurrences[0].target_state, t0);
+    assert!(!occurrences[0].source_padding);
+    assert_eq!(occurrences[1].source, s0);
+    assert_eq!(occurrences[1].target_state, t1);
+    assert!(occurrences[1].source_padding);
+    assert_eq!(occurrences[2].source, s1);
+    assert_eq!(occurrences[2].target_state, t2);
+    assert!(!occurrences[2].source_padding);
+    assert_eq!(
+        occurrences[0].source_execution_object_id,
+        occurrences[1].source_execution_object_id
+    );
+    assert_eq!(
+        occurrences[0].effective_source,
+        occurrences[1].effective_source
+    );
+    assert_eq!(occurrences[0].timing.start_time, 3.0);
+    assert_eq!(occurrences[0].timing.duration, 2.0);
+}
+
+#[test]
+fn contraction_marks_repeated_target_without_inventing_source_execution_identity() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 1.0);
+    let s1 = object(&mut store, 0.9);
+    let s2 = object(&mut store, 0.8);
+    let t0 = object(&mut store, 0.4);
+    let t1 = object(&mut store, 0.5);
+    let source = family(&mut store, &[s0, s1, s2]);
+    let target = family(&mut store, &[t0, t1]);
+    store.attach_to_scene(source).unwrap();
+    let execution = index(&store);
+
+    let mut transaction = SemanticMutationTransaction::new();
+    let animation = transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new().rate_func(RateFunction::Linear),
+    );
+    let prepared = transaction.prepare(&mut store).unwrap();
+    let schedule = lower_prepared_semantic_animation_schedule(
+        &prepared,
+        &execution,
+        animation,
+        0.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+    let activation =
+        prepare_family_transform_activations(&prepared, &execution, &schedule, |object| {
+            Some(effective(object))
+        })
+        .unwrap();
+
+    let occurrences = activation.occurrences();
+    assert_eq!(occurrences.len(), 3);
+    assert!(!occurrences[0].target_padding);
+    assert!(occurrences[1].target_padding);
+    assert!(!occurrences[2].target_padding);
+    assert!(occurrences
+        .iter()
+        .all(|occurrence| !occurrence.source_padding));
+    assert_ne!(
+        occurrences[0].source_execution_object_id,
+        occurrences[1].source_execution_object_id
+    );
+    assert_ne!(
+        occurrences[1].source_execution_object_id,
+        occurrences[2].source_execution_object_id
+    );
+}


### PR DESCRIPTION
## Summary

Adds the next bounded B3 activation-preparation layer, stacked on #1430.

- consumes the shared prepared family-Transform schedule from #1430;
- derives recursive unequal-family correspondence through #1421's compiler-owned correspondence path;
- resolves only real source leaves through the existing stable `SemanticExecutionIndex`;
- captures each distinct source execution row's coherent effective state exactly once at activation preparation;
- repeated source padding occurrences reuse that captured value as their initial visual state rather than receiving synthetic semantic/execution identity;
- carries deterministic occurrence ordinals plus shared timing/time maps/options for later derived-display materialization;
- publishes nothing and mutates neither semantic topology nor runtime state.

## Qualification

The exact production implementation before probe removal passed:

- `cargo test -p noon-compile --test family_transform_activation` — success (2→3 expansion/capture reuse and 3→2 contraction coverage);
- `cargo fmt --all -- --check` — success.

The diagnostic workflow's final bookkeeping condition reported failure despite both substantive steps succeeding; that temporary workflow has now been removed from the production diff.

## Scope / safety

This PR intentionally does **not** switch `ExecutionSession::FamilyTransformTo` away from its current strict equal-family path yet. Doing that before derived channel/materialization publication exists would create a no-op family Transform. The next layer will reuse the canonical Transform channel lowerer for ordinary source occurrences and release-only derived channels for repeated source occurrences, then materialize padding through #1425/#1426 identity-free display publication.

Persistent topology reconciliation remains exclusively explicit `become()` from #1416.

Refs #82.