### PR TITLE
Retain execution-only presentation endpoints at completion

### DIFF
--- a/crates/noon/src/execution_segment.rs
+++ b/crates/noon/src/execution_segment.rs
@@ -45,6 +45,10 @@ pub(crate) struct SegmentCompletionEntry {
     pub property: Property,
     pub track: TrackId,
     pub end_time: f64,
+    /// Keep this execution endpoint authoritative instead of reconciling the track
+    /// back to authored base state at segment completion. Used only for derived/
+    /// presentation state with no authored field to receive the endpoint.
+    pub retain_effective: bool,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -1219,6 +1219,7 @@ impl ExecutionSession {
                 property: track.property,
                 track: track_id,
                 end_time,
+                retain_effective: false,
             });
             definitions.push(definition);
             next_track_id = raw_id.checked_add(1);
@@ -3243,6 +3244,7 @@ impl ExecutionSession {
                             property,
                             track,
                             end_time,
+                            retain_effective: false,
                         }
                     },
                 )

--- a/crates/noon/src/execution_session/completion.rs
+++ b/crates/noon/src/execution_session/completion.rs
@@ -365,12 +365,11 @@ impl ExecutionSession {
             // their execution history. A kept reveal lifecycle likewise has no
             // semantic reveal field to receive its endpoint, so its completed
             // execution track remains the authoritative persistent reveal history.
-            if (!entry.property.is_instant() || entry.property == noon_core::Property::ZIndex)
-                && !matches!(
-                    &entry.completion,
-                    SemanticAnimationCompletion::RevealLifecycle { remove: false }
-                )
-            {
+            if should_reconcile_execution_track(
+                entry.property,
+                &entry.completion,
+                entry.retain_effective,
+            ) {
                 release.push(ExecutionPatch::ReconcileTrack {
                     track: entry.track,
                     object: entry.execution_object,
@@ -503,6 +502,48 @@ fn has_ancestor_in(
         }
     }
     false
+}
+
+fn should_reconcile_execution_track(
+    property: noon_core::Property,
+    completion: &SemanticAnimationCompletion,
+    retain_effective: bool,
+) -> bool {
+    !retain_effective
+        && (!property.is_instant() || property == noon_core::Property::ZIndex)
+        && !matches!(
+            completion,
+            SemanticAnimationCompletion::RevealLifecycle { remove: false }
+        )
+}
+
+#[cfg(test)]
+mod retain_effective_completion_tests {
+    use super::*;
+
+    #[test]
+    fn retained_presentation_endpoint_skips_only_execution_reconciliation() {
+        assert!(should_reconcile_execution_track(
+            noon_core::Property::Appearance,
+            &SemanticAnimationCompletion::Release,
+            false,
+        ));
+        assert!(!should_reconcile_execution_track(
+            noon_core::Property::Appearance,
+            &SemanticAnimationCompletion::Release,
+            true,
+        ));
+        assert!(!should_reconcile_execution_track(
+            noon_core::Property::Reveal,
+            &SemanticAnimationCompletion::RevealLifecycle { remove: false },
+            false,
+        ));
+        assert!(should_reconcile_execution_track(
+            noon_core::Property::ZIndex,
+            &SemanticAnimationCompletion::Priority { value: 3.0 },
+            false,
+        ));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds the live-session release policy required by unequal-family Transform contraction, stacked on #1438.

- adds `retain_effective` to session completion entries as execution-release metadata;
- ordinary tracks continue to reconcile back to authored base state exactly as before;
- a retained presentation endpoint skips only the final `ReconcileTrack`, leaving the execution track authoritative;
- existing RevealLifecycle and ZIndex completion behavior is preserved;
- all existing completion-entry construction defaults `retain_effective` to false, so this changes no current animation behavior until family Transform wiring opts in.

This deliberately does **not** add another `SemanticAnimationCompletion` variant: retaining an effective padding endpoint is execution release policy, not authored animation meaning.

## Qualification

Exact production content passed:

- focused `retained_presentation_endpoint_skips_only_execution_reconciliation` test;
- `cargo check -p noon`;
- `cargo clippy -p noon --lib -- -D warnings`;
- full `cargo fmt --all` was applied before the focused gate.

The branch is reconstructed as one production commit `489606ac8ddd68e2e3f5974166487698ab62de2c` directly on #1438; the temporary patch workflow is absent.

## Remaining integration

The family Transform activation layer must propagate #1438's per-track `retain_effective` marker into the corresponding completion entry. Derived source-padding copies remain separate identity-free renderer publication data.

Refs #82.