### PR TITLE
Package reproducible Noon agent authoring bundle

### DIFF
--- a/.github/workflows/noon-agent-foundation.yml
+++ b/.github/workflows/noon-agent-foundation.yml
@@ -7,9 +7,18 @@ on:
       - "scripts/noon-capabilities.py"
       - "scripts/test_noon_capabilities.py"
       - "scripts/check-noon-agent-skill.py"
+      - "scripts/package-noon-agent.mjs"
+      - "scripts/package-noon-agent.test.mjs"
       - "scripts/manim-api-coverage.py"
       - "scripts/agent-preview-artifacts*.mjs"
       - "scripts/agent-preview-capture*.mjs"
+      - "scripts/agent-preview-sessions.mjs"
+      - "tools/noon-mcp/**"
+      - "web/agent-preview-host*"
+      - "web/*authoring*.js"
+      - "web/*execution*.js"
+      - "web/provenanced-authoring-client.js"
+      - "web/semantic-preview-session.js"
       - "compat/manim-v0.21.0.json"
       - "web/python/**"
       - "parity/manim-v0.21/upstream-examples/**"
@@ -21,9 +30,18 @@ on:
       - "scripts/noon-capabilities.py"
       - "scripts/test_noon_capabilities.py"
       - "scripts/check-noon-agent-skill.py"
+      - "scripts/package-noon-agent.mjs"
+      - "scripts/package-noon-agent.test.mjs"
       - "scripts/manim-api-coverage.py"
       - "scripts/agent-preview-artifacts*.mjs"
       - "scripts/agent-preview-capture*.mjs"
+      - "scripts/agent-preview-sessions.mjs"
+      - "tools/noon-mcp/**"
+      - "web/agent-preview-host*"
+      - "web/*authoring*.js"
+      - "web/*execution*.js"
+      - "web/provenanced-authoring-client.js"
+      - "web/semantic-preview-session.js"
       - "compat/manim-v0.21.0.json"
       - "web/python/**"
       - "parity/manim-v0.21/upstream-examples/**"
@@ -38,25 +56,52 @@ concurrency:
 
 jobs:
   inventory:
-    name: Capability inventory and skill contracts
+    name: Capability inventory, skill and package contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
       - name: Test offline discovery and negative cases
         run: python -B -m unittest discover -s scripts -p test_noon_capabilities.py -v
       - name: Validate actual checkout inventory without Manim
         run: python -S -B scripts/noon-capabilities.py > "$RUNNER_TEMP/noon-agent-capabilities.json"
       - name: Validate skill and current example references
         run: python -S -B scripts/check-noon-agent-skill.py
+      - name: Test deterministic package and tamper rejection
+        run: node --test scripts/package-noon-agent.test.mjs
+      - name: Build and verify package from a scrubbed environment
+        run: |
+          mkdir -p "$RUNNER_TEMP/noon-agent-home"
+          env -i \
+            HOME="$RUNNER_TEMP/noon-agent-home" \
+            PATH="$PATH" \
+            LANG=C \
+            LC_ALL=C \
+            node scripts/package-noon-agent.mjs --output "$RUNNER_TEMP/noon-agent-package"
+          env -i \
+            HOME="$RUNNER_TEMP/noon-agent-home" \
+            PATH="$PATH" \
+            LANG=C \
+            LC_ALL=C \
+            node scripts/package-noon-agent.mjs --verify "$RUNNER_TEMP/noon-agent-package"
       - name: Upload source inventory (not runtime qualification)
         uses: actions/upload-artifact@v7
         with:
           name: noon-agent-capabilities
           path: ${{ runner.temp }}/noon-agent-capabilities.json
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload reproducible authoring package
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-agent-package
+          path: ${{ runner.temp }}/noon-agent-package
           if-no-files-found: error
           retention-days: 14
   artifacts:

--- a/scripts/check-noon-agent-skill.py
+++ b/scripts/check-noon-agent-skill.py
@@ -14,7 +14,6 @@ SKILL = "skills/noon-authoring"
 COMMANDS = (
     "scripts/noon-capabilities.py", "scripts/package-noon-agent.mjs",
     "scripts/build-web-demo.sh", "scripts/check.sh", "scripts/manim-tutorial-smoke.mjs",
-    "tools/noon-mcp/bin/noon-preview.mjs", "tools/noon-mcp/scripts/setup-preview-runtime.mjs",
 )
 
 

--- a/scripts/check-noon-agent-skill.py
+++ b/scripts/check-noon-agent-skill.py
@@ -12,8 +12,9 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = "skills/noon-authoring"
 COMMANDS = (
-    "scripts/noon-capabilities.py", "scripts/build-web-demo.sh",
-    "scripts/check.sh", "scripts/manim-tutorial-smoke.mjs",
+    "scripts/noon-capabilities.py", "scripts/package-noon-agent.mjs",
+    "scripts/build-web-demo.sh", "scripts/check.sh", "scripts/manim-tutorial-smoke.mjs",
+    "tools/noon-mcp/bin/noon-preview.mjs", "tools/noon-mcp/scripts/setup-preview-runtime.mjs",
 )
 
 

--- a/scripts/package-noon-agent.mjs
+++ b/scripts/package-noon-agent.mjs
@@ -1,0 +1,455 @@
+#!/usr/bin/env node
+import { constants as fsConstants } from "node:fs";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const NOON_AGENT_PACKAGE_SCHEMA = 1;
+export const NOON_AGENT_PACKAGE_KIND = "noon-agent-package";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "..");
+const skillRoot = "skills/noon-authoring";
+const manifestName = "manifest.json";
+const capabilitiesName = "capabilities.json";
+const runnerEntrypoints = Object.freeze([
+  "tools/noon-mcp/bin/noon-preview.mjs",
+  "tools/noon-mcp/src/server.mjs",
+  "tools/noon-mcp/src/preview-worker.mjs",
+  "tools/noon-mcp/scripts/setup-preview-runtime.mjs",
+  "web/agent-preview-host.js",
+]);
+const runnerStaticFiles = Object.freeze([
+  "tools/noon-mcp/package.json",
+  "tools/noon-mcp/package-lock.json",
+  "tools/noon-mcp/preview.Dockerfile",
+  "web/agent-preview-host.html",
+]);
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sortedObject(value) {
+  if (Array.isArray(value)) return value.map(sortedObject);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sortedObject(value[key])]));
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(sortedObject(value), null, 2)}\n`;
+}
+
+function portable(relative) {
+  return relative.split(path.sep).join("/");
+}
+
+function validateRelative(relative) {
+  if (typeof relative !== "string" || relative.length === 0 || relative.includes("\\") ||
+      path.posix.isAbsolute(relative) || relative.split("/").includes("..")) {
+    throw new Error(`unsafe package path: ${JSON.stringify(relative)}`);
+  }
+  return relative;
+}
+
+async function confinedRegularFile(root, relative) {
+  validateRelative(relative);
+  const rootReal = await realpath(root);
+  const target = path.resolve(root, relative);
+  const metadata = await lstat(target);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(`package source must be a regular non-symlink file: ${relative}`);
+  }
+  const targetReal = await realpath(target);
+  if (targetReal !== rootReal && !targetReal.startsWith(`${rootReal}${path.sep}`)) {
+    throw new Error(`package source escapes root: ${relative}`);
+  }
+  return target;
+}
+
+async function walkRegularFiles(root, relativeDir) {
+  validateRelative(relativeDir);
+  const start = path.resolve(root, relativeDir);
+  const metadata = await lstat(start);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error(`package source must be a regular directory: ${relativeDir}`);
+  }
+  const files = [];
+  async function visit(directory, prefix) {
+    const entries = (await readdir(directory, { withFileTypes: true }))
+      .sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const relative = portable(path.join(prefix, entry.name));
+      if (entry.isSymbolicLink()) throw new Error(`symbolic links are not packageable: ${relative}`);
+      if (entry.isDirectory()) await visit(path.join(directory, entry.name), relative);
+      else if (entry.isFile()) files.push(relative);
+      else throw new Error(`unsupported package source entry: ${relative}`);
+    }
+  }
+  await visit(start, relativeDir);
+  return Object.freeze(files);
+}
+
+function nodeMajor() {
+  return Number.parseInt(process.versions.node.split(".", 1)[0], 10);
+}
+
+function requireNode22() {
+  if (!Number.isSafeInteger(nodeMajor()) || nodeMajor() < 22) {
+    throw new Error(`Noon agent packaging requires Node >=22; found ${process.versions.node}`);
+  }
+}
+
+function cleanSubprocessEnv() {
+  const env = {
+    PATH: process.env.PATH ?? "",
+    LANG: "C",
+    LC_ALL: "C",
+    PYTHONUTF8: "1",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  for (const name of ["SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT"]) {
+    if (process.env[name]) env[name] = process.env[name];
+  }
+  return env;
+}
+
+function runText(executable, args, { maxBuffer = 64 * 1024 * 1024 } = {}) {
+  const result = spawnSync(executable, args, {
+    cwd: repoRoot,
+    env: cleanSubprocessEnv(),
+    encoding: "utf8",
+    maxBuffer,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = String(result.stderr ?? "").trim().slice(0, 2000);
+    throw new Error(`${executable} failed (${result.status}): ${detail}`);
+  }
+  return String(result.stdout ?? "");
+}
+
+function pythonExecutable() {
+  const configured = process.env.NOON_PYTHON;
+  if (configured !== undefined) {
+    if (configured.trim() === "" || configured.includes("\0")) throw new Error("NOON_PYTHON must be non-empty text");
+    return configured;
+  }
+  return "python3";
+}
+
+function generateCapabilities() {
+  const python = pythonExecutable();
+  const version = runText(python, ["-S", "-B", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"])
+    .trim().split(".").map((part) => Number.parseInt(part, 10));
+  if (version.length !== 2 || version.some((value) => !Number.isSafeInteger(value)) ||
+      version[0] < 3 || (version[0] === 3 && version[1] < 12)) {
+    throw new Error("Noon agent packaging requires Python >=3.12");
+  }
+  const text = runText(python, ["-S", "-B", "scripts/noon-capabilities.py"]);
+  let report;
+  try { report = JSON.parse(text); }
+  catch (error) { throw new Error(`capability exporter returned invalid JSON: ${error.message}`); }
+  if (report?.schema_version !== 1 || report?.kind !== "noon-agent-capabilities" ||
+      report?.scope !== "source-inventory" || !report?.provenance?.input_sha256) {
+    throw new Error("capability exporter returned an unsupported source inventory");
+  }
+  return Object.freeze({ report, bytes: Buffer.from(stableJson(report), "utf8") });
+}
+
+function relativeImports(source) {
+  const found = new Set();
+  const patterns = [
+    /(?:import|export)\s+(?:[^"'()]*?\s+from\s+)?["'](\.[^"']+)["']/g,
+    /import\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) found.add(match[1]);
+  }
+  return [...found].sort();
+}
+
+async function runnerSourceFiles() {
+  const pending = [...runnerEntrypoints];
+  const files = new Set(runnerStaticFiles);
+  while (pending.length > 0) {
+    const relative = portable(pending.pop());
+    if (files.has(relative)) continue;
+    const filename = await confinedRegularFile(repoRoot, relative);
+    files.add(relative);
+    if (!/\.(?:mjs|js)$/u.test(relative)) continue;
+    const source = await readFile(filename, "utf8");
+    for (const specifier of relativeImports(source)) {
+      const resolved = path.resolve(path.dirname(filename), specifier);
+      const rel = portable(path.relative(repoRoot, resolved));
+      validateRelative(rel);
+      if (!files.has(rel)) pending.push(rel);
+    }
+  }
+  return Object.freeze([...files].sort());
+}
+
+async function hashCheckoutFiles(files) {
+  const output = {};
+  for (const relative of files) {
+    const filename = await confinedRegularFile(repoRoot, relative);
+    output[relative] = sha256(await readFile(filename));
+  }
+  return Object.freeze(output);
+}
+
+function mapDigest(files) {
+  const lines = Object.entries(files).sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, digest]) => `${name}\0${digest}\n`);
+  return sha256(Buffer.from(lines.join(""), "utf8"));
+}
+
+async function copySkill(outputRoot) {
+  const sourceFiles = await walkRegularFiles(repoRoot, skillRoot);
+  const hashes = {};
+  for (const sourceRelative of sourceFiles) {
+    const relativeWithinSkill = portable(path.relative(skillRoot, sourceRelative));
+    const destinationRelative = `skill/noon-authoring/${relativeWithinSkill}`;
+    const source = await confinedRegularFile(repoRoot, sourceRelative);
+    const destination = path.resolve(outputRoot, destinationRelative);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(source, destination, fsConstants.COPYFILE_EXCL);
+    hashes[destinationRelative] = sha256(await readFile(destination));
+  }
+  return Object.freeze(hashes);
+}
+
+async function currentRevision() {
+  try {
+    const revision = runText("git", ["-C", repoRoot, "rev-parse", "HEAD"], { maxBuffer: 64 * 1024 }).trim();
+    return /^[0-9a-f]{40}$/u.test(revision) ? revision : null;
+  } catch {
+    return null;
+  }
+}
+
+async function enumerateBundleFiles(bundleRoot) {
+  const entries = [];
+  async function visit(directory, prefix = "") {
+    const children = (await readdir(directory, { withFileTypes: true }))
+      .sort((left, right) => left.name.localeCompare(right.name));
+    for (const child of children) {
+      const relative = prefix ? `${prefix}/${child.name}` : child.name;
+      if (child.isSymbolicLink()) throw new Error(`bundle contains symbolic link: ${relative}`);
+      if (child.isDirectory()) await visit(path.join(directory, child.name), relative);
+      else if (child.isFile()) entries.push(relative);
+      else throw new Error(`bundle contains unsupported entry: ${relative}`);
+    }
+  }
+  await visit(bundleRoot);
+  return Object.freeze(entries);
+}
+
+async function readBundleJson(bundleRoot, relative) {
+  const filename = await confinedRegularFile(bundleRoot, relative);
+  try { return JSON.parse(await readFile(filename, "utf8")); }
+  catch (error) { throw new Error(`${relative} is invalid JSON: ${error.message}`); }
+}
+
+export async function buildAgentBundle({ outputDir }) {
+  requireNode22();
+  if (typeof outputDir !== "string" || outputDir.trim() === "" || outputDir.includes("\0")) {
+    throw new TypeError("outputDir must be a non-empty path without NUL");
+  }
+  const outputRoot = path.resolve(outputDir);
+  await mkdir(outputRoot, { recursive: false });
+
+  const capabilities = generateCapabilities();
+  const skillFiles = await copySkill(outputRoot);
+  const capabilitiesPath = path.join(outputRoot, capabilitiesName);
+  await writeFile(capabilitiesPath, capabilities.bytes, { flag: "wx" });
+
+  const sourceFiles = await runnerSourceFiles();
+  const runnerHashes = await hashCheckoutFiles(sourceFiles);
+  const packageJsonBytes = await readFile(await confinedRegularFile(repoRoot, "tools/noon-mcp/package.json"));
+  const packageLockBytes = await readFile(await confinedRegularFile(repoRoot, "tools/noon-mcp/package-lock.json"));
+  const packageJson = JSON.parse(packageJsonBytes.toString("utf8"));
+  if (typeof packageJson.name !== "string" || typeof packageJson.version !== "string") {
+    throw new Error("MCP package metadata is incomplete");
+  }
+
+  const payloadFiles = Object.freeze({
+    [capabilitiesName]: sha256(capabilities.bytes),
+    ...skillFiles,
+  });
+  const generatorRelative = "scripts/package-noon-agent.mjs";
+  const generatorSha256 = sha256(await readFile(await confinedRegularFile(repoRoot, generatorRelative)));
+  const manifest = {
+    schema: NOON_AGENT_PACKAGE_SCHEMA,
+    kind: NOON_AGENT_PACKAGE_KIND,
+    source: {
+      revision: capabilities.report.provenance.revision ?? null,
+      dirty: capabilities.report.provenance.dirty ?? null,
+    },
+    capabilities: {
+      path: capabilitiesName,
+      schemaVersion: capabilities.report.schema_version,
+      sha256: payloadFiles[capabilitiesName],
+    },
+    skill: {
+      root: "skill/noon-authoring",
+      files: skillFiles,
+    },
+    runner: {
+      package: packageJson.name,
+      version: packageJson.version,
+      packageJsonSha256: sha256(packageJsonBytes),
+      packageLockSha256: sha256(packageLockBytes),
+      sourceSha256: runnerHashes,
+      sourceSetSha256: mapDigest(runnerHashes),
+      loadedBuildIdentity: "runtime-observed-per-artifact",
+    },
+    generator: {
+      path: generatorRelative,
+      sha256: generatorSha256,
+    },
+    environment: {
+      node: ">=22",
+      python: ">=3.12",
+      platform: "POSIX",
+      docker: "required-for-isolated-rendering",
+      installMcpDependencies: "cd tools/noon-mcp && npm ci --ignore-scripts --no-audit --no-fund",
+      preparePreviewRuntime: "cd tools/noon-mcp && node scripts/setup-preview-runtime.mjs",
+    },
+    payload: {
+      files: payloadFiles,
+      sha256: mapDigest(payloadFiles),
+    },
+  };
+  await writeFile(path.join(outputRoot, manifestName), stableJson(manifest), { flag: "wx" });
+  return Object.freeze({ outputDir: outputRoot, manifest: Object.freeze(manifest) });
+}
+
+export async function verifyAgentBundle({ bundleDir }) {
+  requireNode22();
+  if (typeof bundleDir !== "string" || bundleDir.trim() === "" || bundleDir.includes("\0")) {
+    throw new TypeError("bundleDir must be a non-empty path without NUL");
+  }
+  const bundleRoot = await realpath(path.resolve(bundleDir));
+  const rootMetadata = await lstat(bundleRoot);
+  if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) throw new Error("bundleDir must be a regular directory");
+  const manifest = await readBundleJson(bundleRoot, manifestName);
+  if (manifest?.schema !== NOON_AGENT_PACKAGE_SCHEMA || manifest?.kind !== NOON_AGENT_PACKAGE_KIND) {
+    throw new Error("unsupported Noon agent package manifest");
+  }
+  if (!manifest.payload?.files || typeof manifest.payload.files !== "object" || Array.isArray(manifest.payload.files)) {
+    throw new Error("manifest payload file map is missing");
+  }
+
+  const actualFiles = (await enumerateBundleFiles(bundleRoot)).filter((name) => name !== manifestName);
+  const expectedFiles = Object.keys(manifest.payload.files).sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new Error("bundle payload file set does not match manifest");
+  }
+  const actualPayload = {};
+  for (const relative of expectedFiles) {
+    const bytes = await readFile(await confinedRegularFile(bundleRoot, relative));
+    const digest = sha256(bytes);
+    if (digest !== manifest.payload.files[relative]) throw new Error(`bundle payload hash mismatch: ${relative}`);
+    actualPayload[relative] = digest;
+  }
+  if (mapDigest(actualPayload) !== manifest.payload.sha256) throw new Error("bundle payload digest mismatch");
+
+  const capabilities = await readBundleJson(bundleRoot, manifest.capabilities?.path);
+  if (capabilities?.schema_version !== manifest.capabilities?.schemaVersion ||
+      capabilities?.kind !== "noon-agent-capabilities" || capabilities?.scope !== "source-inventory") {
+    throw new Error("bundled capability inventory does not match manifest");
+  }
+  if (manifest.capabilities.sha256 !== manifest.payload.files[manifest.capabilities.path]) {
+    throw new Error("capability hash is not bound to bundle payload");
+  }
+  if ((capabilities.provenance?.revision ?? null) !== (manifest.source?.revision ?? null) ||
+      (capabilities.provenance?.dirty ?? null) !== (manifest.source?.dirty ?? null)) {
+    throw new Error("bundle source identity does not match capability provenance");
+  }
+
+  const generatorBytes = await readFile(await confinedRegularFile(repoRoot, manifest.generator?.path));
+  if (sha256(generatorBytes) !== manifest.generator?.sha256) throw new Error("package generator source hash mismatch");
+
+  const runnerHashes = manifest.runner?.sourceSha256;
+  if (!runnerHashes || typeof runnerHashes !== "object" || Array.isArray(runnerHashes)) {
+    throw new Error("runner source hash map is missing");
+  }
+  const currentRunnerHashes = await hashCheckoutFiles(Object.keys(runnerHashes).sort());
+  for (const [relative, digest] of Object.entries(runnerHashes)) {
+    if (currentRunnerHashes[relative] !== digest) throw new Error(`runner source hash mismatch: ${relative}`);
+  }
+  if (mapDigest(currentRunnerHashes) !== manifest.runner.sourceSetSha256) throw new Error("runner source-set digest mismatch");
+
+  const packageJsonBytes = await readFile(await confinedRegularFile(repoRoot, "tools/noon-mcp/package.json"));
+  const packageLockBytes = await readFile(await confinedRegularFile(repoRoot, "tools/noon-mcp/package-lock.json"));
+  const packageJson = JSON.parse(packageJsonBytes.toString("utf8"));
+  if (packageJson.name !== manifest.runner.package || packageJson.version !== manifest.runner.version ||
+      sha256(packageJsonBytes) !== manifest.runner.packageJsonSha256 ||
+      sha256(packageLockBytes) !== manifest.runner.packageLockSha256) {
+    throw new Error("runner package identity mismatch");
+  }
+  if (manifest.runner.loadedBuildIdentity !== "runtime-observed-per-artifact") {
+    throw new Error("package must not substitute source metadata for loaded runtime build identity");
+  }
+
+  const revision = await currentRevision();
+  if (manifest.source?.revision !== null && revision !== manifest.source.revision) {
+    throw new Error("bundle Git revision does not match current checkout");
+  }
+  return Object.freeze({ ok: true, bundleDir: bundleRoot, payloadSha256: manifest.payload.sha256,
+    runnerSourceSetSha256: manifest.runner.sourceSetSha256, revision });
+}
+
+export function parsePackageArgs(argv) {
+  if (!Array.isArray(argv) || argv.some((value) => typeof value !== "string")) throw new TypeError("arguments must be strings");
+  let mode = null;
+  let target = null;
+  let help = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") { help = true; continue; }
+    if (arg !== "--output" && arg !== "--verify") throw new TypeError(`unknown argument: ${arg}`);
+    if (mode !== null) throw new TypeError("choose exactly one of --output or --verify");
+    index += 1;
+    if (index >= argv.length || argv[index].trim() === "") throw new TypeError(`${arg} requires a path`);
+    mode = arg === "--output" ? "output" : "verify";
+    target = argv[index];
+  }
+  if (!help && mode === null) throw new TypeError("choose exactly one of --output or --verify");
+  return Object.freeze({ mode, target, help });
+}
+
+const usage = `Usage:\n  node scripts/package-noon-agent.mjs --output <new-directory>\n  node scripts/package-noon-agent.mjs --verify <bundle-directory>\n\nBuilds or verifies a deterministic checkout-bound Noon authoring skill/capability package. Actual loaded worker/WASM identity remains runtime-observed in preview artifacts.\n`;
+
+async function main() {
+  const args = parsePackageArgs(process.argv.slice(2));
+  if (args.help) { process.stdout.write(usage); return; }
+  if (args.mode === "output") {
+    const result = await buildAgentBundle({ outputDir: args.target });
+    process.stdout.write(`${JSON.stringify({ ok: true, outputDir: result.outputDir, payloadSha256: result.manifest.payload.sha256 })}\n`);
+  } else {
+    const result = await verifyAgentBundle({ bundleDir: args.target });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  }
+}
+
+if (path.resolve(process.argv[1] ?? "") === path.resolve(scriptPath)) {
+  main().catch((error) => {
+    process.stderr.write(`${String(error?.stack ?? error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/package-noon-agent.mjs
+++ b/scripts/package-noon-agent.mjs
@@ -20,8 +20,10 @@ export const NOON_AGENT_PACKAGE_KIND = "noon-agent-package";
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..");
 const skillRoot = "skills/noon-authoring";
+const packagedSkillRoot = "skill/noon-authoring";
 const manifestName = "manifest.json";
 const capabilitiesName = "capabilities.json";
+const generatorRelative = "scripts/package-noon-agent.mjs";
 const runnerEntrypoints = Object.freeze([
   "tools/noon-mcp/bin/noon-preview.mjs",
   "tools/noon-mcp/src/server.mjs",
@@ -62,6 +64,19 @@ function validateRelative(relative) {
     throw new Error(`unsafe package path: ${JSON.stringify(relative)}`);
   }
   return relative;
+}
+
+function plainRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value));
+}
+
+function sortedKeys(record) {
+  return Object.keys(record).sort();
+}
+
+function sameStrings(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 async function confinedRegularFile(root, relative) {
@@ -217,19 +232,28 @@ function mapDigest(files) {
   return sha256(Buffer.from(lines.join(""), "utf8"));
 }
 
-async function copySkill(outputRoot) {
-  const sourceFiles = await walkRegularFiles(repoRoot, skillRoot);
+async function skillSourceHashes() {
   const hashes = {};
-  for (const sourceRelative of sourceFiles) {
+  for (const sourceRelative of await walkRegularFiles(repoRoot, skillRoot)) {
     const relativeWithinSkill = portable(path.relative(skillRoot, sourceRelative));
-    const destinationRelative = `skill/noon-authoring/${relativeWithinSkill}`;
+    const destinationRelative = `${packagedSkillRoot}/${relativeWithinSkill}`;
+    hashes[destinationRelative] = sha256(await readFile(await confinedRegularFile(repoRoot, sourceRelative)));
+  }
+  return Object.freeze(hashes);
+}
+
+async function copySkill(outputRoot) {
+  const expected = await skillSourceHashes();
+  for (const [destinationRelative, digest] of Object.entries(expected)) {
+    const relativeWithinSkill = destinationRelative.slice(`${packagedSkillRoot}/`.length);
+    const sourceRelative = `${skillRoot}/${relativeWithinSkill}`;
     const source = await confinedRegularFile(repoRoot, sourceRelative);
     const destination = path.resolve(outputRoot, destinationRelative);
     await mkdir(path.dirname(destination), { recursive: true });
     await copyFile(source, destination, fsConstants.COPYFILE_EXCL);
-    hashes[destinationRelative] = sha256(await readFile(destination));
+    if (sha256(await readFile(destination)) !== digest) throw new Error(`copied skill hash mismatch: ${destinationRelative}`);
   }
-  return Object.freeze(hashes);
+  return expected;
 }
 
 async function currentRevision() {
@@ -290,7 +314,6 @@ export async function buildAgentBundle({ outputDir }) {
     [capabilitiesName]: sha256(capabilities.bytes),
     ...skillFiles,
   });
-  const generatorRelative = "scripts/package-noon-agent.mjs";
   const generatorSha256 = sha256(await readFile(await confinedRegularFile(repoRoot, generatorRelative)));
   const manifest = {
     schema: NOON_AGENT_PACKAGE_SCHEMA,
@@ -305,7 +328,7 @@ export async function buildAgentBundle({ outputDir }) {
       sha256: payloadFiles[capabilitiesName],
     },
     skill: {
-      root: "skill/noon-authoring",
+      root: packagedSkillRoot,
       files: skillFiles,
     },
     runner: {
@@ -326,6 +349,7 @@ export async function buildAgentBundle({ outputDir }) {
       python: ">=3.12",
       platform: "POSIX",
       docker: "required-for-isolated-rendering",
+      buildBrowserPackage: "bash scripts/build-web-demo.sh",
       installMcpDependencies: "cd tools/noon-mcp && npm ci --ignore-scripts --no-audit --no-fund",
       preparePreviewRuntime: "cd tools/noon-mcp && node scripts/setup-preview-runtime.mjs",
     },
@@ -343,24 +367,23 @@ export async function verifyAgentBundle({ bundleDir }) {
   if (typeof bundleDir !== "string" || bundleDir.trim() === "" || bundleDir.includes("\0")) {
     throw new TypeError("bundleDir must be a non-empty path without NUL");
   }
-  const bundleRoot = await realpath(path.resolve(bundleDir));
-  const rootMetadata = await lstat(bundleRoot);
-  if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) throw new Error("bundleDir must be a regular directory");
+  const requestedRoot = path.resolve(bundleDir);
+  const requestedMetadata = await lstat(requestedRoot);
+  if (requestedMetadata.isSymbolicLink() || !requestedMetadata.isDirectory()) {
+    throw new Error("bundleDir must be a regular non-symlink directory");
+  }
+  const bundleRoot = await realpath(requestedRoot);
   const manifest = await readBundleJson(bundleRoot, manifestName);
   if (manifest?.schema !== NOON_AGENT_PACKAGE_SCHEMA || manifest?.kind !== NOON_AGENT_PACKAGE_KIND) {
     throw new Error("unsupported Noon agent package manifest");
   }
-  if (!manifest.payload?.files || typeof manifest.payload.files !== "object" || Array.isArray(manifest.payload.files)) {
-    throw new Error("manifest payload file map is missing");
-  }
+  if (!plainRecord(manifest.payload?.files)) throw new Error("manifest payload file map is missing");
 
   const actualFiles = (await enumerateBundleFiles(bundleRoot)).filter((name) => name !== manifestName);
-  const expectedFiles = Object.keys(manifest.payload.files).sort();
-  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
-    throw new Error("bundle payload file set does not match manifest");
-  }
+  const payloadFiles = sortedKeys(manifest.payload.files);
+  if (!sameStrings(actualFiles, payloadFiles)) throw new Error("bundle payload file set does not match manifest");
   const actualPayload = {};
-  for (const relative of expectedFiles) {
+  for (const relative of payloadFiles) {
     const bytes = await readFile(await confinedRegularFile(bundleRoot, relative));
     const digest = sha256(bytes);
     if (digest !== manifest.payload.files[relative]) throw new Error(`bundle payload hash mismatch: ${relative}`);
@@ -368,29 +391,56 @@ export async function verifyAgentBundle({ bundleDir }) {
   }
   if (mapDigest(actualPayload) !== manifest.payload.sha256) throw new Error("bundle payload digest mismatch");
 
-  const capabilities = await readBundleJson(bundleRoot, manifest.capabilities?.path);
+  if (manifest.capabilities?.path !== capabilitiesName) throw new Error("capability package path mismatch");
+  const bundledCapabilitiesBytes = await readFile(await confinedRegularFile(bundleRoot, capabilitiesName));
+  const capabilities = await readBundleJson(bundleRoot, capabilitiesName);
   if (capabilities?.schema_version !== manifest.capabilities?.schemaVersion ||
       capabilities?.kind !== "noon-agent-capabilities" || capabilities?.scope !== "source-inventory") {
     throw new Error("bundled capability inventory does not match manifest");
   }
-  if (manifest.capabilities.sha256 !== manifest.payload.files[manifest.capabilities.path]) {
+  if (manifest.capabilities.sha256 !== manifest.payload.files[capabilitiesName] ||
+      manifest.capabilities.sha256 !== sha256(bundledCapabilitiesBytes)) {
     throw new Error("capability hash is not bound to bundle payload");
+  }
+  const currentCapabilities = generateCapabilities();
+  if (sha256(currentCapabilities.bytes) !== manifest.capabilities.sha256) {
+    throw new Error("bundled capability inventory does not match current canonical inventory");
   }
   if ((capabilities.provenance?.revision ?? null) !== (manifest.source?.revision ?? null) ||
       (capabilities.provenance?.dirty ?? null) !== (manifest.source?.dirty ?? null)) {
     throw new Error("bundle source identity does not match capability provenance");
   }
 
-  const generatorBytes = await readFile(await confinedRegularFile(repoRoot, manifest.generator?.path));
+  if (manifest.skill?.root !== packagedSkillRoot || !plainRecord(manifest.skill?.files)) {
+    throw new Error("skill package root or file map is invalid");
+  }
+  const currentSkillHashes = await skillSourceHashes();
+  const skillFiles = sortedKeys(manifest.skill.files);
+  if (!sameStrings(skillFiles, sortedKeys(currentSkillHashes))) {
+    throw new Error("skill package file set does not match current skill tree");
+  }
+  for (const relative of skillFiles) {
+    if (manifest.skill.files[relative] !== currentSkillHashes[relative] ||
+        manifest.payload.files[relative] !== currentSkillHashes[relative]) {
+      throw new Error(`skill package hash mismatch: ${relative}`);
+    }
+  }
+
+  if (manifest.generator?.path !== generatorRelative) throw new Error("package generator path mismatch");
+  const generatorBytes = await readFile(await confinedRegularFile(repoRoot, generatorRelative));
   if (sha256(generatorBytes) !== manifest.generator?.sha256) throw new Error("package generator source hash mismatch");
 
-  const runnerHashes = manifest.runner?.sourceSha256;
-  if (!runnerHashes || typeof runnerHashes !== "object" || Array.isArray(runnerHashes)) {
-    throw new Error("runner source hash map is missing");
+  if (!plainRecord(manifest.runner?.sourceSha256)) throw new Error("runner source hash map is missing");
+  const expectedRunnerFiles = await runnerSourceFiles();
+  const runnerFiles = sortedKeys(manifest.runner.sourceSha256);
+  if (!sameStrings(runnerFiles, [...expectedRunnerFiles])) {
+    throw new Error("runner source file set does not match current entrypoints");
   }
-  const currentRunnerHashes = await hashCheckoutFiles(Object.keys(runnerHashes).sort());
-  for (const [relative, digest] of Object.entries(runnerHashes)) {
-    if (currentRunnerHashes[relative] !== digest) throw new Error(`runner source hash mismatch: ${relative}`);
+  const currentRunnerHashes = await hashCheckoutFiles(expectedRunnerFiles);
+  for (const relative of expectedRunnerFiles) {
+    if (currentRunnerHashes[relative] !== manifest.runner.sourceSha256[relative]) {
+      throw new Error(`runner source hash mismatch: ${relative}`);
+    }
   }
   if (mapDigest(currentRunnerHashes) !== manifest.runner.sourceSetSha256) throw new Error("runner source-set digest mismatch");
 

--- a/scripts/package-noon-agent.test.mjs
+++ b/scripts/package-noon-agent.test.mjs
@@ -20,6 +20,14 @@ async function fileBytes(root, relative) {
   return await readFile(path.join(root, relative));
 }
 
+async function readManifest(root) {
+  return JSON.parse(await readFile(path.join(root, "manifest.json"), "utf8"));
+}
+
+async function writeManifest(root, manifest) {
+  await writeFile(path.join(root, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
 test("argument parser requires one explicit package mode", () => {
   assert.deepEqual(parsePackageArgs(["--output", "out"]), { mode: "output", target: "out", help: false });
   assert.deepEqual(parsePackageArgs(["--verify", "bundle"]), { mode: "verify", target: "bundle", help: false });
@@ -45,6 +53,7 @@ test("package is deterministic, checkout-bound and independently verifiable", { 
   assert.equal(a.manifest.runner.loadedBuildIdentity, "runtime-observed-per-artifact");
   assert.equal(a.manifest.environment.node, ">=22");
   assert.equal(a.manifest.environment.python, ">=3.12");
+  assert.equal(a.manifest.environment.buildBrowserPackage, "bash scripts/build-web-demo.sh");
   assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "tools/noon-mcp/src/server.mjs"));
   assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "web/agent-preview-host.js"));
   assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "scripts/agent-preview-sessions.mjs"));
@@ -85,4 +94,33 @@ test("verification rejects modified payload and symlink substitution", { timeout
   await rm(linkedSkill);
   await symlink(path.join(repoRoot, "skills/noon-authoring/SKILL.md"), linkedSkill);
   await assert.rejects(verifyAgentBundle({ bundleDir: linked }), /symbolic link|non-symlink/);
+
+  const target = path.join(root, "root-target");
+  await buildAgentBundle({ outputDir: target });
+  const rootLink = path.join(root, "root-link");
+  await symlink(target, rootLink, "dir");
+  await assert.rejects(verifyAgentBundle({ bundleDir: rootLink }), /non-symlink directory/);
+});
+
+test("verification recomputes required skill and runner file sets", { timeout: 30_000 }, async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-agent-package-omission-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const missingSkill = path.join(root, "missing-skill");
+  await buildAgentBundle({ outputDir: missingSkill });
+  const skillManifest = await readManifest(missingSkill);
+  const skillKey = Object.keys(skillManifest.skill.files).sort()[0];
+  assert.ok(skillKey);
+  delete skillManifest.skill.files[skillKey];
+  await writeManifest(missingSkill, skillManifest);
+  await assert.rejects(verifyAgentBundle({ bundleDir: missingSkill }), /skill package file set/);
+
+  const missingRunner = path.join(root, "missing-runner");
+  await buildAgentBundle({ outputDir: missingRunner });
+  const runnerManifest = await readManifest(missingRunner);
+  const runnerKey = Object.keys(runnerManifest.runner.sourceSha256).sort()[0];
+  assert.ok(runnerKey);
+  delete runnerManifest.runner.sourceSha256[runnerKey];
+  await writeManifest(missingRunner, runnerManifest);
+  await assert.rejects(verifyAgentBundle({ bundleDir: missingRunner }), /runner source file set/);
 });

--- a/scripts/package-noon-agent.test.mjs
+++ b/scripts/package-noon-agent.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  NOON_AGENT_PACKAGE_KIND,
+  NOON_AGENT_PACKAGE_SCHEMA,
+  buildAgentBundle,
+  parsePackageArgs,
+  verifyAgentBundle,
+} from "./package-noon-agent.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+
+async function fileBytes(root, relative) {
+  return await readFile(path.join(root, relative));
+}
+
+test("argument parser requires one explicit package mode", () => {
+  assert.deepEqual(parsePackageArgs(["--output", "out"]), { mode: "output", target: "out", help: false });
+  assert.deepEqual(parsePackageArgs(["--verify", "bundle"]), { mode: "verify", target: "bundle", help: false });
+  assert.equal(parsePackageArgs(["--help"]).help, true);
+  assert.throws(() => parsePackageArgs([]), /exactly one/);
+  assert.throws(() => parsePackageArgs(["--output", "a", "--verify", "b"]), /exactly one/);
+  assert.throws(() => parsePackageArgs(["--unknown"]), /unknown argument/);
+});
+
+test("package is deterministic, checkout-bound and independently verifiable", { timeout: 30_000 }, async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-agent-package-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const first = path.join(root, "first");
+  const second = path.join(root, "second");
+
+  const a = await buildAgentBundle({ outputDir: first });
+  const b = await buildAgentBundle({ outputDir: second });
+  assert.equal(a.manifest.schema, NOON_AGENT_PACKAGE_SCHEMA);
+  assert.equal(a.manifest.kind, NOON_AGENT_PACKAGE_KIND);
+  assert.deepEqual(a.manifest, b.manifest);
+  assert.equal(a.manifest.runner.package, "@noon-animation/mcp");
+  assert.match(a.manifest.runner.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(a.manifest.runner.loadedBuildIdentity, "runtime-observed-per-artifact");
+  assert.equal(a.manifest.environment.node, ">=22");
+  assert.equal(a.manifest.environment.python, ">=3.12");
+  assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "tools/noon-mcp/src/server.mjs"));
+  assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "web/agent-preview-host.js"));
+  assert.ok(Object.keys(a.manifest.runner.sourceSha256).some((name) => name === "scripts/agent-preview-sessions.mjs"));
+
+  for (const relative of Object.keys(a.manifest.payload.files)) {
+    assert.deepEqual(await fileBytes(first, relative), await fileBytes(second, relative), relative);
+  }
+  assert.deepEqual(await fileBytes(first, "manifest.json"), await fileBytes(second, "manifest.json"));
+  const capabilities = JSON.parse(await readFile(path.join(first, "capabilities.json"), "utf8"));
+  assert.equal(capabilities.kind, "noon-agent-capabilities");
+  assert.equal(capabilities.scope, "source-inventory");
+  assert.equal(capabilities.qualification.behavioral_tests_run, false);
+  assert.equal(capabilities.runtime.host, null);
+  assert.equal(capabilities.runtime.renderer_backend, null);
+
+  const verified = await verifyAgentBundle({ bundleDir: first });
+  assert.equal(verified.ok, true);
+  assert.equal(verified.payloadSha256, a.manifest.payload.sha256);
+  assert.equal(verified.runnerSourceSetSha256, a.manifest.runner.sourceSetSha256);
+
+  await assert.rejects(buildAgentBundle({ outputDir: first }), /exist|EEXIST/i,
+    "package builder must never overwrite an existing bundle");
+});
+
+test("verification rejects modified payload and symlink substitution", { timeout: 30_000 }, async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "noon-agent-package-tamper-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const modified = path.join(root, "modified");
+  await buildAgentBundle({ outputDir: modified });
+  const skill = path.join(modified, "skill/noon-authoring/SKILL.md");
+  await writeFile(skill, `${await readFile(skill, "utf8")}\n# tampered\n`);
+  await assert.rejects(verifyAgentBundle({ bundleDir: modified }), /hash mismatch/);
+
+  const linked = path.join(root, "linked");
+  await buildAgentBundle({ outputDir: linked });
+  const linkedSkill = path.join(linked, "skill/noon-authoring/SKILL.md");
+  await rm(linkedSkill);
+  await symlink(path.join(repoRoot, "skills/noon-authoring/SKILL.md"), linkedSkill);
+  await assert.rejects(verifyAgentBundle({ bundleDir: linked }), /symbolic link|non-symlink/);
+});

--- a/skills/noon-authoring/SKILL.md
+++ b/skills/noon-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: noon-authoring
 description: Author and review Noon animation scenes using capability-qualified ManimCE-style Python or the shared Rust API. Use when a user asks to create, explain, repair, or verify a Noon animation, or when scene source imports noon. Not a generic ManimGL skill or a contract for modifying Noon internals.
-compatibility: Requires a trusted Noon repository checkout and Python 3.12+ for capability discovery. Previewing requires the repository's existing browser build and rendering environment; capability discovery alone does not render or install dependencies.
+compatibility: Requires a trusted Noon checkout, Python 3.12+, and Node 22+. Discovery does not render. Isolated CLI/MCP preview additionally requires Docker and a prepared NOON_PREVIEW_RUNTIME_CONFIG; the local runner is not a remote or malicious-checkout sandbox.
 metadata:
   version: "0.1.0"
 ---
@@ -45,31 +45,62 @@ about an installed binary, the current GPU, or a live session. See
 3. Write ordinary `from noon import *` Python for the supported CE-like surface, or
    use the current shared Rust API. Keep the editable source as the deliverable.
    Do not import `manimlib`, invoke `manim`/`manimgl`, or silently switch renderers.
-4. Use the existing playground to render the scene. Inspect the intended initial
-   state, transition interiors, completion boundaries, and final membership. A
-   final blank frame after `FadeOut` can be correct; a successful run alone is not
-   visual verification. Apply the [verification checks](references/verification.md).
+4. Render through the qualified shared preview path when it is configured. Inspect
+   the intended initial state, transition interiors, completion boundaries, and final
+   membership. A final blank frame after `FadeOut` can be correct; a successful run
+   alone is not visual verification. Apply the [verification checks](references/verification.md).
 5. Revise source based on actual diagnostics and frames. Preserve the original
    mathematical and animation semantics; never conceal an unsupported operation by
    replacing `MathTex` with `Text` or removing an updater.
 
 ## Current preview route
 
-Use an already-built playground when available. To build one explicitly:
+The supported file-based agent preview is the shared checkout-bound CLI. Prepare the
+same isolated runtime used by MCP, then render selected authored times:
 
 ```bash
 bash scripts/build-web-demo.sh
-python3 -m http.server --bind 127.0.0.1 --directory web 8080
+cd tools/noon-mcp
+npm ci --ignore-scripts --no-audit --no-fund
+node scripts/setup-preview-runtime.mjs
+# Export the absolute runtimeConfig path printed above.
+export NOON_PREVIEW_RUNTIME_CONFIG=/absolute/path/to/runtime.json
+cd ../..
+node tools/noon-mcp/bin/noon-preview.mjs \
+  --source scene.py --output noon-preview-output \
+  --time 1 --time 1.5 --time 3
 ```
 
-Open the local playground, paste the source into **Python scene source**, and run
-it. The build can require downloads and substantial dependencies; it is not a side
-effect of capability discovery. Do not claim the preview ran when the required
-browser/WASM environment is unavailable.
+The CLI uses the same `AgentPreviewService`, isolated Docker runner, retained artifact
+store, and observed runtime provenance as MCP. Read `manifest.json` and inspect the
+actual `frame-*.png` files; do not substitute a successful process exit for visual
+verification. Sampling is forward-only and bounded, and success/failure both await
+session/container cleanup.
 
-There is not yet a supported `noon render` command or shipped Noon MCP preview
-server in this skill. The isolated runner and MCP adapter are tracked in #1197 and
-#1198. Do not invent their installation or tool commands.
+When the existing local MCP server is launched with that same
+`NOON_PREVIEW_RUNTIME_CONFIG`, use its shared rendering tools rather than inventing
+another render path:
+
+1. `noon_open_scene` with the complete source;
+2. `noon_sample_frames` with a nondecreasing schedule of useful authored times;
+3. `noon_inspect` for the last coherent metadata when needed;
+4. `noon_close_scene` when finished.
+
+`open`/`sample` return actual `image/png` content plus retained descriptors carrying
+source/build/requested-time/published-time/backend provenance. Session handles are
+scope-local and become stale after close/cancellation. A new source edit starts a new
+scene session; persistent live object editing is not implied.
+
+If the isolated runtime is unavailable, the existing browser playground remains a
+manual fallback. Build it with `bash scripts/build-web-demo.sh`, serve `web/` locally,
+and report that the qualified CLI/MCP preview was unavailable. Do not claim rendering
+occurred when only capability discovery or source inspection ran.
+
+For a reproducible source bundle of this skill plus the canonical capability inventory,
+use `node scripts/package-noon-agent.mjs --output <new-directory>` and verify it with
+`node scripts/package-noon-agent.mjs --verify <bundle-directory>`. The bundle identifies
+checkout runner source; actual loaded worker/WASM identity is still observed from each
+preview artifact rather than fabricated from source metadata.
 
 ## Semantic boundaries
 

--- a/skills/noon-authoring/references/verification.md
+++ b/skills/noon-authoring/references/verification.md
@@ -9,11 +9,42 @@ transition. Check object count/membership, source-versus-target identity, endpoi
 layout, clipping, glyphs, and explanatory pacing. Include an initial frame and the
 intended final state, but do not reject a deliberately empty frame after removal.
 
-Record the actual source, Noon revision, execution host/backend, and requested and
-observed scene times when the available tooling exposes them. Null or unavailable
-metadata is not a license to guess. Compare raster evidence only within the
-qualified backend and tolerance policy; do not require universal cross-GPU bit
-identity or widen thresholds to make a failing scene pass.
+Record the actual source, Noon revision, execution host/backend, requested and
+published scene times, and retained artifact/build identities when the tooling exposes
+them. Null or unavailable metadata is not a license to guess. Compare raster evidence
+only within the qualified backend and tolerance policy; do not require universal
+cross-GPU bit identity or widen thresholds to make a failing scene pass.
+
+## Newly authored source
+
+When `NOON_PREVIEW_RUNTIME_CONFIG` has been prepared, prefer the shared isolated CLI
+or MCP path for source-specific evidence. For a file:
+
+```bash
+node tools/noon-mcp/bin/noon-preview.mjs \
+  --source scene.py --output noon-preview-output \
+  --time 1 --time 1.5 --time 3
+```
+
+Verify `manifest.json` and inspect the corresponding PNGs. The manifest binds each
+retained frame to the submitted source hash, observed runtime build identity,
+requested/published time, actual backend, PNG hash, byte length, and opaque session.
+The CLI and configured MCP tools delegate to the same `AgentPreviewService` and runner.
+
+For MCP, use `noon_open_scene`, forward-only `noon_sample_frames`, optional
+`noon_inspect`, and `noon_close_scene`. Do not reuse a handle after close or
+cancellation. A tool result containing an image is evidence only for that returned
+artifact and provenance; it is not proof for an unrendered revision of the source.
+
+The local preview boundary has qualified Docker containment for the supported Linux
+path: network disabled, read-only root/mounts, private namespaces, explicit seccomp,
+all outer capabilities dropped, no-new-privileges, bounded CPU/PID/memory/tmpfs,
+process-level cancellation, and cleanup. Pyodide is pinned into the preview image so
+the runtime does not require network access. This is **not** a hardened remote service
+or a sandbox for a malicious checkout: the configured Noon checkout, runtime setup,
+and local Docker daemon remain trusted inputs.
+
+## Repository changes and corpus checks
 
 For repository changes, the existing validation entrypoints are:
 
@@ -30,12 +61,26 @@ be exercised with:
 node scripts/manim-tutorial-smoke.mjs
 ```
 
-This is a corpus test, not a general source-to-video CLI or a security sandbox.
-Do not claim that invoking it verifies a newly authored source file unless that
-file was actually included in the run. CI declarations and manifest labels are
-not current test results. Report the exact tests and images actually inspected.
+This is a corpus test, not proof that a different source file was rendered. CI
+declarations and manifest labels are not current test results. Report the exact tests,
+backend, source revision, artifact hashes, and images actually inspected.
 
-Do not execute untrusted scene code against unrestricted host files, credentials,
-or networking. AST parsing, a browser worker, local MCP transport, and a timeout
-are not by themselves sufficient isolation. The bounded agent runner is separate
-work; do not present today's repository harness as a hardened remote service.
+## Reproducible source package
+
+A checkout-bound authoring package can be built and verified without installing npm
+dependencies or running lifecycle hooks:
+
+```bash
+node scripts/package-noon-agent.mjs --output /new/path/noon-agent-bundle
+node scripts/package-noon-agent.mjs --verify /new/path/noon-agent-bundle
+```
+
+The bundle contains the maintained skill and canonical source capability inventory,
+plus hashes for the runner/MCP source it delegates to. Those source hashes are not a
+substitute for the actual loaded worker/WASM identity: preview artifacts obtain that
+identity from the running browser worker and retain it with each frame.
+
+Do not execute untrusted scene code against unrestricted host files, credentials, or
+networking. Capability discovery and bundle verification execute no scenes. If the
+qualified local preview boundary is unavailable, report that limitation rather than
+silently falling back to unrestricted source execution.


### PR DESCRIPTION
Advances #1199 with the first bounded packaging/source-identity slice on top of #1427.

## Package

Adds `scripts/package-noon-agent.mjs` with explicit `--output` and `--verify` modes. The package is checkout-bound and deterministic: it contains the existing `skills/noon-authoring` tree plus the canonical `scripts/noon-capabilities.py` source inventory, and a manifest records exact payload hashes, source revision/dirty state, MCP package/version/lock identities, and the local runner source dependency set derived from the real CLI/server/worker/setup entrypoints and their relative imports.

The package deliberately does **not** invent a loaded engine identity. `runner.loadedBuildIdentity` is explicitly `runtime-observed-per-artifact`; actual worker/WASM/build identity continues to come from the qualified browser worker and retained preview artifacts.

Verification is not self-referential: it recomputes the canonical capability inventory, the complete current `skills/noon-authoring` tree, and the exact runner dependency file set from the checkout before accepting the manifest. It rejects payload drift, omitted/extra skill or runner entries, source/package/generator drift, unexpected payload files, payload or bundle-root symlinks, and a bundle built for another checkout revision. Output uses exclusive creation and never overwrites an existing bundle.

Node 22+ and Python 3.12+ are explicit. Capability generation runs with a scrubbed subprocess environment; package build/verify execute no scenes and install no npm dependencies or lifecycle hooks.

## Skill/docs

Updates the existing authoring skill to use the landed shared preview path: capability discovery -> isolated CLI or configured MCP -> actual retained PNG/provenance inspection -> revision. Manual browser playground remains a fallback. The verification reference distinguishes the qualified local Docker boundary from a remote/malicious-checkout sandbox and documents package build/verify. The skill checker validates repository-level discovery/build/package commands; the package dependency-graph verifier separately requires the real CLI/server/worker/runtime-setup entrypoints and their current imported sources.

## Qualification

`Noon agent foundation` sets up Python 3.12 and Node 22, runs capability/skill checks and package determinism/tamper/omission tests, then builds and verifies a package under an `env -i` scrubbed environment before any npm install. It uploads the verified bundle as CI evidence. Existing capability inventory and artifact-ownership qualification remain intact.

No third-party runtime bytes are copied into this bundle: the payload is the repository-authored skill plus generated capability JSON. Runner/runtime files are source-hashed references in the trusted checkout; loaded worker/WASM identity remains observed at runtime.

Out of scope: the deterministic semantic evaluation corpus, docs-only vs skill+runner vs skill+MCP comparison, stochastic agent runs, scoring/reporting, or any new scene/runtime/renderer/capability authority. Those are follow-up #1199 slices and the deterministic corpus will also close #1197's remaining R5 semantic-breadth rows.

Base at start: `222a8b60c9d20e3338267b05f3712931ba28ad03`. Repository CI/self-review only per `AGENTS.override.md`.