### PR TITLE
Add static ArrowVectorField authoring

### DIFF
--- a/crates/noon/src/arrow_authoring.rs
+++ b/crates/noon/src/arrow_authoring.rs
@@ -261,12 +261,88 @@ impl ManimArrow {
     }
 }
 
+/// Publish several already-validated Arrow requests and one outer family in one
+/// semantic transaction. This crate-private seam lets composite authoring reuse
+/// the single Arrow implementation without exposing a second geometry path.
+pub(crate) fn create_arrow_batch_family(
+    store: Rc<RefCell<SemanticStore>>,
+    options: Vec<ManimArrowOptions>,
+) -> Result<(MobjectFamily, Vec<ManimArrow>), AuthoringError> {
+    let (family_node, committed) = {
+        let mut store_ref = store.borrow_mut();
+        let prepared = options
+            .into_iter()
+            .map(|options| options.prepare(&mut store_ref))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut paths = Vec::with_capacity(
+            prepared.len() + prepared.iter().filter(|arrow| arrow.start_tip.is_some()).count(),
+        );
+        for arrow in &prepared {
+            paths.push(arrow.end_tip.clone());
+            if let Some(path) = &arrow.start_tip {
+                paths.push(path.clone());
+            }
+        }
+
+        store_ref.with_geometry_paths(paths, |store, handles| {
+            let mut transaction = SemanticMutationTransaction::new();
+            let family = transaction.create_node(SemanticNodeCreation::family());
+            let mut staged = Vec::with_capacity(prepared.len());
+            let mut handle_index = 0usize;
+            for arrow in &prepared {
+                let end_tip_handle = handles[handle_index];
+                handle_index += 1;
+                let start_tip_handle = if arrow.start_tip.is_some() {
+                    let handle = handles[handle_index];
+                    handle_index += 1;
+                    Some(handle)
+                } else {
+                    None
+                };
+                let staged_arrow = stage_prepared_arrow(
+                    &mut transaction,
+                    arrow,
+                    end_tip_handle,
+                    start_tip_handle,
+                );
+                transaction.add_member(family, staged_arrow.family);
+                staged.push(staged_arrow);
+            }
+            debug_assert_eq!(handle_index, handles.len());
+
+            let result = transaction.apply(store).map_err(AuthoringError::from)?;
+            let family_node = result
+                .resolve(family)
+                .ok_or(AuthoringError::UnresolvedCreatedNode(family))?;
+            let committed = staged
+                .into_iter()
+                .map(|arrow| resolve_staged_arrow(arrow, |token| result.resolve(token)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok((family_node, committed))
+        })?
+    };
+
+    let family = MobjectFamily::from_node(Rc::clone(&store), family_node)?;
+    let arrows = committed
+        .into_iter()
+        .map(|arrow| ManimArrow::from_committed(Rc::clone(&store), arrow))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((family, arrows))
+}
+
 struct PreparedArrow {
     shaft: SemanticObjectState,
     end_tip: VectorPath,
     start_tip: Option<VectorPath>,
     tip_color: Color,
     z_index: f64,
+}
+
+struct StagedArrow {
+    family: noon_core::SemanticLocalNodeToken,
+    shaft: noon_core::SemanticLocalNodeToken,
+    end_tip: noon_core::SemanticLocalNodeToken,
+    start_tip: Option<noon_core::SemanticLocalNodeToken>,
 }
 
 struct CommittedArrow {
@@ -306,6 +382,22 @@ fn commit_transaction(
     start_tip_handle: Option<noon_core::GeometryResourceHandle>,
 ) -> Result<CommittedArrow, AuthoringError> {
     let mut transaction = SemanticMutationTransaction::new();
+    let staged = stage_prepared_arrow(
+        &mut transaction,
+        prepared,
+        end_tip_handle,
+        start_tip_handle,
+    );
+    let result = transaction.apply(store).map_err(AuthoringError::from)?;
+    resolve_staged_arrow(staged, |token| result.resolve(token))
+}
+
+fn stage_prepared_arrow(
+    transaction: &mut SemanticMutationTransaction,
+    prepared: &PreparedArrow,
+    end_tip_handle: noon_core::GeometryResourceHandle,
+    start_tip_handle: Option<noon_core::GeometryResourceHandle>,
+) -> StagedArrow {
     let shaft = transaction.create_node(SemanticNodeCreation::object(prepared.shaft.clone()));
     let end_tip = transaction.create_node(SemanticNodeCreation::object(tip_state(
         prepared,
@@ -323,24 +415,28 @@ fn commit_transaction(
     if let Some(start_tip) = start_tip {
         transaction.add_member(family, start_tip);
     }
+    StagedArrow {
+        family,
+        shaft,
+        end_tip,
+        start_tip,
+    }
+}
 
-    let result = transaction.apply(store).map_err(AuthoringError::from)?;
+fn resolve_staged_arrow(
+    staged: StagedArrow,
+    mut resolve: impl FnMut(noon_core::SemanticLocalNodeToken) -> Option<noon_core::SemanticNodeId>,
+) -> Result<CommittedArrow, AuthoringError> {
     Ok(CommittedArrow {
-        family: result
-            .resolve(family)
-            .ok_or(AuthoringError::UnresolvedCreatedNode(family))?,
-        shaft: result
-            .resolve(shaft)
-            .ok_or(AuthoringError::UnresolvedCreatedNode(shaft))?,
-        end_tip: result
-            .resolve(end_tip)
-            .ok_or(AuthoringError::UnresolvedCreatedNode(end_tip))?,
-        start_tip: start_tip
-            .map(|token| {
-                result
-                    .resolve(token)
-                    .ok_or(AuthoringError::UnresolvedCreatedNode(token))
-            })
+        family: resolve(staged.family)
+            .ok_or(AuthoringError::UnresolvedCreatedNode(staged.family))?,
+        shaft: resolve(staged.shaft)
+            .ok_or(AuthoringError::UnresolvedCreatedNode(staged.shaft))?,
+        end_tip: resolve(staged.end_tip)
+            .ok_or(AuthoringError::UnresolvedCreatedNode(staged.end_tip))?,
+        start_tip: staged
+            .start_tip
+            .map(|token| resolve(token).ok_or(AuthoringError::UnresolvedCreatedNode(token)))
             .transpose()?,
     })
 }

--- a/crates/noon/src/arrow_authoring.rs
+++ b/crates/noon/src/arrow_authoring.rs
@@ -284,7 +284,7 @@ pub(crate) fn create_arrow_batch_family(
             }
         }
 
-        store_ref.with_geometry_paths(paths, |store, handles| {
+        store_ref.with_geometry_paths(paths, |store, handles| -> Result<_, AuthoringError> {
             let mut transaction = SemanticMutationTransaction::new();
             let family = transaction.create_node(SemanticNodeCreation::family());
             let mut staged = Vec::with_capacity(prepared.len());
@@ -585,8 +585,6 @@ mod tests {
         )
         .unwrap();
         let (start, end) = line_endpoints(&arrow.shaft().state().unwrap());
-        // Public endpoints are +/-0.75 after buff. The 0.35 tip then moves only
-        // the retained shaft endpoint back to its base at x=0.40.
         assert!((start.x + 0.75).abs() < 1e-6);
         assert!((end.x - 0.40).abs() < 1e-6);
         assert!((arrow.shaft().state().unwrap().style.stroke_width - 0.06).abs() < 1e-12);
@@ -609,7 +607,7 @@ mod tests {
         options.set_buff(0.0).unwrap();
         let arrow = ManimArrow::create(Rc::clone(scene.integration_store()), options).unwrap();
         let (_, end) = line_endpoints(&arrow.shaft().state().unwrap());
-        assert!((end.x - 0.3).abs() < 1e-6); // 25% tip cap => 0.1
+        assert!((end.x - 0.3).abs() < 1e-6);
         assert!((arrow.shaft().state().unwrap().style.stroke_width - 0.02).abs() < 1e-12);
     }
 

--- a/crates/noon/src/arrow_authoring.rs
+++ b/crates/noon/src/arrow_authoring.rs
@@ -275,7 +275,11 @@ pub(crate) fn create_arrow_batch_family(
             .map(|options| options.prepare(&mut store_ref))
             .collect::<Result<Vec<_>, _>>()?;
         let mut paths = Vec::with_capacity(
-            prepared.len() + prepared.iter().filter(|arrow| arrow.start_tip.is_some()).count(),
+            prepared.len()
+                + prepared
+                    .iter()
+                    .filter(|arrow| arrow.start_tip.is_some())
+                    .count(),
         );
         for arrow in &prepared {
             paths.push(arrow.end_tip.clone());
@@ -299,12 +303,8 @@ pub(crate) fn create_arrow_batch_family(
                 } else {
                     None
                 };
-                let staged_arrow = stage_prepared_arrow(
-                    &mut transaction,
-                    arrow,
-                    end_tip_handle,
-                    start_tip_handle,
-                );
+                let staged_arrow =
+                    stage_prepared_arrow(&mut transaction, arrow, end_tip_handle, start_tip_handle);
                 transaction.add_member(family, staged_arrow.family);
                 staged.push(staged_arrow);
             }
@@ -382,12 +382,7 @@ fn commit_transaction(
     start_tip_handle: Option<noon_core::GeometryResourceHandle>,
 ) -> Result<CommittedArrow, AuthoringError> {
     let mut transaction = SemanticMutationTransaction::new();
-    let staged = stage_prepared_arrow(
-        &mut transaction,
-        prepared,
-        end_tip_handle,
-        start_tip_handle,
-    );
+    let staged = stage_prepared_arrow(&mut transaction, prepared, end_tip_handle, start_tip_handle);
     let result = transaction.apply(store).map_err(AuthoringError::from)?;
     resolve_staged_arrow(staged, |token| result.resolve(token))
 }
@@ -430,8 +425,7 @@ fn resolve_staged_arrow(
     Ok(CommittedArrow {
         family: resolve(staged.family)
             .ok_or(AuthoringError::UnresolvedCreatedNode(staged.family))?,
-        shaft: resolve(staged.shaft)
-            .ok_or(AuthoringError::UnresolvedCreatedNode(staged.shaft))?,
+        shaft: resolve(staged.shaft).ok_or(AuthoringError::UnresolvedCreatedNode(staged.shaft))?,
         end_tip: resolve(staged.end_tip)
             .ok_or(AuthoringError::UnresolvedCreatedNode(staged.end_tip))?,
         start_tip: staged

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -99,6 +99,7 @@ mod state_replacement;
 mod text_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_part_authoring;
+mod vector_field_authoring;
 mod z_index;
 
 pub use animation_authoring::DeclaredAnimation;
@@ -156,6 +157,10 @@ pub use noon_core::{
     RED_E, RIGHT, SMALL_BUFF, TAU, TEAL, TEAL_A, TEAL_B, TEAL_C, TEAL_D, TEAL_E, UL, UP, UR, WHITE,
     YELLOW, YELLOW_A, YELLOW_B, YELLOW_C, YELLOW_D, YELLOW_E,
 };
+pub use noon_geometry::{
+    StaticVectorFieldError, StaticVectorFieldPlan, VectorFieldAxis, VectorFieldAxisRange,
+    VectorFieldPoint, VectorFieldRanges2D, VectorFieldSample, DEFAULT_VECTOR_FIELD_STEP,
+};
 pub use noon_runtime::EvaluationError;
 pub use path_queries::PathQuery;
 pub use rotation_authoring::ManimRotationPivot;
@@ -175,18 +180,19 @@ pub use text_authoring::{
 };
 #[cfg(any(feature = "native-text", feature = "typst"))]
 pub use text_part_authoring::TextPartAuthoringError;
+pub use vector_field_authoring::{ArrowVectorFieldAuthoringError, ManimArrowVectorField};
 
 /// Common imports for direct typed semantic authoring and live publication.
 /// Host integration and mutable arena access must be imported explicitly.
 pub mod prelude {
     pub use crate::{
-        AnimationOptions, AuthoringError, BooleanOperation, Color, ContinuationStep,
-        DeclaredAnimation, DrawBorderThenFillOptions, EffectiveMobjectState, ExecutionSession,
-        FadeEndpoint, FadeTranslation, LiveContinuation, LiveProgram, LiveSession,
-        LiveSessionError, ManimArrow, ManimArrowOptions, Mobject, MobjectFamily,
-        MobjectFamilyMember, NativeBoolSignal, NativeVectorSignal, RateFunction, Scene,
-        SemanticObjectState, SemanticStyle, StoredGeometry, TrackerPosition, ValueTracker, Vec2,
-        VectorPath,
+        AnimationOptions, ArrowVectorFieldAuthoringError, AuthoringError, BooleanOperation, Color,
+        ContinuationStep, DeclaredAnimation, DrawBorderThenFillOptions, EffectiveMobjectState,
+        ExecutionSession, FadeEndpoint, FadeTranslation, LiveContinuation, LiveProgram,
+        LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions, ManimArrowVectorField, Mobject,
+        MobjectFamily, MobjectFamilyMember, NativeBoolSignal, NativeVectorSignal, RateFunction,
+        Scene, SemanticObjectState, SemanticStyle, StoredGeometry, TrackerPosition, ValueTracker,
+        Vec2, VectorFieldAxisRange, VectorFieldPoint, VectorFieldRanges2D, VectorPath,
     };
 }
 

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -158,8 +158,8 @@ pub use noon_core::{
     YELLOW, YELLOW_A, YELLOW_B, YELLOW_C, YELLOW_D, YELLOW_E,
 };
 pub use noon_geometry::{
-    StaticVectorFieldError, StaticVectorFieldPlan, VectorFieldAxis, VectorFieldAxisRange,
-    VectorFieldPoint, VectorFieldRanges2D, VectorFieldSample, DEFAULT_VECTOR_FIELD_STEP,
+    StaticVectorFieldError, VectorFieldAxis, VectorFieldAxisRange, VectorFieldPoint,
+    VectorFieldRanges2D, DEFAULT_VECTOR_FIELD_STEP,
 };
 pub use noon_runtime::EvaluationError;
 pub use path_queries::PathQuery;

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -189,10 +189,11 @@ pub mod prelude {
         AnimationOptions, ArrowVectorFieldAuthoringError, AuthoringError, BooleanOperation, Color,
         ContinuationStep, DeclaredAnimation, DrawBorderThenFillOptions, EffectiveMobjectState,
         ExecutionSession, FadeEndpoint, FadeTranslation, LiveContinuation, LiveProgram,
-        LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions, ManimArrowVectorField, Mobject,
-        MobjectFamily, MobjectFamilyMember, NativeBoolSignal, NativeVectorSignal, RateFunction,
-        Scene, SemanticObjectState, SemanticStyle, StoredGeometry, TrackerPosition, ValueTracker,
-        Vec2, VectorFieldAxisRange, VectorFieldPoint, VectorFieldRanges2D, VectorPath,
+        LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions, ManimArrowVectorField,
+        Mobject, MobjectFamily, MobjectFamilyMember, NativeBoolSignal, NativeVectorSignal,
+        RateFunction, Scene, SemanticObjectState, SemanticStyle, StoredGeometry, TrackerPosition,
+        ValueTracker, Vec2, VectorFieldAxisRange, VectorFieldPoint, VectorFieldRanges2D,
+        VectorPath,
     };
 }
 

--- a/crates/noon/src/vector_field_authoring.rs
+++ b/crates/noon/src/vector_field_authoring.rs
@@ -1,0 +1,323 @@
+//! Static Manim-style ArrowVectorField authoring over shared Arrow families.
+//!
+//! Field callbacks are evaluated once during authoring by `noon-geometry`'s
+//! deterministic planner. The prepared samples are then published atomically as
+//! ordinary nested semantic families. No callback, runtime loop, or renderer-owned
+//! vector-field model survives construction.
+
+use crate::arrow_authoring::create_arrow_batch_family;
+use crate::{AuthoringError, ManimArrow, ManimArrowOptions, MobjectFamily};
+use noon_core::{Color, SemanticStore, BLUE_E, GREEN, RED, YELLOW};
+use noon_geometry::{
+    plan_static_arrow_vector_field, plan_static_arrow_vector_field_with_length,
+    StaticVectorFieldError, StaticVectorFieldPlan, VectorFieldPoint, VectorFieldRanges2D,
+};
+use std::{cell::RefCell, fmt, rc::Rc};
+
+const DEFAULT_MIN_COLOR_SCHEME_VALUE: f64 = 0.0;
+const DEFAULT_MAX_COLOR_SCHEME_VALUE: f64 = 2.0;
+
+/// Error from deterministic static ArrowVectorField preparation or semantic publication.
+#[derive(Debug)]
+pub enum ArrowVectorFieldAuthoringError {
+    Planning(StaticVectorFieldError),
+    Authoring(AuthoringError),
+}
+
+impl fmt::Display for ArrowVectorFieldAuthoringError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Planning(error) => write!(formatter, "static vector-field planning failed: {error}"),
+            Self::Authoring(error) => write!(formatter, "static vector-field authoring failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ArrowVectorFieldAuthoringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Planning(error) => Some(error),
+            Self::Authoring(error) => Some(error),
+        }
+    }
+}
+
+impl From<StaticVectorFieldError> for ArrowVectorFieldAuthoringError {
+    fn from(value: StaticVectorFieldError) -> Self {
+        Self::Planning(value)
+    }
+}
+
+impl From<AuthoringError> for ArrowVectorFieldAuthoringError {
+    fn from(value: AuthoringError) -> Self {
+        Self::Authoring(value)
+    }
+}
+
+/// One static ArrowVectorField authored as an outer family of ordinary Vector families.
+///
+/// This slice implements pinned ManimCE v0.21 default length and default norm-color
+/// behavior for explicit 2D ranges. Dynamic StreamLines/updaters are deliberately not
+/// part of this type.
+#[derive(Clone, Debug)]
+pub struct ManimArrowVectorField {
+    family: MobjectFamily,
+    vectors: Vec<ManimArrow>,
+}
+
+impl ManimArrowVectorField {
+    /// Evaluate `field` once over the deterministic shared planner and publish the
+    /// resulting default-styled Vector families atomically.
+    pub fn create<F>(
+        store: Rc<RefCell<SemanticStore>>,
+        field: F,
+        ranges: VectorFieldRanges2D,
+    ) -> Result<Self, ArrowVectorFieldAuthoringError>
+    where
+        F: FnMut(VectorFieldPoint) -> VectorFieldPoint,
+    {
+        let plan = plan_static_arrow_vector_field(field, ranges)?;
+        Self::from_plan(store, &plan)
+    }
+
+    /// Variant of [`Self::create`] using an explicit displayed-length mapper.
+    ///
+    /// The mapper is still evaluated only during authoring and is not retained as
+    /// runtime or renderer behavior.
+    pub fn create_with_length<F, L>(
+        store: Rc<RefCell<SemanticStore>>,
+        field: F,
+        ranges: VectorFieldRanges2D,
+        length: L,
+    ) -> Result<Self, ArrowVectorFieldAuthoringError>
+    where
+        F: FnMut(VectorFieldPoint) -> VectorFieldPoint,
+        L: FnMut(f64) -> f64,
+    {
+        let plan = plan_static_arrow_vector_field_with_length(field, ranges, length)?;
+        Self::from_plan(store, &plan)
+    }
+
+    pub fn family(&self) -> &MobjectFamily {
+        &self.family
+    }
+
+    pub fn vectors(&self) -> &[ManimArrow] {
+        &self.vectors
+    }
+
+    fn from_plan(
+        store: Rc<RefCell<SemanticStore>>,
+        plan: &StaticVectorFieldPlan,
+    ) -> Result<Self, ArrowVectorFieldAuthoringError> {
+        // Build every inert Arrow request before touching the semantic store. The
+        // batch seam then preflights every Arrow and admits all tip resources before
+        // one transaction publishes the nested field family.
+        let mut options = Vec::with_capacity(plan.samples.len());
+        for sample in &plan.samples {
+            let mut vector = ManimArrowOptions::vector(
+                sample.display_vector.x,
+                sample.display_vector.y,
+            )?;
+            vector.set_translation(sample.point.x, sample.point.y)?;
+            let color = default_vector_field_color(sample.raw_norm);
+            vector.set_color(
+                f64::from(color.red),
+                f64::from(color.green),
+                f64::from(color.blue),
+                1.0,
+            )?;
+            options.push(vector);
+        }
+
+        let (family, vectors) = create_arrow_batch_family(store, options)?;
+        Ok(Self { family, vectors })
+    }
+}
+
+/// Pinned ManimCE v0.21 default `VectorField.pos_to_color` for the default
+/// norm-based scheme and `[BLUE_E, GREEN, YELLOW, RED]` gradient.
+fn default_vector_field_color(norm: f64) -> Color {
+    debug_assert!(norm.is_finite() && norm >= 0.0);
+    let colors = [BLUE_E, GREEN, YELLOW, RED];
+    let value = norm.clamp(
+        DEFAULT_MIN_COLOR_SCHEME_VALUE,
+        DEFAULT_MAX_COLOR_SCHEME_VALUE,
+    );
+    let mut scaled = (value - DEFAULT_MIN_COLOR_SCHEME_VALUE)
+        / (DEFAULT_MAX_COLOR_SCHEME_VALUE - DEFAULT_MIN_COLOR_SCHEME_VALUE);
+    scaled *= (colors.len() - 1) as f64;
+    let index = (scaled as usize).min(colors.len() - 1);
+    let next = (index + 1).min(colors.len() - 1);
+    let alpha = scaled % 1.0;
+    let interpolate = |left: f32, right: f32| {
+        (f64::from(left) + (f64::from(right) - f64::from(left)) * alpha) as f32
+    };
+    Color::rgb(
+        interpolate(colors[index].red, colors[next].red),
+        interpolate(colors[index].green, colors[next].green),
+        interpolate(colors[index].blue, colors[next].blue),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Scene;
+    use noon_core::{SemanticPaint, SemanticVec3};
+    use noon_geometry::VectorFieldAxisRange;
+
+    fn ranges(x: VectorFieldAxisRange, y: VectorFieldAxisRange) -> VectorFieldRanges2D {
+        VectorFieldRanges2D::new(x, y)
+    }
+
+    fn stroke_color(vector: &ManimArrow) -> Color {
+        match vector.shaft().state().unwrap().style.stroke {
+            Some(SemanticPaint::Solid(color)) => color,
+            other => panic!("vector shaft must retain one solid stroke, got {other:?}"),
+        }
+    }
+
+    fn assert_color_close(actual: Color, expected: Color) {
+        assert!((actual.red - expected.red).abs() < 1e-6);
+        assert!((actual.green - expected.green).abs() < 1e-6);
+        assert!((actual.blue - expected.blue).abs() < 1e-6);
+        assert!((actual.alpha - expected.alpha).abs() < 1e-6);
+    }
+
+    #[test]
+    fn static_field_publishes_ordered_nested_vector_families() {
+        let scene = Scene::new();
+        let field = ManimArrowVectorField::create(
+            Rc::clone(scene.integration_store()),
+            |point| VectorFieldPoint::new(point.x + 1.0, point.y),
+            ranges(
+                VectorFieldAxisRange::new(0.0, 1.0, 1.0),
+                VectorFieldAxisRange::new(0.0, 1.0, 1.0),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(field.vectors().len(), 4);
+        let direct_members = scene
+            .integration_store()
+            .borrow()
+            .semantic_family_members_checked(field.family().node_id())
+            .unwrap();
+        assert_eq!(
+            direct_members,
+            field
+                .vectors()
+                .iter()
+                .map(|vector| vector.family().node_id())
+                .collect::<Vec<_>>()
+        );
+
+        let translations = field
+            .vectors()
+            .iter()
+            .map(|vector| vector.shaft().state().unwrap().transform.translation)
+            .collect::<Vec<SemanticVec3>>();
+        assert_eq!(
+            translations,
+            vec![
+                SemanticVec3::new(0.0, 0.0, 0.0),
+                SemanticVec3::new(0.0, 1.0, 0.0),
+                SemanticVec3::new(1.0, 0.0, 0.0),
+                SemanticVec3::new(1.0, 1.0, 0.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_norm_colors_match_pinned_gradient_endpoints_and_midpoint() {
+        let scene = Scene::new();
+        let field = ManimArrowVectorField::create(
+            Rc::clone(scene.integration_store()),
+            |point| VectorFieldPoint::new(point.x, 0.0),
+            ranges(
+                VectorFieldAxisRange::new(0.0, 2.0, 1.0),
+                VectorFieldAxisRange::new(0.0, 0.0, 1.0),
+            ),
+        )
+        .unwrap();
+
+        assert_color_close(stroke_color(&field.vectors()[0]), BLUE_E);
+        let midpoint = Color::rgb(
+            (GREEN.red + YELLOW.red) * 0.5,
+            (GREEN.green + YELLOW.green) * 0.5,
+            (GREEN.blue + YELLOW.blue) * 0.5,
+        );
+        assert_color_close(stroke_color(&field.vectors()[1]), midpoint);
+        assert_color_close(stroke_color(&field.vectors()[2]), RED);
+    }
+
+    #[test]
+    fn planning_failure_publishes_no_semantic_identity_or_tip_resource() {
+        let scene = Scene::new();
+        let before_nodes = scene.integration_store().borrow().len();
+        let before_revision = scene.integration_store().borrow().scene_revision();
+        let before_resources = scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .stats();
+
+        let result = ManimArrowVectorField::create(
+            Rc::clone(scene.integration_store()),
+            |point| {
+                if point.x == 0.0 {
+                    VectorFieldPoint::new(1.0, 0.0)
+                } else {
+                    VectorFieldPoint::new(f64::NAN, 0.0)
+                }
+            },
+            ranges(
+                VectorFieldAxisRange::new(0.0, 1.0, 1.0),
+                VectorFieldAxisRange::new(0.0, 0.0, 1.0),
+            ),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ArrowVectorFieldAuthoringError::Planning(
+                StaticVectorFieldError::NonFiniteFieldOutput { sample_index: 1 }
+            ))
+        ));
+        assert_eq!(scene.integration_store().borrow().len(), before_nodes);
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            before_revision
+        );
+        assert_eq!(
+            scene
+                .integration_store()
+                .borrow()
+                .geometry_resources()
+                .stats(),
+            before_resources
+        );
+    }
+
+    #[test]
+    fn empty_static_field_is_one_empty_semantic_family() {
+        let scene = Scene::new();
+        let field = ManimArrowVectorField::create(
+            Rc::clone(scene.integration_store()),
+            |_| VectorFieldPoint::new(1.0, 0.0),
+            ranges(
+                VectorFieldAxisRange::new(1.0, 0.0, 1.0),
+                VectorFieldAxisRange::new(0.0, 0.0, 1.0),
+            ),
+        )
+        .unwrap();
+
+        assert!(field.vectors().is_empty());
+        assert!(scene
+            .integration_store()
+            .borrow()
+            .semantic_family_members_checked(field.family().node_id())
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/noon/src/vector_field_authoring.rs
+++ b/crates/noon/src/vector_field_authoring.rs
@@ -27,8 +27,12 @@ pub enum ArrowVectorFieldAuthoringError {
 impl fmt::Display for ArrowVectorFieldAuthoringError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Planning(error) => write!(formatter, "static vector-field planning failed: {error}"),
-            Self::Authoring(error) => write!(formatter, "static vector-field authoring failed: {error}"),
+            Self::Planning(error) => {
+                write!(formatter, "static vector-field planning failed: {error}")
+            }
+            Self::Authoring(error) => {
+                write!(formatter, "static vector-field authoring failed: {error}")
+            }
         }
     }
 }
@@ -115,10 +119,8 @@ impl ManimArrowVectorField {
         // one transaction publishes the nested field family.
         let mut options = Vec::with_capacity(plan.samples.len());
         for sample in &plan.samples {
-            let mut vector = ManimArrowOptions::vector(
-                sample.display_vector.x,
-                sample.display_vector.y,
-            )?;
+            let mut vector =
+                ManimArrowOptions::vector(sample.display_vector.x, sample.display_vector.y)?;
             vector.set_translation(sample.point.x, sample.point.y)?;
             let color = default_vector_field_color(sample.raw_norm);
             vector.set_color(


### PR DESCRIPTION
Advances #88 under #85/#954 by connecting the merged #1433 deterministic vector-field planner to the shared #1411 Arrow/Vector semantic authoring path.

This slice adds shared Rust `ManimArrowVectorField` authoring for explicit 2D ranges. Field and optional length callbacks are evaluated once during authoring by `noon-geometry`; no callback, runtime loop, or renderer-owned vector-field model survives construction. Prepared samples preserve the planner's pinned ManimCE v0.21 range/order/length semantics, lower each displayed vector through the existing `ManimArrowOptions::vector` implementation, root it at the sampled point, and apply the pinned default norm color mapping (`min=0`, `max=2`, `[BLUE_E, GREEN, YELLOW, RED]`).

Publication is one atomic semantic operation: a crate-private batch seam reuses the existing Arrow preparation/geometry logic, admits every tip path through `SemanticStore::with_geometry_paths`, stages every ordinary Vector family plus one outer field family in one `SemanticMutationTransaction`, and resolves normal semantic handles only after commit. Preparation failures occur before publication; resource/publication failures roll back the unpublished geometry batch through the existing store contract. There is no second identity or vector-field scene model.

Focused tests cover stable nested family/sample order and rooted translations, default norm-gradient endpoints/interpolation, planning-failure atomicity, and empty-field family behavior. Existing Arrow tests remain unchanged semantically; the single-arrow path now shares the same staging helper as the batch path.

Boundary: shared Rust static authoring only. This does not add Python/Web facades, StreamLines/dynamic callbacks, renderer changes, custom `color_scheme`/color lists/single-color options, frame-derived default ranges, or any #1416/#78 work. It does not mark ArrowVectorField supported. Source-equivalent ManimCE v0.21 fixtures plus geometry/state and WebGPU/WebGL raster parity through #185 remain required before capability promotion.

Qualified against current master `222a8b60c9d20e3338267b05f3712931ba28ad03`; intervening changes from the branch base are MCP/agent-preview-only and do not touch `crates/noon`.