### PR TITLE
Lower unequal family Transform execution channels

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_payload.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload.rs
@@ -1,6 +1,7 @@
 mod affine;
 mod family_transform;
 mod family_transform_activation;
+mod family_transform_channels;
 mod prepared_composition;
 mod scheduled_captures;
 mod text_write;
@@ -9,6 +10,7 @@ mod transform_payload;
 pub use affine::*;
 pub use family_transform::*;
 pub use family_transform_activation::*;
+pub use family_transform_channels::*;
 pub use prepared_composition::*;
 pub use text_write::*;
 pub use transform_payload::*;

--- a/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
@@ -1,0 +1,404 @@
+use std::collections::{hash_map::Entry, HashMap};
+
+use noon_core::{
+    ObjectId, PreparedSemanticMutationTransaction, Property, SemanticNodeId,
+    SemanticObjectProperty, SemanticTransactionNodeRef, TimelineError, TrackDefinition, TrackId,
+    TrackValues,
+};
+
+use super::affine::{
+    completion_at_endpoint, driver_key, lower_transform_channels, transform_driver_conflict,
+    validate_affine_payload, AffinePayloadIssue,
+};
+use super::family_transform_activation::{
+    PreparedFamilyTransformActivationProjection, PreparedFamilyTransformOccurrence,
+};
+use super::prepared_composition::{
+    PreparedSemanticAnimationLoweringError, PreparedSemanticAnimationTrack,
+};
+
+/// One identity-free execution channel for a repeated source occurrence.
+///
+/// The channel intentionally owns no `ObjectId`, semantic node, completion action, or
+/// persistent topology. `anchor_execution_object_id` points only to the real source
+/// row whose activation-effective state was copied before this derived occurrence
+/// began evolving independently.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedDerivedFamilyTransformTrack {
+    pub occurrence_index: u32,
+    pub anchor_execution_object_id: ObjectId,
+    pub property: Property,
+    pub values: TrackValues,
+    pub timing: noon_core::TrackTiming,
+    pub time_map: noon_core::CompositionTimeMap,
+}
+
+/// One source-padding display occurrence ready for runtime-only evaluation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedDerivedFamilyTransformOccurrence {
+    pub occurrence_index: u32,
+    pub anchor_execution_object_id: ObjectId,
+    pub source: SemanticNodeId,
+    pub target_state: SemanticNodeId,
+    pub effective_source: super::EffectiveAnimationProperties,
+    pub tracks: Vec<PreparedDerivedFamilyTransformTrack>,
+}
+
+/// Compiler-owned channel projection for a prepared unequal-family Transform.
+///
+/// Real source occurrences reuse the ordinary prepared animation-track vocabulary so
+/// execution publication/completion stays on the existing path. Repeated source
+/// occurrences are retained separately as plan-local display channels and never enter
+/// the stable object-slot domain.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PreparedFamilyTransformChannelProjection {
+    stable_tracks: Vec<PreparedSemanticAnimationTrack>,
+    derived_occurrences: Vec<PreparedDerivedFamilyTransformOccurrence>,
+}
+
+impl PreparedFamilyTransformChannelProjection {
+    pub fn stable_tracks(&self) -> &[PreparedSemanticAnimationTrack] {
+        &self.stable_tracks
+    }
+
+    pub fn derived_occurrences(&self) -> &[PreparedDerivedFamilyTransformOccurrence] {
+        &self.derived_occurrences
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stable_tracks.is_empty() && self.derived_occurrences.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PreparedFamilyTransformChannelError {
+    Target {
+        animation: SemanticTransactionNodeRef,
+        node: SemanticTransactionNodeRef,
+        error: noon_core::SemanticTransactionReadError,
+    },
+    Payload(PreparedSemanticAnimationLoweringError),
+    MultipleDrivers {
+        first_animation: SemanticTransactionNodeRef,
+        next_animation: SemanticTransactionNodeRef,
+        target: SemanticNodeId,
+        property: SemanticObjectProperty,
+    },
+    /// Contraction requires the padded target's transparent endpoint to remain an
+    /// execution/effective state without becoming authored opacity. The existing
+    /// completion path reconciles `Release` tracks back to authored base state, so
+    /// this shape remains fail-closed until the effective-hold completion contract is
+    /// introduced.
+    TargetPaddingRequiresEffectiveHold {
+        animation: SemanticTransactionNodeRef,
+        source: SemanticNodeId,
+        target_state: SemanticNodeId,
+        occurrence_index: u32,
+    },
+}
+
+impl std::fmt::Display for PreparedFamilyTransformChannelError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Target {
+                animation,
+                node,
+                error,
+            } => write!(
+                formatter,
+                "prepared family Transform {animation:?} cannot read object {node:?}: {error}"
+            ),
+            Self::Payload(error) => error.fmt(formatter),
+            Self::MultipleDrivers {
+                first_animation,
+                next_animation,
+                target,
+                property,
+            } => write!(
+                formatter,
+                "prepared family Transform {next_animation:?} conflicts with {first_animation:?} on {property:?} for source {}:{}",
+                target.slot(),
+                target.generation()
+            ),
+            Self::TargetPaddingRequiresEffectiveHold {
+                animation,
+                source,
+                target_state,
+                occurrence_index,
+            } => write!(
+                formatter,
+                "prepared family Transform {animation:?} contraction occurrence {occurrence_index} maps source {}:{} to padded target {}:{}; execution-only endpoint holding is not available yet",
+                source.slot(),
+                source.generation(),
+                target_state.slot(),
+                target_state.generation()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PreparedFamilyTransformChannelError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Target { error, .. } => Some(error),
+            Self::Payload(error) => Some(error),
+            Self::MultipleDrivers { .. } | Self::TargetPaddingRequiresEffectiveHold { .. } => None,
+        }
+    }
+}
+
+/// Lower activation-effective family correspondence through the canonical Transform
+/// payload lowerer.
+///
+/// Expansion is fully represented here: real source leaves become ordinary stable
+/// execution tracks, while repeated source occurrences receive identity-free derived
+/// channels plus a 0→1 appearance ramp matching Manim's faded padding copy. The
+/// function is pure and publishes nothing.
+///
+/// Contraction remains explicitly rejected when correspondence introduces a padded
+/// target occurrence. Persisting that transparent endpoint in effective execution
+/// state requires a completion mode distinct from ordinary `Release`, which would
+/// otherwise restore authored visibility immediately after segment completion.
+pub fn lower_prepared_family_transform_channels(
+    prepared: &PreparedSemanticMutationTransaction<'_>,
+    activation: &PreparedFamilyTransformActivationProjection,
+) -> Result<PreparedFamilyTransformChannelProjection, PreparedFamilyTransformChannelError> {
+    let mut stable_tracks = Vec::new();
+    let mut derived_occurrences = Vec::new();
+    let mut driven = HashMap::<(u64, u8), SemanticTransactionNodeRef>::new();
+
+    for occurrence in activation.occurrences() {
+        if occurrence.target_padding {
+            return Err(
+                PreparedFamilyTransformChannelError::TargetPaddingRequiresEffectiveHold {
+                    animation: occurrence.animation,
+                    source: occurrence.source,
+                    target_state: occurrence.target_state,
+                    occurrence_index: occurrence.occurrence_index,
+                },
+            );
+        }
+
+        let source_ref: SemanticTransactionNodeRef = occurrence.source.into();
+        let target_ref: SemanticTransactionNodeRef = occurrence.target_state.into();
+        let source = prepared.object_state(source_ref).map_err(|error| {
+            PreparedFamilyTransformChannelError::Target {
+                animation: occurrence.animation,
+                node: source_ref,
+                error,
+            }
+        })?;
+        let target = prepared.object_state(target_ref).map_err(|error| {
+            PreparedFamilyTransformChannelError::Target {
+                animation: occurrence.animation,
+                node: target_ref,
+                error,
+            }
+        })?;
+
+        validate_affine_payload(source, target, occurrence.options)
+            .map_err(|issue| payload_error(occurrence, issue))?;
+        let channels = lower_transform_channels(
+            prepared.store(),
+            source,
+            target,
+            occurrence.effective_source,
+            noon_core::SemanticTransformInterpolation::Affine,
+        )
+        .map_err(|issue| payload_error(occurrence, issue))?;
+
+        if occurrence.source_padding {
+            let mut tracks = channels
+                .into_iter()
+                .map(|channel| PreparedDerivedFamilyTransformTrack {
+                    occurrence_index: occurrence.occurrence_index,
+                    anchor_execution_object_id: occurrence.source_execution_object_id,
+                    property: channel.property,
+                    values: channel.values,
+                    timing: occurrence.timing,
+                    time_map: occurrence.time_map.clone(),
+                })
+                .collect::<Vec<_>>();
+            tracks.push(PreparedDerivedFamilyTransformTrack {
+                occurrence_index: occurrence.occurrence_index,
+                anchor_execution_object_id: occurrence.source_execution_object_id,
+                property: Property::Appearance,
+                values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+                timing: occurrence.timing,
+                time_map: occurrence.time_map.clone(),
+            });
+            derived_occurrences.push(PreparedDerivedFamilyTransformOccurrence {
+                occurrence_index: occurrence.occurrence_index,
+                anchor_execution_object_id: occurrence.source_execution_object_id,
+                source: occurrence.source,
+                target_state: occurrence.target_state,
+                effective_source: occurrence.effective_source,
+                tracks,
+            });
+            continue;
+        }
+
+        for channel in channels {
+            push_stable_channel(occurrence, channel, &mut driven, &mut stable_tracks)?;
+        }
+    }
+
+    Ok(PreparedFamilyTransformChannelProjection {
+        stable_tracks,
+        derived_occurrences,
+    })
+}
+
+fn push_stable_channel(
+    occurrence: &PreparedFamilyTransformOccurrence,
+    channel: super::affine::LoweredAffineChannel,
+    driven: &mut HashMap<(u64, u8), SemanticTransactionNodeRef>,
+    tracks: &mut Vec<PreparedSemanticAnimationTrack>,
+) -> Result<(), PreparedFamilyTransformChannelError> {
+    if let Some(first_animation) = transform_driver_conflict(
+        driven,
+        occurrence.source_execution_object_id,
+        channel.property,
+        occurrence.animation,
+    ) {
+        return Err(PreparedFamilyTransformChannelError::MultipleDrivers {
+            first_animation,
+            next_animation: occurrence.animation,
+            target: occurrence.source,
+            property: channel.conflict_property,
+        });
+    }
+    match driven.entry(driver_key(
+        occurrence.source_execution_object_id,
+        channel.property,
+    )) {
+        Entry::Occupied(entry) => {
+            return Err(PreparedFamilyTransformChannelError::MultipleDrivers {
+                first_animation: *entry.get(),
+                next_animation: occurrence.animation,
+                target: occurrence.source,
+                property: channel.conflict_property,
+            });
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(occurrence.animation);
+        }
+    }
+
+    tracks.push(PreparedSemanticAnimationTrack {
+        animation: occurrence.animation,
+        target: occurrence.source.into(),
+        execution_object_id: occurrence.source_execution_object_id,
+        property: channel.property,
+        completion: completion_at_endpoint(channel.completion, occurrence.timing.easing),
+        values: channel.values,
+        timing: occurrence.timing,
+        time_map: occurrence.time_map.clone(),
+    });
+    Ok(())
+}
+
+fn payload_error(
+    occurrence: &PreparedFamilyTransformOccurrence,
+    issue: AffinePayloadIssue,
+) -> PreparedFamilyTransformChannelError {
+    let animation = occurrence.animation;
+    let target: SemanticTransactionNodeRef = occurrence.source.into();
+    let target_state: SemanticTransactionNodeRef = occurrence.target_state.into();
+    let error = match issue {
+        AffinePayloadIssue::InvalidEffectiveTransform => {
+            PreparedSemanticAnimationLoweringError::InvalidEffectiveTransform { animation, target }
+        }
+        AffinePayloadIssue::InvalidEffectiveStyle => {
+            PreparedSemanticAnimationLoweringError::InvalidEffectiveStyle { animation, target }
+        }
+        AffinePayloadIssue::InvalidEffectiveReveal => {
+            PreparedSemanticAnimationLoweringError::InvalidEffectiveReveal { animation, target }
+        }
+        AffinePayloadIssue::UnsupportedContentChange => {
+            PreparedSemanticAnimationLoweringError::UnsupportedContentChange {
+                animation,
+                target,
+                target_state,
+            }
+        }
+        AffinePayloadIssue::UnsupportedPointCorrespondence => {
+            PreparedSemanticAnimationLoweringError::UnsupportedPointCorrespondence {
+                animation,
+                target,
+                target_state,
+            }
+        }
+        AffinePayloadIssue::UnsupportedStyleChange => {
+            PreparedSemanticAnimationLoweringError::UnsupportedStyleChange {
+                animation,
+                target,
+                target_state,
+            }
+        }
+        AffinePayloadIssue::UnsupportedBindingChange => {
+            PreparedSemanticAnimationLoweringError::UnsupportedBindingChange {
+                animation,
+                target,
+                target_state,
+            }
+        }
+        AffinePayloadIssue::UnsupportedDepthChange(field) => {
+            PreparedSemanticAnimationLoweringError::UnsupportedDepthChange {
+                animation,
+                target,
+                target_state,
+                field,
+            }
+        }
+        AffinePayloadIssue::UnsupportedLifecycle {
+            remover,
+            introducer,
+        } => PreparedSemanticAnimationLoweringError::UnsupportedLifecycle {
+            animation,
+            remover,
+            introducer,
+        },
+        AffinePayloadIssue::ReactiveDriverConflict(property) => {
+            PreparedSemanticAnimationLoweringError::ReactiveDriverConflict {
+                animation,
+                target,
+                property,
+            }
+        }
+        AffinePayloadIssue::InvalidTargetValue { field, error } => {
+            PreparedSemanticAnimationLoweringError::InvalidTargetValue {
+                animation,
+                target_state,
+                field,
+                error,
+            }
+        }
+        AffinePayloadIssue::TargetValueOutOfRange(field) => {
+            PreparedSemanticAnimationLoweringError::TargetValueOutOfRange {
+                animation,
+                target_state,
+                field,
+            }
+        }
+        AffinePayloadIssue::InvalidTargetStyle(error) => {
+            PreparedSemanticAnimationLoweringError::InvalidTargetStyle {
+                animation,
+                target_state,
+                error,
+            }
+        }
+    };
+    PreparedFamilyTransformChannelError::Payload(error)
+}
+
+/// Attach a stable execution-track ID at the same boundary used by ordinary prepared
+/// animation tracks. This helper exists only to make the channel projection directly
+/// consumable by the live-session activation layer without inventing another track
+/// representation there.
+pub fn materialize_family_transform_stable_track(
+    track: &PreparedSemanticAnimationTrack,
+    id: TrackId,
+) -> Result<TrackDefinition, TimelineError> {
+    track.with_track_id(id)
+}

--- a/crates/noon-compile/tests/family_transform_channels.rs
+++ b/crates/noon-compile/tests/family_transform_channels.rs
@@ -1,0 +1,222 @@
+use std::collections::HashMap;
+
+use noon_compile::{
+    lower_prepared_family_transform_channels, lower_prepared_semantic_animation_schedule,
+    prepare_family_transform_activations, EffectiveAnimationProperties,
+    PreparedFamilyTransformChannelError, SemanticExecutionIndex,
+};
+use noon_core::{
+    AnimationOptions, ObjectId, Property, RateFunction, SemanticMutationTransaction,
+    SemanticObjectState, SemanticStore, SemanticVec3, StoredGeometry, Style, TrackValues,
+    Transform2D, Vec2,
+};
+
+fn object(store: &mut SemanticStore, x: f64) -> noon_core::SemanticNodeId {
+    let mut state = SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 });
+    state.transform.translation = SemanticVec3::new(x, 0.0, 0.0);
+    store.insert_semantic_object(state)
+}
+
+fn family(
+    store: &mut SemanticStore,
+    members: &[noon_core::SemanticNodeId],
+) -> noon_core::SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+fn index(store: &SemanticStore) -> SemanticExecutionIndex {
+    let mut index = SemanticExecutionIndex::new();
+    index.lower_scene(store).unwrap();
+    index
+}
+
+fn effective(x: f32) -> EffectiveAnimationProperties {
+    EffectiveAnimationProperties {
+        z_index: 0.0,
+        transform: Transform2D {
+            translation: Vec2::new(x, 0.0),
+            ..Transform2D::IDENTITY
+        },
+        style: Style::default(),
+        appearance: 1.0,
+        reveal: 1.0,
+    }
+}
+
+fn prepared_family_transform<'a>(
+    store: &'a mut SemanticStore,
+    index: &SemanticExecutionIndex,
+    source: noon_core::SemanticNodeId,
+    target: noon_core::SemanticNodeId,
+) -> (
+    noon_core::PreparedSemanticMutationTransaction<'a>,
+    noon_compile::PreparedSemanticAnimationScheduleProjection,
+) {
+    let mut transaction = SemanticMutationTransaction::new();
+    let animation = transaction.create_family_transform_animation(
+        source,
+        target,
+        AnimationOptions::new()
+            .run_time(2.0)
+            .rate_func(RateFunction::Linear),
+    );
+    let prepared = transaction.prepare(store).unwrap();
+    let schedule = lower_prepared_semantic_animation_schedule(
+        &prepared,
+        index,
+        animation,
+        1.0,
+        AnimationOptions::new(),
+    )
+    .unwrap();
+    (prepared, schedule)
+}
+
+#[test]
+fn expansion_uses_stable_tracks_for_real_sources_and_identity_free_copy_tracks() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 0.0);
+    let s1 = object(&mut store, 2.0);
+    let t0 = object(&mut store, 1.0);
+    let t1 = object(&mut store, 3.0);
+    let t2 = object(&mut store, 5.0);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1, t2]);
+    store.attach_to_scene(source).unwrap();
+    let index = index(&store);
+    let s0_id = index.execution_object_id(s0).unwrap();
+    let s1_id = index.execution_object_id(s1).unwrap();
+    let (prepared, schedule) = prepared_family_transform(&mut store, &index, source, target);
+
+    let mut samples = HashMap::<ObjectId, usize>::new();
+    let activation = prepare_family_transform_activations(&prepared, &index, &schedule, |id| {
+        *samples.entry(id).or_default() += 1;
+        Some(if id == s0_id {
+            effective(0.0)
+        } else if id == s1_id {
+            effective(2.0)
+        } else {
+            panic!("unexpected source execution object")
+        })
+    })
+    .unwrap();
+    let projection = lower_prepared_family_transform_channels(&prepared, &activation).unwrap();
+
+    assert_eq!(samples.get(&s0_id), Some(&1));
+    assert_eq!(samples.get(&s1_id), Some(&1));
+    assert_eq!(projection.derived_occurrences().len(), 1);
+    let copy = &projection.derived_occurrences()[0];
+    assert_eq!(copy.occurrence_index, 1);
+    assert_eq!(copy.anchor_execution_object_id, s0_id);
+    assert_eq!(copy.source, s0);
+    assert_eq!(copy.target_state, t1);
+    assert_eq!(copy.effective_source, effective(0.0));
+    assert!(copy.tracks.iter().any(|track| {
+        track.property == Property::Position
+            && matches!(
+                &track.values,
+                TrackValues::Vec2 { from, to }
+                    if *from == Vec2::new(0.0, 0.0) && *to == Vec2::new(3.0, 0.0)
+            )
+    }));
+    assert!(copy.tracks.iter().any(|track| {
+        track.property == Property::Appearance
+            && matches!(
+                &track.values,
+                TrackValues::Scalar { from, to } if *from == 0.0 && *to == 1.0
+            )
+    }));
+
+    let stable_sources = projection
+        .stable_tracks()
+        .iter()
+        .filter(|track| track.property == Property::Position)
+        .map(|track| track.execution_object_id)
+        .collect::<Vec<_>>();
+    assert_eq!(stable_sources, vec![s0_id, s1_id]);
+    assert!(projection
+        .stable_tracks()
+        .iter()
+        .all(|track| track.property != Property::Appearance));
+}
+
+#[test]
+fn equal_family_uses_only_existing_stable_track_vocabulary() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 0.0);
+    let s1 = object(&mut store, 2.0);
+    let t0 = object(&mut store, 1.0);
+    let t1 = object(&mut store, 4.0);
+    let source = family(&mut store, &[s0, s1]);
+    let target = family(&mut store, &[t0, t1]);
+    store.attach_to_scene(source).unwrap();
+    let index = index(&store);
+    let s0_id = index.execution_object_id(s0).unwrap();
+    let s1_id = index.execution_object_id(s1).unwrap();
+    let (prepared, schedule) = prepared_family_transform(&mut store, &index, source, target);
+
+    let activation = prepare_family_transform_activations(&prepared, &index, &schedule, |id| {
+        Some(if id == s0_id {
+            effective(0.0)
+        } else {
+            assert_eq!(id, s1_id);
+            effective(2.0)
+        })
+    })
+    .unwrap();
+    let projection = lower_prepared_family_transform_channels(&prepared, &activation).unwrap();
+
+    assert!(projection.derived_occurrences().is_empty());
+    assert_eq!(
+        projection
+            .stable_tracks()
+            .iter()
+            .filter(|track| track.property == Property::Position)
+            .map(|track| track.execution_object_id)
+            .collect::<Vec<_>>(),
+        vec![s0_id, s1_id]
+    );
+}
+
+#[test]
+fn contraction_fails_at_explicit_effective_hold_boundary() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 0.0);
+    let s1 = object(&mut store, 2.0);
+    let s2 = object(&mut store, 4.0);
+    let t0 = object(&mut store, 1.0);
+    let t1 = object(&mut store, 5.0);
+    let source = family(&mut store, &[s0, s1, s2]);
+    let target = family(&mut store, &[t0, t1]);
+    store.attach_to_scene(source).unwrap();
+    let index = index(&store);
+    let ids = [s0, s1, s2].map(|node| index.execution_object_id(node).unwrap());
+    let (prepared, schedule) = prepared_family_transform(&mut store, &index, source, target);
+
+    let activation = prepare_family_transform_activations(&prepared, &index, &schedule, |id| {
+        let x = if id == ids[0] {
+            0.0
+        } else if id == ids[1] {
+            2.0
+        } else {
+            assert_eq!(id, ids[2]);
+            4.0
+        };
+        Some(effective(x))
+    })
+    .unwrap();
+
+    assert!(matches!(
+        lower_prepared_family_transform_channels(&prepared, &activation),
+        Err(PreparedFamilyTransformChannelError::TargetPaddingRequiresEffectiveHold {
+            source: padded_source,
+            target_state: padded_target,
+            occurrence_index: 1,
+            ..
+        }) if padded_source == s1 && padded_target == t0
+    ));
+}


### PR DESCRIPTION
## Summary

Adds the next bounded B3 layer for unequal-family `Transform`, stacked on #1431.

- lowers activation-effective family correspondence through the existing canonical `validate_affine_payload` / `lower_transform_channels` path; there is no second Transform interpolation implementation;
- keeps real source occurrences on the ordinary `PreparedSemanticAnimationTrack` vocabulary, including existing driver-conflict and authored completion behavior;
- represents repeated **source-padding** occurrences separately as identity-free derived channel bundles anchored only to their real source execution row for capture/painter provenance;
- adds the Manim-style faded-copy appearance lane (`0 -> 1`) only to the derived source-padding occurrence;
- equal-family correspondence produces only ordinary stable tracks;
- deliberately fails closed for **target-padding contraction** until its execution-only endpoint-hold policy is installed, rather than authoring padding opacity or letting ordinary `Release` pop the source visible again.

No semantic topology, `SemanticNodeId`, or stable execution `ObjectId` is allocated for padding copies. `ordered_family_leaf_pairs()` remains unchanged and strict.

## Qualification

Exact implementation before temporary-probe removal passed:

- `cargo test -p noon-compile --test family_transform_channels` — 3 passed, 0 failed;
- `cargo test -p noon-compile --test family_transform_activation` — 2 passed, 0 failed;
- `cargo fmt --all -- --check` — passed.

The temporary branch-only probe workflow has been removed from the production diff.

## Stack / remaining B3 work

Base: #1431 / `codex/b3-family-transform-activation`.

Next is the narrow contraction completion policy: retain only the padded-target **appearance** endpoint as effective execution state while canonical geometry/transform/style channels complete normally. After that, the derived-channel evaluator will materialize #1425 identity-free display rows and feed #1426 renderer-owned transient buffers. Only then will `ExecutionSession::FamilyTransformTo` switch away from its current strict equal-family expansion.

Refs #82.