### PR TITLE
Precompile identity-free derived Transform geometry plans

### DIFF
--- a/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
+++ b/crates/noon-compile/src/semantic_lowering/animation_payload/family_transform_channels.rs
@@ -6,6 +6,8 @@ use noon_core::{
     TrackValues,
 };
 
+use crate::{transform::compile_transform_geometry_values, TransformGeometryPlan};
+
 use super::affine::{
     completion_at_endpoint, driver_key, lower_transform_channels, transform_driver_conflict,
     validate_affine_payload, AffinePayloadIssue, LoweredAffineChannel, SemanticAnimationCompletion,
@@ -42,6 +44,7 @@ pub struct PreparedDerivedFamilyTransformTrack {
     pub anchor_execution_object_id: ObjectId,
     pub property: Property,
     pub values: TrackValues,
+    pub transform_geometry_plan: Option<TransformGeometryPlan>,
     pub timing: noon_core::TrackTiming,
     pub time_map: noon_core::CompositionTimeMap,
 }
@@ -97,6 +100,34 @@ pub enum PreparedFamilyTransformChannelError {
         target: SemanticNodeId,
         property: SemanticObjectProperty,
     },
+    DerivedGeometryPlan {
+        occurrence_index: u32,
+        property: Property,
+        failure: PreparedDerivedTransformGeometryPlanFailure,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreparedDerivedTransformGeometryPlanFailure {
+    UnsupportedGeometry,
+    RequiresRetessellation,
+    UnsafeFilledPath,
+}
+
+impl From<crate::transform::TransformCompileFailure>
+    for PreparedDerivedTransformGeometryPlanFailure
+{
+    fn from(value: crate::transform::TransformCompileFailure) -> Self {
+        match value {
+            crate::transform::TransformCompileFailure::UnsupportedGeometry => {
+                Self::UnsupportedGeometry
+            }
+            crate::transform::TransformCompileFailure::RequiresRetessellation => {
+                Self::RequiresRetessellation
+            }
+            crate::transform::TransformCompileFailure::UnsafeFilledPath => Self::UnsafeFilledPath,
+        }
+    }
 }
 
 impl std::fmt::Display for PreparedFamilyTransformChannelError {
@@ -122,6 +153,14 @@ impl std::fmt::Display for PreparedFamilyTransformChannelError {
                 target.slot(),
                 target.generation()
             ),
+            Self::DerivedGeometryPlan {
+                occurrence_index,
+                property,
+                failure,
+            } => write!(
+                formatter,
+                "derived family Transform occurrence {occurrence_index} cannot prepare {property:?} geometry plan: {failure:?}"
+            ),
         }
     }
 }
@@ -131,7 +170,7 @@ impl std::error::Error for PreparedFamilyTransformChannelError {
         match self {
             Self::Target { error, .. } => Some(error),
             Self::Payload(error) => Some(error),
-            Self::MultipleDrivers { .. } => None,
+            Self::MultipleDrivers { .. } | Self::DerivedGeometryPlan { .. } => None,
         }
     }
 }
@@ -192,15 +231,27 @@ pub fn lower_prepared_family_transform_channels(
         if occurrence.source_padding {
             let mut tracks = channels
                 .into_iter()
-                .map(|channel| PreparedDerivedFamilyTransformTrack {
-                    occurrence_index: occurrence.occurrence_index,
-                    anchor_execution_object_id: occurrence.source_execution_object_id,
-                    property: channel.property,
-                    values: channel.values,
-                    timing: occurrence.timing,
-                    time_map: occurrence.time_map.clone(),
+                .map(|channel| {
+                    let transform_geometry_plan =
+                        compile_transform_geometry_values(channel.property, &channel.values)
+                            .map_err(|failure| {
+                                PreparedFamilyTransformChannelError::DerivedGeometryPlan {
+                                    occurrence_index: occurrence.occurrence_index,
+                                    property: channel.property,
+                                    failure: failure.into(),
+                                }
+                            })?;
+                    Ok(PreparedDerivedFamilyTransformTrack {
+                        occurrence_index: occurrence.occurrence_index,
+                        anchor_execution_object_id: occurrence.source_execution_object_id,
+                        property: channel.property,
+                        values: channel.values,
+                        transform_geometry_plan,
+                        timing: occurrence.timing,
+                        time_map: occurrence.time_map.clone(),
+                    })
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, PreparedFamilyTransformChannelError>>()?;
             tracks.push(PreparedDerivedFamilyTransformTrack {
                 occurrence_index: occurrence.occurrence_index,
                 anchor_execution_object_id: occurrence.source_execution_object_id,
@@ -209,6 +260,7 @@ pub fn lower_prepared_family_transform_channels(
                     from: 0.0,
                     to: target_appearance,
                 },
+                transform_geometry_plan: None,
                 timing: occurrence.timing,
                 time_map: occurrence.time_map.clone(),
             });

--- a/crates/noon-compile/src/transform.rs
+++ b/crates/noon-compile/src/transform.rs
@@ -39,8 +39,15 @@ pub(crate) enum TransformCompileFailure {
 pub(crate) fn compile_transform_geometry_plan(
     track: &TrackDefinition,
 ) -> Result<Option<TransformGeometryPlan>, TransformCompileFailure> {
-    if track.property == Property::Morph {
-        return match &track.values {
+    compile_transform_geometry_values(track.property, &track.values)
+}
+
+pub(crate) fn compile_transform_geometry_values(
+    property: Property,
+    values: &TrackValues,
+) -> Result<Option<TransformGeometryPlan>, TransformCompileFailure> {
+    if property == Property::Morph {
+        return match values {
             TrackValues::PreparedMorph {
                 geometry,
                 render_transform,
@@ -72,10 +79,10 @@ pub(crate) fn compile_transform_geometry_plan(
             _ => Ok(None),
         };
     }
-    if track.property != Property::Transform {
+    if property != Property::Transform {
         return Ok(None);
     }
-    let TrackValues::Object { from, to } = &track.values else {
+    let TrackValues::Object { from, to } = values else {
         unreachable!("validated Transform track must contain object snapshots");
     };
 
@@ -328,6 +335,36 @@ fn fixed_frame_inverse_is_finite(
 mod tests {
     use super::*;
     use noon_core::{Color, Vec2};
+
+    #[test]
+    fn identity_free_value_plan_matches_stable_track_plan() {
+        let values = TrackValues::Object {
+            from: noon_core::TransformTrackEndpoint {
+                geometry: GeometryRef::circle(1.0),
+                transform: Transform2D::IDENTITY,
+                style: Style::default(),
+            },
+            to: noon_core::TransformTrackEndpoint {
+                geometry: GeometryRef::rectangle(2.0, 1.0),
+                transform: Transform2D::IDENTITY,
+                style: Style::default(),
+            },
+        };
+        let direct = compile_transform_geometry_values(Property::Transform, &values).unwrap();
+        let track = TrackDefinition {
+            id: noon_core::TrackId::new(7),
+            object: noon_core::ObjectId::new(11),
+            property: Property::Transform,
+            values,
+            timing: noon_core::TrackTiming::new(0.0, 1.0, noon_core::RateFunction::Linear),
+            time_map: noon_core::CompositionTimeMap::identity(),
+        };
+        assert_eq!(direct, compile_transform_geometry_plan(&track).unwrap());
+        assert!(matches!(
+            direct,
+            Some(TransformGeometryPlan::PathPair { .. })
+        ));
+    }
 
     #[test]
     fn fixed_world_pair_requires_finite_invertible_driver_takeover() {


### PR DESCRIPTION
## Summary

Adds the compiler prerequisite for evaluating source-padding copies without fabricating execution identity, stacked on #1439.

- factors stable `compile_transform_geometry_plan(track)` through a pure `property + TrackValues` helper;
- the stable compiler path remains unchanged semantically and continues to call the same implementation;
- identity-free derived family-Transform tracks now retain the same `TransformGeometryPlan` that stable tracks would receive;
- no fake `TrackId`, `ObjectId`, semantic node, or stable slot is introduced merely to prepare transient geometry;
- derived geometry-plan failures are projected into a bounded typed family-Transform error.

A regression constructs identical Transform values through the direct identity-free helper and an ordinary stable `TrackDefinition` and verifies they produce the same `PathPair` plan.

## Qualification

Exact production content passed:

- `identity_free_value_plan_matches_stable_track_plan`;
- `cargo test -p noon-compile --test family_transform_channels`;
- `cargo clippy -p noon-compile --tests -- -D warnings`;
- formatting was applied before qualification.

The branch is reconstructed as one production commit `00868bb3d4d396fcb2c7236c28ab3a9937962a01` directly on #1439; temporary patch workflow files are absent.

## Remaining integration

The next layer evaluates these identity-free tracks against activation-time copied frame state using Runtime's existing interpolation/prepared-morph helpers, then attaches the resulting `DerivedDisplayObject`s to the exact renderer publication.

Refs #82.