### PR TITLE
Share TangentLine path sampling and construction

### DIFF
--- a/crates/noon-native/examples/tangent_line.rs
+++ b/crates/noon-native/examples/tangent_line.rs
@@ -3,9 +3,7 @@ use noon::{ManimGeometryOptions, Scene};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut scene = Scene::new();
 
-    let mut circle_options = ManimGeometryOptions::circle(2.0)?;
-    circle_options.set_color(1.0, 1.0, 1.0, 1.0)?;
-    let circle = scene.geometry(circle_options)?;
+    let circle = scene.geometry(ManimGeometryOptions::circle(2.0)?)?;
 
     let mut first_options = circle.manim_tangent_line_options(0.0, 4.0, 1.0e-6)?;
     first_options.set_color(41.0 / 255.0, 171.0 / 255.0, 202.0 / 255.0, 1.0)?;

--- a/crates/noon-native/examples/tangent_line.rs
+++ b/crates/noon-native/examples/tangent_line.rs
@@ -1,0 +1,21 @@
+use noon::{ManimGeometryOptions, Scene};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut scene = Scene::new();
+
+    let mut circle_options = ManimGeometryOptions::circle(2.0)?;
+    circle_options.set_color(1.0, 1.0, 1.0, 1.0)?;
+    let circle = scene.geometry(circle_options)?;
+
+    let mut first_options = circle.manim_tangent_line_options(0.0, 4.0, 1.0e-6)?;
+    first_options.set_color(41.0 / 255.0, 171.0 / 255.0, 202.0 / 255.0, 1.0)?;
+    let first = scene.geometry(first_options)?;
+
+    let mut second_options = circle.manim_tangent_line_options(0.4, 4.0, 1.0e-6)?;
+    second_options.set_color(131.0 / 255.0, 193.0 / 255.0, 103.0 / 255.0, 1.0)?;
+    let second = scene.geometry(second_options)?;
+
+    scene.add_many(&[(&circle).into(), (&first).into(), (&second).into()])?;
+    noon_native::run(scene.execution_session()?)?;
+    Ok(())
+}

--- a/crates/noon-web/src/authoring_tangent_line.rs
+++ b/crates/noon-web/src/authoring_tangent_line.rs
@@ -2,8 +2,8 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::{WasmAuthoringMobjectHandle, WasmManimGeometryOptions};
 use crate::authoring_error::js_error;
+use crate::{WasmAuthoringMobjectHandle, WasmManimGeometryOptions};
 
 #[wasm_bindgen]
 impl WasmAuthoringMobjectHandle {

--- a/crates/noon-web/src/authoring_tangent_line.rs
+++ b/crates/noon-web/src/authoring_tangent_line.rs
@@ -1,0 +1,25 @@
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::prelude::*;
+
+use crate::{WasmAuthoringMobjectHandle, WasmManimGeometryOptions};
+use crate::authoring_error::js_error;
+
+#[wasm_bindgen]
+impl WasmAuthoringMobjectHandle {
+    /// Derive an inert TangentLine geometry candidate from this retained source.
+    /// Sampling and length normalization stay in shared Rust; the frontend may
+    /// apply ordinary constructor style before publishing the returned candidate.
+    #[wasm_bindgen(js_name = tangentLineOptions)]
+    pub fn tangent_line_options(
+        &self,
+        alpha: f64,
+        length: f64,
+        d_alpha: f64,
+    ) -> Result<WasmManimGeometryOptions, JsValue> {
+        self.semantic_mobject()
+            .manim_tangent_line_options(alpha, length, d_alpha)
+            .map(WasmManimGeometryOptions::from_options)
+            .map_err(js_error)
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -9,6 +9,8 @@ mod authoring_error;
 mod authoring_geometry;
 mod authoring_mobject;
 mod authoring_options;
+#[cfg(target_arch = "wasm32")]
+mod authoring_tangent_line;
 mod canonical_authoring_scene;
 mod clock;
 mod determinism;

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -95,6 +95,7 @@ mod scene_membership;
 mod sector_authoring;
 mod semantic_mobject;
 mod state_replacement;
+mod tangent_line_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]

--- a/crates/noon/src/tangent_line_authoring.rs
+++ b/crates/noon/src/tangent_line_authoring.rs
@@ -1,0 +1,127 @@
+//! Shared Manim-compatible TangentLine construction from retained path queries.
+//!
+//! Tangent sampling is a semantic authoring operation: the source path is observed
+//! once in authored world space, two nearby path proportions are sampled, and the
+//! resulting direction is normalized to the requested line length. The result is an
+//! ordinary analytic Line candidate; no source dependency, renderer primitive, or
+//! frontend-owned geometry is retained after construction.
+
+use crate::{AuthoringError, ManimGeometryOptions, Mobject};
+
+impl Mobject {
+    /// Prepare an inert analytic Line matching ManimCE v0.21 `TangentLine`.
+    ///
+    /// `alpha +/- d_alpha` is clamped to `[0, 1]` before sampling the source's
+    /// authored world-space path. The sampled chord is then scaled about its
+    /// midpoint to `length`, exactly matching the constructor's Line-then-scale
+    /// geometry for a nondegenerate sample. This query creates no semantic identity
+    /// or immutable geometry resource; callers publish the returned options through
+    /// the ordinary geometry authoring path after applying constructor style.
+    pub fn manim_tangent_line_options(
+        &self,
+        alpha: f64,
+        length: f64,
+        d_alpha: f64,
+    ) -> Result<ManimGeometryOptions, AuthoringError> {
+        let query = self.path_query()?;
+        let a1 = (alpha - d_alpha).clamp(0.0, 1.0);
+        let a2 = (alpha + d_alpha).clamp(0.0, 1.0);
+        let first = query.point_from_proportion(a1)?;
+        let second = query.point_from_proportion(a2)?;
+
+        let dx = second.0 - first.0;
+        let dy = second.1 - first.1;
+        let sample_length = dx.hypot(dy);
+        if !sample_length.is_finite() || sample_length == 0.0 {
+            return Err(AuthoringError::NonPositiveNumber {
+                name: "TangentLine sampled chord length".to_owned(),
+                value: sample_length,
+            });
+        }
+
+        let midpoint = ((first.0 + second.0) * 0.5, (first.1 + second.1) * 0.5);
+        let half = length * 0.5;
+        let unit = (dx / sample_length, dy / sample_length);
+        ManimGeometryOptions::line(
+            midpoint.0 - unit.0 * half,
+            midpoint.1 - unit.1 * half,
+            midpoint.0 + unit.0 * half,
+            midpoint.1 + unit.1 * half,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Scene;
+
+    #[test]
+    fn tangent_line_uses_clamped_path_samples_and_requested_length() {
+        let scene = Scene::new();
+        let circle = scene.circle(2.0).unwrap();
+        let query = circle.path_query().unwrap();
+        let sample_a = query.point_from_proportion(0.0).unwrap();
+        let sample_b = query.point_from_proportion(1.0e-6).unwrap();
+        let midpoint = (
+            (sample_a.0 + sample_b.0) * 0.5,
+            (sample_a.1 + sample_b.1) * 0.5,
+        );
+
+        let line = scene
+            .geometry(
+                circle
+                    .manim_tangent_line_options(0.0, 4.0, 1.0e-6)
+                    .unwrap(),
+            )
+            .unwrap();
+        let endpoints = line.manim_line_endpoints().unwrap();
+        let dx = endpoints.end.0 - endpoints.start.0;
+        let dy = endpoints.end.1 - endpoints.start.1;
+        assert!((dx.hypot(dy) - 4.0).abs() < 1.0e-5);
+        assert!(((endpoints.start.0 + endpoints.end.0) * 0.5 - midpoint.0).abs() < 1.0e-6);
+        assert!(((endpoints.start.1 + endpoints.end.1) * 0.5 - midpoint.1).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn tangent_line_does_not_mutate_its_source() {
+        let scene = Scene::new();
+        let circle = scene.circle(2.0).unwrap();
+        let before = circle.state().unwrap();
+        let revision = scene.revision();
+
+        let options = circle
+            .manim_tangent_line_options(0.4, 3.0, 1.0e-5)
+            .unwrap();
+        assert_eq!(circle.state().unwrap(), before);
+        assert_eq!(scene.revision(), revision);
+
+        let _line = scene.geometry(options).unwrap();
+        assert_eq!(circle.state().unwrap(), before);
+    }
+
+    #[test]
+    fn tangent_line_rejects_degenerate_sampling_before_publication() {
+        let scene = Scene::new();
+        let circle = scene.circle(2.0).unwrap();
+        let revision = scene.revision();
+        let resources = scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .stats();
+
+        assert!(circle
+            .manim_tangent_line_options(0.5, 1.0, 0.0)
+            .is_err());
+        assert_eq!(scene.revision(), revision);
+        assert_eq!(
+            scene
+                .integration_store()
+                .borrow()
+                .geometry_resources()
+                .stats(),
+            resources
+        );
+    }
+}

--- a/crates/noon/src/tangent_line_authoring.rs
+++ b/crates/noon/src/tangent_line_authoring.rs
@@ -53,7 +53,6 @@ impl Mobject {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::Scene;
 
     #[test]

--- a/crates/noon/src/tangent_line_authoring.rs
+++ b/crates/noon/src/tangent_line_authoring.rs
@@ -69,11 +69,7 @@ mod tests {
         );
 
         let line = scene
-            .geometry(
-                circle
-                    .manim_tangent_line_options(0.0, 4.0, 1.0e-6)
-                    .unwrap(),
-            )
+            .geometry(circle.manim_tangent_line_options(0.0, 4.0, 1.0e-6).unwrap())
             .unwrap();
         let endpoints = line.manim_line_endpoints().unwrap();
         let dx = endpoints.end.0 - endpoints.start.0;
@@ -90,9 +86,7 @@ mod tests {
         let before = circle.state().unwrap();
         let revision = scene.revision();
 
-        let options = circle
-            .manim_tangent_line_options(0.4, 3.0, 1.0e-5)
-            .unwrap();
+        let options = circle.manim_tangent_line_options(0.4, 3.0, 1.0e-5).unwrap();
         assert_eq!(circle.state().unwrap(), before);
         assert_eq!(scene.revision(), revision);
 
@@ -111,9 +105,7 @@ mod tests {
             .geometry_resources()
             .stats();
 
-        assert!(circle
-            .manim_tangent_line_options(0.5, 1.0, 0.0)
-            .is_err());
+        assert!(circle.manim_tangent_line_options(0.5, 1.0, 0.0).is_err());
         assert_eq!(scene.revision(), revision);
         assert_eq!(
             scene

--- a/crates/noon/tests/manim_tangent_line.rs
+++ b/crates/noon/tests/manim_tangent_line.rs
@@ -1,0 +1,144 @@
+use noon::{ManimGeometryOptions, Scene, Vec2};
+
+fn midpoint(start: (f64, f64), end: (f64, f64)) -> (f64, f64) {
+    ((start.0 + end.0) * 0.5, (start.1 + end.1) * 0.5)
+}
+
+#[test]
+fn tangent_line_samples_generic_retained_paths_in_authored_world_space() {
+    let scene = Scene::new();
+    let mut source_options = ManimGeometryOptions::rectangle(4.0, 2.0).unwrap();
+    source_options.set_scale(1.25, 0.75).unwrap();
+    source_options.set_rotation(0.3).unwrap();
+    source_options.set_translation(-0.4, 0.6).unwrap();
+    let source = scene.geometry(source_options).unwrap();
+
+    let query = source.path_query().unwrap();
+    let a = query.point_from_proportion(0.3 - 1.0e-4).unwrap();
+    let b = query.point_from_proportion(0.3 + 1.0e-4).unwrap();
+    let expected_midpoint = midpoint(a, b);
+
+    let tangent = scene
+        .geometry(
+            source
+                .manim_tangent_line_options(0.3, 3.5, 1.0e-4)
+                .unwrap(),
+        )
+        .unwrap();
+    let endpoints = tangent.manim_line_endpoints().unwrap();
+    let actual_midpoint = midpoint(endpoints.start, endpoints.end);
+    let dx = endpoints.end.0 - endpoints.start.0;
+    let dy = endpoints.end.1 - endpoints.start.1;
+
+    assert!((dx.hypot(dy) - 3.5).abs() < 1.0e-5);
+    assert!((actual_midpoint.0 - expected_midpoint.0).abs() < 1.0e-6);
+    assert!((actual_midpoint.1 - expected_midpoint.1).abs() < 1.0e-6);
+}
+
+#[test]
+fn endpoint_alpha_clamps_like_manim() {
+    let scene = Scene::new();
+    let source = scene.circle(2.0).unwrap();
+    let query = source.path_query().unwrap();
+    let first = query.point_from_proportion(0.0).unwrap();
+    let nearby = query.point_from_proportion(1.0e-6).unwrap();
+    let expected = midpoint(first, nearby);
+
+    let tangent = scene
+        .geometry(
+            source
+                .manim_tangent_line_options(0.0, 4.0, 1.0e-6)
+                .unwrap(),
+        )
+        .unwrap();
+    let endpoints = tangent.manim_line_endpoints().unwrap();
+    let center = midpoint(endpoints.start, endpoints.end);
+    assert!((center.0 - expected.0).abs() < 1.0e-6);
+    assert!((center.1 - expected.1).abs() < 1.0e-6);
+}
+
+#[test]
+fn signed_requested_length_preserves_manim_line_scaling_orientation() {
+    let scene = Scene::new();
+    let source = scene.circle(1.5).unwrap();
+    let positive = scene
+        .geometry(
+            source
+                .manim_tangent_line_options(0.25, 2.0, 1.0e-5)
+                .unwrap(),
+        )
+        .unwrap();
+    let negative = scene
+        .geometry(
+            source
+                .manim_tangent_line_options(0.25, -2.0, 1.0e-5)
+                .unwrap(),
+        )
+        .unwrap();
+    let p = positive.manim_line_endpoints().unwrap();
+    let n = negative.manim_line_endpoints().unwrap();
+
+    assert!((p.start.0 - n.end.0).abs() < 1.0e-6);
+    assert!((p.start.1 - n.end.1).abs() < 1.0e-6);
+    assert!((p.end.0 - n.start.0).abs() < 1.0e-6);
+    assert!((p.end.1 - n.start.1).abs() < 1.0e-6);
+}
+
+#[test]
+fn tangent_line_sampling_is_read_only_until_candidate_publication() {
+    let scene = Scene::new();
+    let source = scene.circle(2.0).unwrap();
+    let state = source.state().unwrap();
+    let revision = scene.revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .stats();
+
+    let candidate = source
+        .manim_tangent_line_options(0.4, 2.5, 1.0e-5)
+        .unwrap();
+    assert_eq!(source.state().unwrap(), state);
+    assert_eq!(scene.revision(), revision);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .stats(),
+        resources
+    );
+
+    let tangent = scene.geometry(candidate).unwrap();
+    assert_eq!(source.state().unwrap(), state);
+    assert_ne!(tangent.node_id(), source.node_id());
+}
+
+#[test]
+fn degenerate_sample_rejects_without_semantic_publication() {
+    let scene = Scene::new();
+    let source = scene.circle(2.0).unwrap();
+    let revision = scene.revision();
+    let result = source.manim_tangent_line_options(0.5, 1.0, 0.0);
+    assert!(result.is_err());
+    assert_eq!(scene.revision(), revision);
+}
+
+#[test]
+fn zero_requested_length_is_a_valid_degenerate_line() {
+    let scene = Scene::new();
+    let source = scene.circle(2.0).unwrap();
+    let tangent = scene
+        .geometry(
+            source
+                .manim_tangent_line_options(0.2, 0.0, 1.0e-5)
+                .unwrap(),
+        )
+        .unwrap();
+    let endpoints = tangent.manim_line_endpoints().unwrap();
+    assert_eq!(
+        Vec2::new(endpoints.start.0 as f32, endpoints.start.1 as f32),
+        Vec2::new(endpoints.end.0 as f32, endpoints.end.1 as f32)
+    );
+}

--- a/crates/noon/tests/manim_tangent_line.rs
+++ b/crates/noon/tests/manim_tangent_line.rs
@@ -19,11 +19,7 @@ fn tangent_line_samples_generic_retained_paths_in_authored_world_space() {
     let expected_midpoint = midpoint(a, b);
 
     let tangent = scene
-        .geometry(
-            source
-                .manim_tangent_line_options(0.3, 3.5, 1.0e-4)
-                .unwrap(),
-        )
+        .geometry(source.manim_tangent_line_options(0.3, 3.5, 1.0e-4).unwrap())
         .unwrap();
     let endpoints = tangent.manim_line_endpoints().unwrap();
     let actual_midpoint = midpoint(endpoints.start, endpoints.end);
@@ -45,11 +41,7 @@ fn endpoint_alpha_clamps_like_manim() {
     let expected = midpoint(first, nearby);
 
     let tangent = scene
-        .geometry(
-            source
-                .manim_tangent_line_options(0.0, 4.0, 1.0e-6)
-                .unwrap(),
-        )
+        .geometry(source.manim_tangent_line_options(0.0, 4.0, 1.0e-6).unwrap())
         .unwrap();
     let endpoints = tangent.manim_line_endpoints().unwrap();
     let center = midpoint(endpoints.start, endpoints.end);
@@ -96,9 +88,7 @@ fn tangent_line_sampling_is_read_only_until_candidate_publication() {
         .geometry_resources()
         .stats();
 
-    let candidate = source
-        .manim_tangent_line_options(0.4, 2.5, 1.0e-5)
-        .unwrap();
+    let candidate = source.manim_tangent_line_options(0.4, 2.5, 1.0e-5).unwrap();
     assert_eq!(source.state().unwrap(), state);
     assert_eq!(scene.revision(), revision);
     assert_eq!(
@@ -130,11 +120,7 @@ fn zero_requested_length_is_a_valid_degenerate_line() {
     let scene = Scene::new();
     let source = scene.circle(2.0).unwrap();
     let tangent = scene
-        .geometry(
-            source
-                .manim_tangent_line_options(0.2, 0.0, 1.0e-5)
-                .unwrap(),
-        )
+        .geometry(source.manim_tangent_line_options(0.2, 0.0, 1.0e-5).unwrap())
         .unwrap();
     let endpoints = tangent.manim_line_endpoints().unwrap();
     assert_eq!(

--- a/parity/manim-v0.21/core-examples/tangent_line.py
+++ b/parity/manim-v0.21/core-examples/tangent_line.py
@@ -1,0 +1,10 @@
+from manim import *
+
+
+class TangentLineExample(Scene):
+    def construct(self):
+        circle = Circle(radius=2)
+        line_1 = TangentLine(circle, alpha=0.0, length=4, color=BLUE_D)
+        line_2 = TangentLine(circle, alpha=0.4, length=4, color=GREEN)
+        self.add(circle, line_1, line_2)
+        self.wait(0.2)

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -143,6 +143,17 @@
       }
     },
     {
+      "id": "tangent-line",
+      "scene": "TangentLineExample",
+      "source": "parity/manim-v0.21/core-examples/tangent_line.py",
+      "expected_duration": 0.2,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 2,
+        "max_differing_ratio": 0.006,
+        "max_mean_absolute_channel_error": 0.5
+      }
+    },
+    {
       "id": "canonical-curve-layout",
       "scene": "OrdinaryCanonicalCurveLayout",
       "source": "parity/manim-v0.21/core-examples/canonical_curve_layout.py",

--- a/web/python/_manim_geometry.py
+++ b/web/python/_manim_geometry.py
@@ -50,6 +50,51 @@ class Triangle(_compat.Path):
         _triangle_init(self, **kwargs)
 
 
+class TangentLine(_compat.Line):
+    """Line tangent to a retained VMobject using shared Rust path sampling."""
+
+    def __init__(
+        self,
+        vmob: _compat.VMobject,
+        alpha: float,
+        length: float = 1.0,
+        d_alpha: float = 1.0e-6,
+        **kwargs: Any,
+    ) -> None:
+        import _manim_semantic_handles as shared
+
+        if not isinstance(vmob, _compat.VMobject):
+            raise TypeError("TangentLine requires a VMobject source")
+        if shared._live_constructor_context("TangentLine") is not None:
+            raise NotImplementedError(
+                "live TangentLine construction requires effective shared path sampling"
+            )
+        source = shared._handle_for(vmob)
+        if source is None or not hasattr(source, "tangentLineOptions"):
+            raise NotImplementedError(
+                "TangentLine requires a current shared Rust path handle"
+            )
+
+        alpha_value = _base._ir._finite_number("alpha", alpha)
+        length_value = _base._ir._finite_number("length", length)
+        d_alpha_value = _base._ir._finite_number("d_alpha", d_alpha)
+        options = engine_call(
+            source.tangentLineOptions,
+            alpha_value,
+            length_value,
+            d_alpha_value,
+            operation="TangentLine",
+        )
+        values = dict(kwargs)
+        color = values.pop("color", None)
+        shared._apply_shared_constructor_options(options, values)
+        if color is not None:
+            shared._apply_constructor_color(options, _compat._as_color("color", color))
+        shared._attach_geometry_options(self, options, "TangentLine")
+        self.length = length_value
+        self.d_alpha = d_alpha_value
+
+
 def _line_get_start(self: _compat.Line) -> _base.Vec2:
     import _manim_semantic_handles as shared
 

--- a/web/python/examples/ordinary_tangent_line.py
+++ b/web/python/examples/ordinary_tangent_line.py
@@ -1,0 +1,11 @@
+"""Source-equivalent TangentLine example using shared Rust path sampling."""
+from noon import *
+
+
+class TangentLineExample(Scene):
+    def construct(self):
+        circle = Circle(radius=2)
+        line_1 = TangentLine(circle, alpha=0.0, length=4, color=BLUE_D)
+        line_2 = TangentLine(circle, alpha=0.4, length=4, color=GREEN)
+        self.add(circle, line_1, line_2)
+        self.wait(0.2)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -770,6 +770,7 @@ _PUBLIC_EXPORTS = {
     "Arrow": "_manim_arrow",
     "Vector": "_manim_arrow",
     "DoubleArrow": "_manim_arrow",
+    "TangentLine": "_manim_geometry",
     "Elbow": "_manim_shared_geometry",
     "RoundedRectangle": "_manim_shared_geometry",
     "SurroundingRectangle": "_manim_shared_geometry",

--- a/web/python/test_manim_tangent_line.py
+++ b/web/python/test_manim_tangent_line.py
@@ -1,0 +1,121 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimTangentLineFacadeTests(unittest.TestCase):
+    def test_tangent_line_delegates_sampling_and_length_to_shared_rust(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(
+            value for value in (str(python_dir), env.get("PYTHONPATH")) if value
+        )
+        source = textwrap.dedent(
+            r"""
+            import sys
+            import types
+
+            calls = []
+            fake_js = types.ModuleType("js")
+
+            class FakeOptions:
+                def setZIndex(self, value): calls.append(("z_index", float(value)))
+                def setTranslation(self, x, y): calls.append(("translation", float(x), float(y)))
+                def setRotation(self, value): calls.append(("rotation", float(value)))
+                def setScale(self, x, y): calls.append(("scale", float(x), float(y)))
+                def setStrokeWidth(self, value): calls.append(("stroke_width", float(value)))
+                def setStrokeWidthMode(self, value): calls.append(("stroke_width_mode", str(value)))
+                def setStrokeJoin(self, value): calls.append(("stroke_join", str(value)))
+                def setStrokeCap(self, value): calls.append(("stroke_cap", str(value)))
+                def setObjectOpacity(self, value): calls.append(("opacity", float(value)))
+                def setColor(self, r, g, b, a): calls.append(("color", float(r), float(g), float(b), float(a)))
+                def disableFill(self): calls.append(("disable_fill",))
+                def setFill(self, r, g, b, a): calls.append(("fill", float(r), float(g), float(b), float(a)))
+                def setFillColor(self, r, g, b, a): calls.append(("fill_color", float(r), float(g), float(b), float(a)))
+                def setFillOpacity(self, value): calls.append(("fill_opacity", float(value)))
+                def disableStroke(self): calls.append(("disable_stroke",))
+                def setStroke(self, r, g, b, a): calls.append(("stroke", float(r), float(g), float(b), float(a)))
+                def setStrokeColor(self, r, g, b, a): calls.append(("stroke_color", float(r), float(g), float(b), float(a)))
+                def setStrokeOpacity(self, value): calls.append(("stroke_opacity", float(value)))
+
+            class FakeSourceHandle:
+                semanticSlot = 1
+                semanticGeneration = 0
+                def tangentLineOptions(self, alpha, length, d_alpha):
+                    calls.append(("tangent", float(alpha), float(length), float(d_alpha)))
+                    return FakeOptions()
+
+            class FakeCreatedHandle:
+                semanticSlot = 2
+                semanticGeneration = 0
+
+            class EmptyGeometryOptions:
+                @staticmethod
+                def emptyPath(): return FakeOptions()
+
+            fake_js.noonAuthoringGeometryOptions = EmptyGeometryOptions
+            fake_js.noonAuthoringVectorPath = lambda: None
+            fake_js.noonCreateAuthoringGeometryHandle = lambda options: (
+                calls.append(("publish",)) or FakeCreatedHandle()
+            )
+            fake_js.noonCreateAuthoringFamilyHandle = lambda batch, z: None
+            fake_js.noonAuthoringMembershipBatch = lambda kind: None
+            sys.modules["js"] = fake_js
+
+            import noon
+            import _manim_compat as compat
+            from _manim_geometry import TangentLine
+
+            circle = object.__new__(compat.Circle)
+            circle._raw = None
+            circle._scene = None
+            circle._object = None
+            circle._semantic_handle = FakeSourceHandle()
+            circle._semantic_handle_fresh = True
+
+            tangent = TangentLine(
+                circle,
+                0.4,
+                length=3.0,
+                d_alpha=1e-5,
+                color="#29ABCA",
+                stroke_width=6.0,
+            )
+            assert calls[0] == ("tangent", 0.4, 3.0, 1e-5)
+            assert ("stroke_width", 0.06) in calls
+            assert any(call[0] == "color" for call in calls)
+            assert ("publish",) in calls
+            assert tangent.length == 3.0
+            assert tangent.d_alpha == 1e-5
+            assert tangent._semantic_handle.semanticSlot == 2
+
+            before = list(calls)
+            try:
+                TangentLine(object(), 0.5)
+            except TypeError:
+                pass
+            else:
+                raise AssertionError("non-VMobject TangentLine source unexpectedly succeeded")
+            assert calls == before
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #77 / #954 with the common static 2D `TangentLine` constructor using the existing shared path-query authority.

## What this owns
- Rust `Mobject::manim_tangent_line_options(...)` samples the source object's authored world-space `PathQuery`, clips `alpha +/- d_alpha` to `[0, 1]`, and normalizes the sampled chord to the requested signed length.
- The result is one ordinary analytic `Line` candidate. Sampling creates no semantic identity, immutable resource, renderer primitive, source dependency, or frontend geometry mirror.
- The same shared Rust operation is first-class for native Rust and exposed through the existing WASM semantic mobject handle as typed `tangentLineOptions`.
- Python `TangentLine(Line)` is only argument/style adaptation plus ordinary geometry publication; it does not sample path points or derive the tangent itself.
- Generic transformed retained-path coverage verifies the constructor is not Circle-specific; endpoint clipping, negative/zero requested length, read-only sampling, and atomic degenerate rejection are covered separately.
- Public `noon.TangentLine`, paired native/Python executable examples, the pinned ManimCE v0.21 docs scene, and a blocking manifest/raster entry are included.

## Explicitly not claimed
- Live construction from a source after execution bootstrap. Noon rejects that path until effective shared path sampling owns it; it does not read stale authored state.
- Degenerate sampled chords (`d_alpha=0` or both clipped samples equal) as source-equivalent success/error behavior; this slice rejects them as typed invalid input before publication.
- Extra `Line` constructor breadth such as nonzero `path_arc`/`buff` passed through `TangentLine`, or other remaining #77 line-query/lifecycle gaps.
- This PR does not close #77.

## Qualification
Exact-head CI is the merge gate. Focused Rust tests cover transformed generic paths, endpoint clipping, signed and zero requested length, source immutability/resource locality, and degenerate atomic rejection. The native/Python pair uses the same shared Rust constructor path. `parity/manim-v0.21/core-examples/tangent_line.py` is source-equivalent to the pinned ManimCE docs example and is registered in the canonical raster manifest, so semantic/raster differential is blocking rather than advisory.

Self-review and CI only; no automated review requested.