### PR TITLE
Retain contraction padding appearance as effective state

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
@@ -8,7 +8,7 @@ use noon_core::{
 
 use super::affine::{
     completion_at_endpoint, driver_key, lower_transform_channels, transform_driver_conflict,
-    validate_affine_payload, AffinePayloadIssue,
+    validate_affine_payload, AffinePayloadIssue, LoweredAffineChannel, SemanticAnimationCompletion,
 };
 use super::family_transform_activation::{
     PreparedFamilyTransformActivationProjection, PreparedFamilyTransformOccurrence,
@@ -16,6 +16,19 @@ use super::family_transform_activation::{
 use super::prepared_composition::{
     PreparedSemanticAnimationLoweringError, PreparedSemanticAnimationTrack,
 };
+
+/// One ordinary stable-source family Transform track plus its completion policy.
+///
+/// `retain_effective` is execution-session release metadata, not authored animation
+/// meaning. It is used only for a real source occurrence that maps to a padded target:
+/// the padding fade has no authored property to receive its endpoint, so completion
+/// must leave that exact presentation value effective instead of reconciling it to
+/// the stable row's base appearance.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedFamilyTransformStableTrack {
+    pub track: PreparedSemanticAnimationTrack,
+    pub retain_effective: bool,
+}
 
 /// One identity-free execution channel for a repeated source occurrence.
 ///
@@ -52,12 +65,12 @@ pub struct PreparedDerivedFamilyTransformOccurrence {
 /// the stable object-slot domain.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct PreparedFamilyTransformChannelProjection {
-    stable_tracks: Vec<PreparedSemanticAnimationTrack>,
+    stable_tracks: Vec<PreparedFamilyTransformStableTrack>,
     derived_occurrences: Vec<PreparedDerivedFamilyTransformOccurrence>,
 }
 
 impl PreparedFamilyTransformChannelProjection {
-    pub fn stable_tracks(&self) -> &[PreparedSemanticAnimationTrack] {
+    pub fn stable_tracks(&self) -> &[PreparedFamilyTransformStableTrack] {
         &self.stable_tracks
     }
 
@@ -84,17 +97,6 @@ pub enum PreparedFamilyTransformChannelError {
         target: SemanticNodeId,
         property: SemanticObjectProperty,
     },
-    /// Contraction requires the padded target's transparent endpoint to remain an
-    /// execution/effective state without becoming authored opacity. The existing
-    /// completion path reconciles `Release` tracks back to authored base state, so
-    /// this shape remains fail-closed until the effective-hold completion contract is
-    /// introduced.
-    TargetPaddingRequiresEffectiveHold {
-        animation: SemanticTransactionNodeRef,
-        source: SemanticNodeId,
-        target_state: SemanticNodeId,
-        occurrence_index: u32,
-    },
 }
 
 impl std::fmt::Display for PreparedFamilyTransformChannelError {
@@ -120,19 +122,6 @@ impl std::fmt::Display for PreparedFamilyTransformChannelError {
                 target.slot(),
                 target.generation()
             ),
-            Self::TargetPaddingRequiresEffectiveHold {
-                animation,
-                source,
-                target_state,
-                occurrence_index,
-            } => write!(
-                formatter,
-                "prepared family Transform {animation:?} contraction occurrence {occurrence_index} maps source {}:{} to padded target {}:{}; execution-only endpoint holding is not available yet",
-                source.slot(),
-                source.generation(),
-                target_state.slot(),
-                target_state.generation()
-            ),
         }
     }
 }
@@ -142,7 +131,7 @@ impl std::error::Error for PreparedFamilyTransformChannelError {
         match self {
             Self::Target { error, .. } => Some(error),
             Self::Payload(error) => Some(error),
-            Self::MultipleDrivers { .. } | Self::TargetPaddingRequiresEffectiveHold { .. } => None,
+            Self::MultipleDrivers { .. } => None,
         }
     }
 }
@@ -150,15 +139,18 @@ impl std::error::Error for PreparedFamilyTransformChannelError {
 /// Lower activation-effective family correspondence through the canonical Transform
 /// payload lowerer.
 ///
-/// Expansion is fully represented here: real source leaves become ordinary stable
-/// execution tracks, while repeated source occurrences receive identity-free derived
-/// channels plus a 0→1 appearance ramp matching Manim's faded padding copy. The
-/// function is pure and publishes nothing.
+/// Real source leaves become ordinary stable execution tracks. Repeated source
+/// occurrences receive identity-free derived channels. Manim's alignment fade is
+/// represented in the execution-only Appearance domain:
 ///
-/// Contraction remains explicitly rejected when correspondence introduces a padded
-/// target occurrence. Persisting that transparent endpoint in effective execution
-/// state requires a completion mode distinct from ordinary `Release`, which would
-/// otherwise restore authored visibility immediately after segment completion.
+/// - source padding starts at appearance 0;
+/// - target padding ends at appearance 0;
+/// - a real target ends at appearance 1.
+///
+/// For a real source mapping to target padding, the appearance channel is marked
+/// `retain_effective`; the session completion layer must keep only that presentation
+/// endpoint while canonical geometry/transform/style channels complete normally.
+/// This function remains pure and publishes nothing.
 pub fn lower_prepared_family_transform_channels(
     prepared: &PreparedSemanticMutationTransaction<'_>,
     activation: &PreparedFamilyTransformActivationProjection,
@@ -168,17 +160,6 @@ pub fn lower_prepared_family_transform_channels(
     let mut driven = HashMap::<(u64, u8), SemanticTransactionNodeRef>::new();
 
     for occurrence in activation.occurrences() {
-        if occurrence.target_padding {
-            return Err(
-                PreparedFamilyTransformChannelError::TargetPaddingRequiresEffectiveHold {
-                    animation: occurrence.animation,
-                    source: occurrence.source,
-                    target_state: occurrence.target_state,
-                    occurrence_index: occurrence.occurrence_index,
-                },
-            );
-        }
-
         let source_ref: SemanticTransactionNodeRef = occurrence.source.into();
         let target_ref: SemanticTransactionNodeRef = occurrence.target_state.into();
         let source = prepared.object_state(source_ref).map_err(|error| {
@@ -207,6 +188,7 @@ pub fn lower_prepared_family_transform_channels(
         )
         .map_err(|issue| payload_error(occurrence, issue))?;
 
+        let target_appearance = if occurrence.target_padding { 0.0 } else { 1.0 };
         if occurrence.source_padding {
             let mut tracks = channels
                 .into_iter()
@@ -223,7 +205,10 @@ pub fn lower_prepared_family_transform_channels(
                 occurrence_index: occurrence.occurrence_index,
                 anchor_execution_object_id: occurrence.source_execution_object_id,
                 property: Property::Appearance,
-                values: TrackValues::Scalar { from: 0.0, to: 1.0 },
+                values: TrackValues::Scalar {
+                    from: 0.0,
+                    to: target_appearance,
+                },
                 timing: occurrence.timing,
                 time_map: occurrence.time_map.clone(),
             });
@@ -239,7 +224,24 @@ pub fn lower_prepared_family_transform_channels(
         }
 
         for channel in channels {
-            push_stable_channel(occurrence, channel, &mut driven, &mut stable_tracks)?;
+            push_stable_channel(occurrence, channel, false, &mut driven, &mut stable_tracks)?;
+        }
+        if occurrence.effective_source.appearance != target_appearance {
+            push_stable_channel(
+                occurrence,
+                LoweredAffineChannel {
+                    property: Property::Appearance,
+                    conflict_property: SemanticObjectProperty::Presence,
+                    completion: SemanticAnimationCompletion::Release,
+                    values: TrackValues::Scalar {
+                        from: occurrence.effective_source.appearance,
+                        to: target_appearance,
+                    },
+                },
+                occurrence.target_padding,
+                &mut driven,
+                &mut stable_tracks,
+            )?;
         }
     }
 
@@ -251,9 +253,10 @@ pub fn lower_prepared_family_transform_channels(
 
 fn push_stable_channel(
     occurrence: &PreparedFamilyTransformOccurrence,
-    channel: super::affine::LoweredAffineChannel,
+    channel: LoweredAffineChannel,
+    retain_effective: bool,
     driven: &mut HashMap<(u64, u8), SemanticTransactionNodeRef>,
-    tracks: &mut Vec<PreparedSemanticAnimationTrack>,
+    tracks: &mut Vec<PreparedFamilyTransformStableTrack>,
 ) -> Result<(), PreparedFamilyTransformChannelError> {
     if let Some(first_animation) = transform_driver_conflict(
         driven,
@@ -285,15 +288,18 @@ fn push_stable_channel(
         }
     }
 
-    tracks.push(PreparedSemanticAnimationTrack {
-        animation: occurrence.animation,
-        target: occurrence.source.into(),
-        execution_object_id: occurrence.source_execution_object_id,
-        property: channel.property,
-        completion: completion_at_endpoint(channel.completion, occurrence.timing.easing),
-        values: channel.values,
-        timing: occurrence.timing,
-        time_map: occurrence.time_map.clone(),
+    tracks.push(PreparedFamilyTransformStableTrack {
+        track: PreparedSemanticAnimationTrack {
+            animation: occurrence.animation,
+            target: occurrence.source.into(),
+            execution_object_id: occurrence.source_execution_object_id,
+            property: channel.property,
+            completion: completion_at_endpoint(channel.completion, occurrence.timing.easing),
+            values: channel.values,
+            timing: occurrence.timing,
+            time_map: occurrence.time_map.clone(),
+        },
+        retain_effective,
     });
     Ok(())
 }
@@ -397,8 +403,8 @@ fn payload_error(
 /// consumable by the live-session activation layer without inventing another track
 /// representation there.
 pub fn materialize_family_transform_stable_track(
-    track: &PreparedSemanticAnimationTrack,
+    track: &PreparedFamilyTransformStableTrack,
     id: TrackId,
 ) -> Result<TrackDefinition, TimelineError> {
-    track.with_track_id(id)
+    track.track.with_track_id(id)
 }

--- a/crates/noon-compile/tests/family_transform_channels.rs
+++ b/crates/noon-compile/tests/family_transform_channels.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 
 use noon_compile::{
     lower_prepared_family_transform_channels, lower_prepared_semantic_animation_schedule,
-    prepare_family_transform_activations, EffectiveAnimationProperties,
-    PreparedFamilyTransformChannelError, SemanticExecutionIndex,
+    prepare_family_transform_activations, EffectiveAnimationProperties, SemanticExecutionIndex,
 };
 use noon_core::{
     AnimationOptions, ObjectId, Property, RateFunction, SemanticMutationTransaction,
@@ -35,6 +34,10 @@ fn index(store: &SemanticStore) -> SemanticExecutionIndex {
 }
 
 fn effective(x: f32) -> EffectiveAnimationProperties {
+    effective_with_appearance(x, 1.0)
+}
+
+fn effective_with_appearance(x: f32, appearance: f32) -> EffectiveAnimationProperties {
     EffectiveAnimationProperties {
         z_index: 0.0,
         transform: Transform2D {
@@ -42,7 +45,7 @@ fn effective(x: f32) -> EffectiveAnimationProperties {
             ..Transform2D::IDENTITY
         },
         style: Style::default(),
-        appearance: 1.0,
+        appearance,
         reveal: 1.0,
     }
 }
@@ -134,14 +137,18 @@ fn expansion_uses_stable_tracks_for_real_sources_and_identity_free_copy_tracks()
     let stable_sources = projection
         .stable_tracks()
         .iter()
-        .filter(|track| track.property == Property::Position)
-        .map(|track| track.execution_object_id)
+        .filter(|stable| stable.track.property == Property::Position)
+        .map(|stable| stable.track.execution_object_id)
         .collect::<Vec<_>>();
     assert_eq!(stable_sources, vec![s0_id, s1_id]);
     assert!(projection
         .stable_tracks()
         .iter()
-        .all(|track| track.property != Property::Appearance));
+        .all(|stable| !stable.retain_effective));
+    assert!(projection
+        .stable_tracks()
+        .iter()
+        .all(|stable| stable.track.property != Property::Appearance));
 }
 
 #[test]
@@ -175,15 +182,19 @@ fn equal_family_uses_only_existing_stable_track_vocabulary() {
         projection
             .stable_tracks()
             .iter()
-            .filter(|track| track.property == Property::Position)
-            .map(|track| track.execution_object_id)
+            .filter(|stable| stable.track.property == Property::Position)
+            .map(|stable| stable.track.execution_object_id)
             .collect::<Vec<_>>(),
         vec![s0_id, s1_id]
     );
+    assert!(projection
+        .stable_tracks()
+        .iter()
+        .all(|stable| !stable.retain_effective));
 }
 
 #[test]
-fn contraction_fails_at_explicit_effective_hold_boundary() {
+fn contraction_retains_only_the_padded_target_appearance_endpoint() {
     let mut store = SemanticStore::new();
     let s0 = object(&mut store, 0.0);
     let s1 = object(&mut store, 2.0);
@@ -209,14 +220,71 @@ fn contraction_fails_at_explicit_effective_hold_boundary() {
         Some(effective(x))
     })
     .unwrap();
+    let projection = lower_prepared_family_transform_channels(&prepared, &activation).unwrap();
 
+    assert!(projection.derived_occurrences().is_empty());
+    let appearance = projection
+        .stable_tracks()
+        .iter()
+        .find(|stable| {
+            stable.track.execution_object_id == ids[1]
+                && stable.track.property == Property::Appearance
+        })
+        .expect("padded target owns an execution-only appearance track");
+    assert!(appearance.retain_effective);
     assert!(matches!(
-        lower_prepared_family_transform_channels(&prepared, &activation),
-        Err(PreparedFamilyTransformChannelError::TargetPaddingRequiresEffectiveHold {
-            source: padded_source,
-            target_state: padded_target,
-            occurrence_index: 1,
-            ..
-        }) if padded_source == s1 && padded_target == t0
+        &appearance.track.values,
+        TrackValues::Scalar { from, to } if *from == 1.0 && *to == 0.0
+    ));
+
+    let padded_position = projection
+        .stable_tracks()
+        .iter()
+        .find(|stable| {
+            stable.track.execution_object_id == ids[1]
+                && stable.track.property == Property::Position
+        })
+        .expect("real source still transforms toward the padded target copy");
+    assert!(!padded_position.retain_effective);
+    assert!(matches!(
+        &padded_position.track.values,
+        TrackValues::Vec2 { from, to }
+            if *from == Vec2::new(2.0, 0.0) && *to == Vec2::new(1.0, 0.0)
+    ));
+    assert!(projection
+        .stable_tracks()
+        .iter()
+        .filter(|stable| stable.track.property != Property::Appearance)
+        .all(|stable| !stable.retain_effective));
+}
+
+#[test]
+fn previously_hidden_real_source_restores_appearance_for_real_target() {
+    let mut store = SemanticStore::new();
+    let source_leaf = object(&mut store, 0.0);
+    let target_leaf = object(&mut store, 2.0);
+    let source = family(&mut store, &[source_leaf]);
+    let target = family(&mut store, &[target_leaf]);
+    store.attach_to_scene(source).unwrap();
+    let index = index(&store);
+    let source_id = index.execution_object_id(source_leaf).unwrap();
+    let (prepared, schedule) = prepared_family_transform(&mut store, &index, source, target);
+
+    let activation = prepare_family_transform_activations(&prepared, &index, &schedule, |id| {
+        assert_eq!(id, source_id);
+        Some(effective_with_appearance(0.0, 0.0))
+    })
+    .unwrap();
+    let projection = lower_prepared_family_transform_channels(&prepared, &activation).unwrap();
+
+    let appearance = projection
+        .stable_tracks()
+        .iter()
+        .find(|stable| stable.track.property == Property::Appearance)
+        .expect("a previously hidden real source must fade back in for a real target");
+    assert!(!appearance.retain_effective);
+    assert!(matches!(
+        &appearance.track.values,
+        TrackValues::Scalar { from, to } if *from == 0.0 && *to == 1.0
     ));
 }


### PR DESCRIPTION
## Summary

Adds the bounded unequal-family Transform contraction policy on top of #1436.

- real source leaves continue to use canonical Transform geometry/affine/style channels;
- when correspondence maps a real source to a padded target copy, only an execution-domain `Appearance 1 -> 0` channel represents that padding fade;
- that appearance channel is marked `retain_effective`; canonical geometry/transform/style channels keep ordinary authored completion behavior;
- a later Transform that maps a previously hidden real source to a real target naturally emits `Appearance 0 -> 1` with ordinary completion;
- repeated source padding remains identity-free derived display data.

The retain marker is execution-release metadata, not semantic animation meaning: no authored opacity, membership, node identity, or topology is created for alignment padding.

## Qualification

Exact production content passed before workflow cleanup:

- `cargo test -p noon-compile --test family_transform_channels` — 4 passed;
- `cargo test -p noon-compile --test family_transform_activation` — 2 passed;
- `cargo clippy -p noon-compile --tests -- -D warnings` — passed;
- `cargo fmt --all -- --check` — passed after the formatter-only correction.

The branch has been reconstructed as one production commit `be70c498224952335ffa25dd2b402473d44b8b43` directly on #1436; temporary diagnostic workflows are absent.

## Remaining integration

The child session layer supplies the generic `retain_effective` release policy, and the derived-evaluator layer evaluates source-padding copies outside stable `FrameState.objects`. `ExecutionSession::FamilyTransformTo` remains on the strict equal-family expansion until those pieces are wired and qualified together.

Refs #82.