### PR TITLE
Package reproducible agent setup and identity

### DIFF
--- a/.github/workflows/authoring-agent-discovery.yml
+++ b/.github/workflows/authoring-agent-discovery.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "tools/noon-mcp/**"
+      - "skills/noon-authoring/**"
       - "scripts/noon-capabilities.py"
       - "scripts/manim-api-coverage.py"
       - "compat/manim-v0.21.0.json"
@@ -19,6 +20,7 @@ on:
     branches: [master]
     paths:
       - "tools/noon-mcp/**"
+      - "skills/noon-authoring/**"
       - "scripts/noon-capabilities.py"
       - "scripts/manim-api-coverage.py"
       - "compat/manim-v0.21.0.json"
@@ -64,6 +66,56 @@ jobs:
         run: npm test
       - name: Preserve explicit CI topology registration
         run: node ../../web/ci-workflow-topology.test.mjs
+
+  packaging:
+    name: Clean agent package setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: tools/noon-mcp
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: tools/noon-mcp/package-lock.json
+      - name: Prove setup starts without ambient package state
+        run: |
+          test ! -e node_modules
+          test ! -e ../../node_modules
+      - name: Install only the exact lockfile without lifecycle hooks
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Emit deterministic package, skill, capability and runner identity
+        env:
+          NOON_REPO: ${{ github.workspace }}
+        run: |
+          export NOON_PYTHON="$(python3 -I -S -c 'import sys; print(sys.executable)')"
+          node scripts/package-manifest.mjs > "$RUNNER_TEMP/noon-agent-distribution.json"
+          node -e '
+            const fs = require("node:fs");
+            const value = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/noon-agent-distribution.json", "utf8"));
+            if (value.kind !== "noon-agent-distribution" || value.schemaVersion !== 1) process.exit(1);
+            if (value.runner.versions.loadedBuildIdentity !== null) process.exit(1);
+            if (value.environment.preview.implicitLifecycleHooks !== false) process.exit(1);
+          '
+      - name: Exercise real SDK discovery from the clean setup
+        env:
+          NOON_REPO: ${{ github.workspace }}
+        run: |
+          export NOON_PYTHON="$(python3 -I -S -c 'import sys; print(sys.executable)')"
+          node scripts/clean-setup-smoke.mjs
+      - name: Upload package identity evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-agent-distribution
+          path: ${{ runner.temp }}/noon-agent-distribution.json
+          if-no-files-found: error
+          retention-days: 14
 
   preview-isolation:
     name: Docker-isolated real browser preview

--- a/scripts/check-noon-agent-skill.py
+++ b/scripts/check-noon-agent-skill.py
@@ -14,6 +14,10 @@ SKILL = "skills/noon-authoring"
 COMMANDS = (
     "scripts/noon-capabilities.py", "scripts/build-web-demo.sh",
     "scripts/check.sh", "scripts/manim-tutorial-smoke.mjs",
+    "tools/noon-mcp/bin/noon-preview.mjs",
+    "tools/noon-mcp/src/server.mjs",
+    "tools/noon-mcp/scripts/setup-preview-runtime.mjs",
+    "tools/noon-mcp/scripts/package-manifest.mjs",
 )
 
 

--- a/scripts/test_noon_capabilities.py
+++ b/scripts/test_noon_capabilities.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python3
+"""Deterministic source-inventory tests; no Manim, WASM, browser or scenes run."""
 from __future__ import annotations
 
+import copy
+import hashlib
 import importlib.util
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -24,229 +25,210 @@ class CapabilityTests(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
         self.root = Path(self.temp.name)
-        (self.root / "compat").mkdir()
-        (self.root / "scripts").mkdir()
-        (self.root / "web/python/examples").mkdir(parents=True)
-        (self.root / "web/python/_manim_compat.py").write_text("EXPORTED = ('Circle', 'Transform', 'Axes')\n", encoding="utf-8")
-        (self.root / "web/python/noon.py").write_text("from _manim_compat import *\n", encoding="utf-8")
-        (self.root / "scripts/manim-api-coverage.py").write_text(
-            """from pathlib import Path\n"
-            "def validate_tutorial_examples(entries):\n"
-            "    ids=[e.get('id') for e in entries]\n"
-            "    return ['duplicate tutorial example id'] if len(ids)!=len(set(ids)) else []\n"
-            "def noon_public_exports(): return {'Circle','Transform','Axes'}\n"
-            "def browser_evidence_for(name, entries):\n"
-            "    return [e['id'] for e in entries if e.get('status')=='ready' and name in e.get('features',[])]\n"
-            """, encoding="utf-8")
-        shutil.copy2(SCRIPTS / "noon-capabilities.py", self.root / "scripts/noon-capabilities.py")
+        for directory in ("scripts", "compat", "web/python/examples"):
+            (self.root / directory).mkdir(parents=True)
+        for name in ("manim-api-coverage.py", "noon-capabilities.py"):
+            shutil.copyfile(SCRIPTS / name, self.root / "scripts" / name)
+        (self.root / "web/python/noon.py").write_text(
+            '__all__ = ["Circle", "Text", "NewThing"]\nraise RuntimeError("must not import noon")\n',
+            encoding="utf-8",
+        )
+        (self.root / "web/python/_manim_test.py").write_text(
+            'public = {"Create": None}\nraise RuntimeError("must not import adapter")\n', encoding="utf-8",
+        )
+        (self.root / "web/python/examples/circle.py").write_text(
+            'raise RuntimeError("must not execute example")\n', encoding="utf-8",
+        )
         self.policy = {
             "reference": {"package": "manim", "version": "0.21.0"},
-            "statuses": ["supported", "partial", "blocked"],
+            "statuses": ["supported", "partial", "missing", "blocked", "deferred", "intentional-divergence"],
             "overrides": {
-                "Circle": {"status": "supported", "evidence": "circle browser fixture"},
-                "Transform": {"status": "partial", "reason": "subset"},
-                "Axes": {"status": "blocked", "reason": "plotting unavailable"},
+                "Circle": {"status": "supported", "evidence": "fixture test"},
+                "Text": {"status": "partial", "reason": "No exact glyph parity", "dependency": "#83"},
+                "Axes": {"status": "missing", "dependency": "#85"},
             },
         }
         self.tutorial = {
             "reference": {"version": "0.21.0"},
             "entries": [
-                {"id": "circle", "status": "ready", "path": "python/examples/circle.py", "features": ["Circle"]},
-                {"id": "transform", "status": "ready", "path": "python/examples/transform.py", "features": ["Transform"], "parity_status": "candidate"},
-                {"id": "plot", "status": "blocked", "path": "python/examples/plot.py", "features": ["Axes"]},
+                {"id": "circle", "status": "ready", "path": "python/examples/circle.py",
+                 "features": ["Circle", "Create"], "upstream": "quickstart", "reuse": "fixture",
+                 "parity_status": "candidate", "qualification_mode": "shared-live"},
+                {"id": "plot", "status": "blocked", "dependency": "#85", "features": ["Axes"]},
             ],
         }
         self.save()
-        (self.root / "web/python/examples/circle.py").write_text("# circle\n", encoding="utf-8")
-        (self.root / "web/python/examples/transform.py").write_text("# transform\n", encoding="utf-8")
-        (self.root / "web/python/examples/plot.py").write_text("# plot\n", encoding="utf-8")
 
     def save(self):
-        (self.root / "compat/manim-v0.21.0.json").write_text(json.dumps(self.policy), encoding="utf-8")
-        (self.root / "web/python/examples/manim_tutorial_manifest.json").write_text(json.dumps(self.tutorial), encoding="utf-8")
+        (self.root / cap.POLICY).write_text(json.dumps(self.policy), encoding="utf-8")
+        (self.root / cap.TUTORIALS).write_text(json.dumps(self.tutorial), encoding="utf-8")
 
     def report(self):
+        self.save()
         return cap.build_report(self.root)
 
     def test_source_inventory_is_not_runtime_qualification(self):
         report = self.report()
+        self.assertEqual(report["schema_version"], 1)
         self.assertEqual(report["scope"], "source-inventory")
         self.assertFalse(report["qualification"]["behavioral_tests_run"])
+        self.assertTrue(all(value is None for value in report["runtime"].values()))
+        self.assertIsNone(report["provenance"]["revision"])
         self.assertFalse(report["symbols"]["Circle"]["runtime_verified"])
-        self.assertFalse(report["examples"]["circle"]["runtime_verified"])
 
-    def test_hashes_cover_inputs_and_change_with_source(self):
-        first = self.report()
-        hashes = first["provenance"]["input_sha256"]
-        self.assertIn("web/python/examples/circle.py", hashes)
-        self.assertIn("scripts/noon-capabilities.py", hashes)
-        self.assertRegex(hashes["web/python/examples/circle.py"], r"^[0-9a-f]{64}$")
-        self.assertEqual(first["examples"]["circle"]["source_sha256"], hashes["web/python/examples/circle.py"])
-        (self.root / "web/python/examples/circle.py").write_text("# changed\n", encoding="utf-8")
-        second = self.report()
-        self.assertNotEqual(first["examples"]["circle"]["source_sha256"], second["examples"]["circle"]["source_sha256"])
+    def test_noon_adapter_and_example_are_not_executed(self):
+        report = self.report()  # All three fixture files would raise on execution.
+        self.assertTrue(report["symbols"]["Create"]["exported"])
+        self.assertNotIn("manim", sys.modules)
 
-    def test_output_is_deterministic(self):
-        self.assertEqual(self.report(), self.report())
+    def test_static_module_exports_preserve_literal_and_unpacked_names(self):
+        (self.root / "web/python/noon.py").write_text(
+            '_PUBLIC_EXPORTS = {"Text": "_manim_typst", "Square": "_manim_compat"}\n'
+            '_PRIVATE = {"Hidden": "internal"}\n'
+            '__all__ = ["Circle", "NewThing", *_PUBLIC_EXPORTS]\n'
+            'raise RuntimeError("must not import noon")\n', encoding="utf-8",
+        )
+        symbols = self.report()["symbols"]
+        for name in ("Circle", "Text", "Square", "NewThing"):
+            self.assertTrue(symbols[name]["exported"])
+        self.assertNotIn("Hidden", symbols)
+        self.assertFalse(symbols["Square"]["runtime_verified"])
 
-    def test_symbol_filter_returns_relevant_ready_examples(self):
-        selected = cap.select_report(self.report(), ["Circle"], [])
-        self.assertEqual(set(selected["symbols"]), {"Circle"})
-        self.assertEqual(set(selected["examples"]), {"circle"})
+    def test_unclassified_export_cannot_be_promoted(self):
+        row = self.report()["symbols"]["NewThing"]
+        self.assertEqual(row["policy"]["status"], "partial")
+        self.assertEqual(row["classification_source"], "unclassified-export")
 
-    def test_unknown_symbol_and_example_fail(self):
-        report = self.report()
-        with self.assertRaisesRegex(ValueError, "unknown symbols"):
-            cap.select_report(report, ["Nope"], [])
-        with self.assertRaisesRegex(ValueError, "unknown examples"):
-            cap.select_report(report, [], ["nope"])
+    def test_restrictions_and_dependencies_survive(self):
+        row = self.report()["symbols"]["Text"]
+        self.assertEqual(row["policy"], self.policy["overrides"]["Text"])
+        self.assertEqual(row["ready_examples"], [])
+
+    def test_ready_candidate_is_not_parity_qualified(self):
+        row = self.report()["examples"]["circle"]
+        self.assertEqual(row["parity_status"], "candidate")
+        self.assertEqual(row["qualification_mode"], "shared-live")
+        self.assertFalse(row["runtime_verified"])
+
+    def test_qualified_label_needs_fixture(self):
+        self.tutorial["entries"][0]["parity_status"] = "parity-qualified"
+        with self.assertRaisesRegex(ValueError, "requires a parity fixture"):
+            self.report()
+
+    def test_unknown_parity_label_fails(self):
+        self.tutorial["entries"][0]["parity_status"] = "looks-good"
+        with self.assertRaisesRegex(ValueError, "invalid parity_status"):
+            self.report()
 
     def test_supported_requires_export(self):
-        self.policy["overrides"]["Missing"] = {"status": "supported", "evidence": "none"}
-        self.save()
+        self.policy["overrides"]["Ghost"] = {"status": "supported", "evidence": "test"}
         with self.assertRaisesRegex(ValueError, "export is absent"):
             self.report()
 
     def test_supported_requires_evidence(self):
         del self.policy["overrides"]["Circle"]["evidence"]
-        self.save()
         with self.assertRaisesRegex(ValueError, "requires declared evidence"):
             self.report()
 
     def test_blocked_export_with_ready_evidence_fails(self):
-        self.policy["overrides"]["Circle"] = {"status": "blocked", "reason": "bad"}
-        self.save()
-        with self.assertRaisesRegex(ValueError, "blocked export has ready tutorial evidence"):
+        self.policy["overrides"]["Circle"]["status"] = "blocked"
+        with self.assertRaisesRegex(ValueError, "blocked export"):
             self.report()
-
-    def test_unclassified_export_cannot_be_promoted(self):
-        del self.policy["overrides"]["Transform"]
-        self.save()
-        row = self.report()["symbols"]["Transform"]
-        self.assertEqual(row["classification_source"], "unclassified-export")
-        self.assertEqual(row["policy"]["status"], "partial")
-        self.assertIn("Statically exported", row["policy"]["reason"])
-
-    def test_restrictions_and_dependencies_survive(self):
-        self.policy["overrides"]["Transform"]["restriction"] = "same-family only"
-        self.policy["overrides"]["Transform"]["dependency"] = "supported mobject"
-        self.save()
-        row = self.report()["symbols"]["Transform"]["policy"]
-        self.assertEqual(row["restriction"], "same-family only")
-        self.assertEqual(row["dependency"], "supported mobject")
-
-    def test_ready_candidate_is_not_parity_qualified(self):
-        row = self.report()["examples"]["transform"]
-        self.assertEqual(row["status"], "ready")
-        self.assertEqual(row["parity_status"], "candidate")
-        self.assertNotIn("parity_fixture", row)
-
-    def test_qualified_label_needs_fixture(self):
-        self.tutorial["entries"][0]["parity_status"] = "parity-qualified"
-        self.save()
-        with self.assertRaisesRegex(ValueError, "requires a parity fixture"):
-            self.report()
-
-    def test_blocked_example_is_visible_but_not_ready_evidence(self):
-        report = self.report()
-        self.assertIn("plot", report["examples"])
-        self.assertEqual(report["examples"]["plot"]["status"], "blocked")
-        self.assertNotIn("source_sha256", report["examples"]["plot"])
-        self.assertEqual(report["symbols"]["Axes"]["ready_examples"], [])
 
     def test_missing_inventory_fails(self):
-        (self.root / "compat/manim-v0.21.0.json").unlink()
-        with self.assertRaises(OSError):
-            self.report()
+        (self.root / cap.TUTORIALS).unlink()
+        with self.assertRaisesRegex(ValueError, "missing or unconfined"):
+            cap.build_report(self.root)
 
     def test_malformed_inventory_fails(self):
-        (self.root / "compat/manim-v0.21.0.json").write_text("[]", encoding="utf-8")
-        with self.assertRaisesRegex(ValueError, "expected a JSON object"):
-            self.report()
+        (self.root / cap.POLICY).write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "JSON object"):
+            cap.build_report(self.root)
 
     def test_version_mismatch_fails(self):
-        self.tutorial["reference"]["version"] = "0.20.0"
-        self.save()
+        self.tutorial["reference"]["version"] = "99"
         with self.assertRaisesRegex(ValueError, "versions differ"):
             self.report()
 
     def test_invalid_policy_status_fails(self):
-        self.policy["overrides"]["Circle"]["status"] = "working"
-        self.save()
+        self.policy["overrides"]["Circle"]["status"] = "probably"
         with self.assertRaisesRegex(ValueError, "invalid policy status"):
             self.report()
 
-    def test_invalid_features_fail(self):
-        self.tutorial["entries"][0]["features"] = "Circle"
-        self.save()
-        with self.assertRaisesRegex(ValueError, "features must be a string array"):
-            self.report()
-
-    def test_unknown_parity_label_fails(self):
-        self.tutorial["entries"][0]["parity_status"] = "gold"
-        self.save()
-        with self.assertRaisesRegex(ValueError, "invalid parity_status"):
-            self.report()
-
     def test_duplicate_example_fails(self):
-        self.tutorial["entries"].append(dict(self.tutorial["entries"][0]))
-        self.save()
-        with self.assertRaisesRegex(ValueError, "duplicate tutorial example id"):
+        self.tutorial["entries"].append(copy.deepcopy(self.tutorial["entries"][0]))
+        with self.assertRaisesRegex(ValueError, "duplicate id"):
             self.report()
 
     def test_missing_ready_example_fails(self):
         (self.root / "web/python/examples/circle.py").unlink()
-        with self.assertRaisesRegex(ValueError, "missing or unconfined repository file"):
-            self.report()
-
-    def test_absolute_example_is_rejected(self):
-        self.tutorial["entries"][0]["path"] = "/tmp/scene.py"
-        self.save()
-        with self.assertRaisesRegex(ValueError, "unsafe absolute example path"):
+        with self.assertRaisesRegex(ValueError, "missing fixture"):
             self.report()
 
     def test_parent_traversal_is_rejected_even_when_file_exists(self):
-        (self.root / "web/escape.py").write_text("# escape\n", encoding="utf-8")
-        self.tutorial["entries"][0]["path"] = "python/examples/../../escape.py"
-        self.save()
+        self.tutorial["entries"][0]["path"] = "../web/python/examples/circle.py"
         with self.assertRaisesRegex(ValueError, "unsafe repository path"):
             self.report()
 
-    def test_symlink_escape_is_rejected(self):
-        outside = Path(self.temp.name).parent / "outside-noon-capability.py"
-        outside.write_text("# outside\n", encoding="utf-8")
-        self.addCleanup(lambda: outside.unlink(missing_ok=True))
-        target = self.root / "web/python/examples/circle.py"
-        target.unlink()
-        target.symlink_to(outside)
-        with self.assertRaisesRegex(ValueError, "missing or unconfined repository file"):
+    def test_absolute_example_is_rejected(self):
+        self.tutorial["entries"][0]["path"] = str(self.root / "web/python/examples/circle.py")
+        with self.assertRaisesRegex(ValueError, "unsafe absolute"):
             self.report()
 
-    def test_noon_adapter_and_example_are_not_executed(self):
-        (self.root / "web/python/noon.py").write_text("raise RuntimeError('must not execute noon.py')\n", encoding="utf-8")
-        (self.root / "web/python/examples/circle.py").write_text("raise RuntimeError('must not execute scene')\n", encoding="utf-8")
-        report = self.report()
-        self.assertIn("Circle", report["symbols"])
-        self.assertRegex(report["examples"]["circle"]["source_sha256"], r"^[0-9a-f]{64}$")
+    def test_symlink_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "outside.py"
+            target.write_text("secret", encoding="utf-8")
+            fixture = self.root / "web/python/examples/circle.py"
+            fixture.unlink()
+            fixture.symlink_to(target)
+            with self.assertRaisesRegex(ValueError, "unconfined"):
+                self.report()
 
-    def test_static_module_exports_preserve_literal_and_unpacked_names(self):
-        (self.root / "web/python/_manim_more.py").write_text("EXPORTED = ('Line',)\n", encoding="utf-8")
-        (self.root / "web/python/_manim_compat.py").write_text(
-            "EXPORTED = ('Circle', 'Transform', 'Axes')\nfrom _manim_more import *\n", encoding="utf-8")
-        self.policy["overrides"]["Line"] = {"status": "partial", "reason": "line subset"}
-        self.save()
+    def test_invalid_features_fail(self):
+        self.tutorial["entries"][0]["features"] = "Circle"
+        with self.assertRaisesRegex(ValueError, "features must be"):
+            self.report()
+
+    def test_hashes_cover_inputs_and_change_with_source(self):
+        before = self.report()
+        path = "web/python/examples/circle.py"
+        expected = hashlib.sha256((self.root / path).read_bytes()).hexdigest()
+        self.assertEqual(before["provenance"]["input_sha256"][path], expected)
+        self.assertEqual(before["examples"]["circle"]["source_sha256"], expected)
+        (self.root / path).write_text("# changed\n", encoding="utf-8")
+        self.assertNotEqual(self.report()["examples"]["circle"]["source_sha256"], expected)
+
+    def test_output_is_deterministic(self):
+        self.assertEqual(self.report(), self.report())
+
+    def test_symbol_filter_returns_relevant_ready_examples(self):
         report = self.report()
-        self.assertIn("Line", report["symbols"])
-        self.assertTrue(report["symbols"]["Line"]["exported"])
+        selected = cap.select_report(report, ["Circle"], [])
+        self.assertEqual(list(selected["symbols"]), ["Circle"])
+        self.assertEqual(list(selected["examples"]), ["circle"])
+        self.assertIn("Text", report["symbols"])  # No mutation of input.
+
+    def test_unknown_symbol_and_example_fail(self):
+        report = self.report()
+        for symbols, examples in ((["typo"], []), ([], ["typo"])):
+            with self.subTest(symbols=symbols, examples=examples):
+                with self.assertRaisesRegex(ValueError, "unknown"):
+                    cap.select_report(report, symbols, examples)
+
+    def test_blocked_example_is_visible_but_not_ready_evidence(self):
+        selected = cap.select_report(self.report(), ["Axes"], ["plot"])
+        self.assertEqual(selected["examples"]["plot"]["status"], "blocked")
+        self.assertEqual(selected["symbols"]["Axes"]["ready_examples"], [])
 
     def test_cli_works_from_another_directory_without_site_packages(self):
         result = subprocess.run(
             [sys.executable, "-S", "-B", str(self.root / "scripts/noon-capabilities.py"), "--symbol", "Circle"],
-            cwd=Path(self.temp.name).parent, capture_output=True, text=True, timeout=10,
+            cwd="/", capture_output=True, text=True, timeout=10,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        report = json.loads(result.stdout)
-        self.assertEqual(set(report["symbols"]), {"Circle"})
+        self.assertEqual(list(json.loads(result.stdout)["symbols"]), ["Circle"])
+        self.assertEqual(result.stderr, "")
 
     def test_cli_invalid_query_has_no_success_output(self):
         result = subprocess.run(

--- a/scripts/test_noon_capabilities.py
+++ b/scripts/test_noon_capabilities.py
@@ -1,10 +1,9 @@
-"""Deterministic source-inventory tests; no Manim, WASM, browser or scenes run."""
+#!/usr/bin/env python3
 from __future__ import annotations
 
-import copy
-import hashlib
 import importlib.util
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -25,210 +24,229 @@ class CapabilityTests(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
         self.root = Path(self.temp.name)
-        for directory in ("scripts", "compat", "web/python/examples"):
-            (self.root / directory).mkdir(parents=True)
-        for name in ("manim-api-coverage.py", "noon-capabilities.py"):
-            shutil.copyfile(SCRIPTS / name, self.root / "scripts" / name)
-        (self.root / "web/python/noon.py").write_text(
-            '__all__ = ["Circle", "Text", "NewThing"]\nraise RuntimeError("must not import noon")\n',
-            encoding="utf-8",
-        )
-        (self.root / "web/python/_manim_test.py").write_text(
-            'public = {"Create": None}\nraise RuntimeError("must not import adapter")\n', encoding="utf-8",
-        )
-        (self.root / "web/python/examples/circle.py").write_text(
-            'raise RuntimeError("must not execute example")\n', encoding="utf-8",
-        )
+        (self.root / "compat").mkdir()
+        (self.root / "scripts").mkdir()
+        (self.root / "web/python/examples").mkdir(parents=True)
+        (self.root / "web/python/_manim_compat.py").write_text("EXPORTED = ('Circle', 'Transform', 'Axes')\n", encoding="utf-8")
+        (self.root / "web/python/noon.py").write_text("from _manim_compat import *\n", encoding="utf-8")
+        (self.root / "scripts/manim-api-coverage.py").write_text(
+            """from pathlib import Path\n"
+            "def validate_tutorial_examples(entries):\n"
+            "    ids=[e.get('id') for e in entries]\n"
+            "    return ['duplicate tutorial example id'] if len(ids)!=len(set(ids)) else []\n"
+            "def noon_public_exports(): return {'Circle','Transform','Axes'}\n"
+            "def browser_evidence_for(name, entries):\n"
+            "    return [e['id'] for e in entries if e.get('status')=='ready' and name in e.get('features',[])]\n"
+            """, encoding="utf-8")
+        shutil.copy2(SCRIPTS / "noon-capabilities.py", self.root / "scripts/noon-capabilities.py")
         self.policy = {
             "reference": {"package": "manim", "version": "0.21.0"},
-            "statuses": ["supported", "partial", "missing", "blocked", "deferred", "intentional-divergence"],
+            "statuses": ["supported", "partial", "blocked"],
             "overrides": {
-                "Circle": {"status": "supported", "evidence": "fixture test"},
-                "Text": {"status": "partial", "reason": "No exact glyph parity", "dependency": "#83"},
-                "Axes": {"status": "missing", "dependency": "#85"},
+                "Circle": {"status": "supported", "evidence": "circle browser fixture"},
+                "Transform": {"status": "partial", "reason": "subset"},
+                "Axes": {"status": "blocked", "reason": "plotting unavailable"},
             },
         }
         self.tutorial = {
             "reference": {"version": "0.21.0"},
             "entries": [
-                {"id": "circle", "status": "ready", "path": "python/examples/circle.py",
-                 "features": ["Circle", "Create"], "upstream": "quickstart", "reuse": "fixture",
-                 "parity_status": "candidate", "qualification_mode": "shared-live"},
-                {"id": "plot", "status": "blocked", "dependency": "#85", "features": ["Axes"]},
+                {"id": "circle", "status": "ready", "path": "python/examples/circle.py", "features": ["Circle"]},
+                {"id": "transform", "status": "ready", "path": "python/examples/transform.py", "features": ["Transform"], "parity_status": "candidate"},
+                {"id": "plot", "status": "blocked", "path": "python/examples/plot.py", "features": ["Axes"]},
             ],
         }
         self.save()
+        (self.root / "web/python/examples/circle.py").write_text("# circle\n", encoding="utf-8")
+        (self.root / "web/python/examples/transform.py").write_text("# transform\n", encoding="utf-8")
+        (self.root / "web/python/examples/plot.py").write_text("# plot\n", encoding="utf-8")
 
     def save(self):
-        (self.root / cap.POLICY).write_text(json.dumps(self.policy), encoding="utf-8")
-        (self.root / cap.TUTORIALS).write_text(json.dumps(self.tutorial), encoding="utf-8")
+        (self.root / "compat/manim-v0.21.0.json").write_text(json.dumps(self.policy), encoding="utf-8")
+        (self.root / "web/python/examples/manim_tutorial_manifest.json").write_text(json.dumps(self.tutorial), encoding="utf-8")
 
     def report(self):
-        self.save()
         return cap.build_report(self.root)
 
     def test_source_inventory_is_not_runtime_qualification(self):
         report = self.report()
-        self.assertEqual(report["schema_version"], 1)
         self.assertEqual(report["scope"], "source-inventory")
         self.assertFalse(report["qualification"]["behavioral_tests_run"])
-        self.assertTrue(all(value is None for value in report["runtime"].values()))
-        self.assertIsNone(report["provenance"]["revision"])
         self.assertFalse(report["symbols"]["Circle"]["runtime_verified"])
-
-    def test_noon_adapter_and_example_are_not_executed(self):
-        report = self.report()  # All three fixture files would raise on execution.
-        self.assertTrue(report["symbols"]["Create"]["exported"])
-        self.assertNotIn("manim", sys.modules)
-
-    def test_static_module_exports_preserve_literal_and_unpacked_names(self):
-        (self.root / "web/python/noon.py").write_text(
-            '_PUBLIC_EXPORTS = {"Text": "_manim_typst", "Square": "_manim_compat"}\n'
-            '_PRIVATE = {"Hidden": "internal"}\n'
-            '__all__ = ["Circle", "NewThing", *_PUBLIC_EXPORTS]\n'
-            'raise RuntimeError("must not import noon")\n', encoding="utf-8",
-        )
-        symbols = self.report()["symbols"]
-        for name in ("Circle", "Text", "Square", "NewThing"):
-            self.assertTrue(symbols[name]["exported"])
-        self.assertNotIn("Hidden", symbols)
-        self.assertFalse(symbols["Square"]["runtime_verified"])
-
-    def test_unclassified_export_cannot_be_promoted(self):
-        row = self.report()["symbols"]["NewThing"]
-        self.assertEqual(row["policy"]["status"], "partial")
-        self.assertEqual(row["classification_source"], "unclassified-export")
-
-    def test_restrictions_and_dependencies_survive(self):
-        row = self.report()["symbols"]["Text"]
-        self.assertEqual(row["policy"], self.policy["overrides"]["Text"])
-        self.assertEqual(row["ready_examples"], [])
-
-    def test_ready_candidate_is_not_parity_qualified(self):
-        row = self.report()["examples"]["circle"]
-        self.assertEqual(row["parity_status"], "candidate")
-        self.assertEqual(row["qualification_mode"], "shared-live")
-        self.assertFalse(row["runtime_verified"])
-
-    def test_qualified_label_needs_fixture(self):
-        self.tutorial["entries"][0]["parity_status"] = "parity-qualified"
-        with self.assertRaisesRegex(ValueError, "requires a parity fixture"):
-            self.report()
-
-    def test_unknown_parity_label_fails(self):
-        self.tutorial["entries"][0]["parity_status"] = "looks-good"
-        with self.assertRaisesRegex(ValueError, "invalid parity_status"):
-            self.report()
-
-    def test_supported_requires_export(self):
-        self.policy["overrides"]["Ghost"] = {"status": "supported", "evidence": "test"}
-        with self.assertRaisesRegex(ValueError, "export is absent"):
-            self.report()
-
-    def test_supported_requires_evidence(self):
-        del self.policy["overrides"]["Circle"]["evidence"]
-        with self.assertRaisesRegex(ValueError, "requires declared evidence"):
-            self.report()
-
-    def test_blocked_export_with_ready_evidence_fails(self):
-        self.policy["overrides"]["Circle"]["status"] = "blocked"
-        with self.assertRaisesRegex(ValueError, "blocked export"):
-            self.report()
-
-    def test_missing_inventory_fails(self):
-        (self.root / cap.TUTORIALS).unlink()
-        with self.assertRaisesRegex(ValueError, "missing or unconfined"):
-            cap.build_report(self.root)
-
-    def test_malformed_inventory_fails(self):
-        (self.root / cap.POLICY).write_text("[]", encoding="utf-8")
-        with self.assertRaisesRegex(ValueError, "JSON object"):
-            cap.build_report(self.root)
-
-    def test_version_mismatch_fails(self):
-        self.tutorial["reference"]["version"] = "99"
-        with self.assertRaisesRegex(ValueError, "versions differ"):
-            self.report()
-
-    def test_invalid_policy_status_fails(self):
-        self.policy["overrides"]["Circle"]["status"] = "probably"
-        with self.assertRaisesRegex(ValueError, "invalid policy status"):
-            self.report()
-
-    def test_duplicate_example_fails(self):
-        self.tutorial["entries"].append(copy.deepcopy(self.tutorial["entries"][0]))
-        with self.assertRaisesRegex(ValueError, "duplicate id"):
-            self.report()
-
-    def test_missing_ready_example_fails(self):
-        (self.root / "web/python/examples/circle.py").unlink()
-        with self.assertRaisesRegex(ValueError, "missing fixture"):
-            self.report()
-
-    def test_parent_traversal_is_rejected_even_when_file_exists(self):
-        self.tutorial["entries"][0]["path"] = "../web/python/examples/circle.py"
-        with self.assertRaisesRegex(ValueError, "unsafe repository path"):
-            self.report()
-
-    def test_absolute_example_is_rejected(self):
-        self.tutorial["entries"][0]["path"] = str(self.root / "web/python/examples/circle.py")
-        with self.assertRaisesRegex(ValueError, "unsafe absolute"):
-            self.report()
-
-    def test_symlink_escape_is_rejected(self):
-        with tempfile.TemporaryDirectory() as outside:
-            target = Path(outside) / "outside.py"
-            target.write_text("secret", encoding="utf-8")
-            fixture = self.root / "web/python/examples/circle.py"
-            fixture.unlink()
-            fixture.symlink_to(target)
-            with self.assertRaisesRegex(ValueError, "unconfined"):
-                self.report()
-
-    def test_invalid_features_fail(self):
-        self.tutorial["entries"][0]["features"] = "Circle"
-        with self.assertRaisesRegex(ValueError, "features must be"):
-            self.report()
+        self.assertFalse(report["examples"]["circle"]["runtime_verified"])
 
     def test_hashes_cover_inputs_and_change_with_source(self):
-        before = self.report()
-        path = "web/python/examples/circle.py"
-        expected = hashlib.sha256((self.root / path).read_bytes()).hexdigest()
-        self.assertEqual(before["provenance"]["input_sha256"][path], expected)
-        self.assertEqual(before["examples"]["circle"]["source_sha256"], expected)
-        (self.root / path).write_text("# changed\n", encoding="utf-8")
-        self.assertNotEqual(self.report()["examples"]["circle"]["source_sha256"], expected)
+        first = self.report()
+        hashes = first["provenance"]["input_sha256"]
+        self.assertIn("web/python/examples/circle.py", hashes)
+        self.assertIn("scripts/noon-capabilities.py", hashes)
+        self.assertRegex(hashes["web/python/examples/circle.py"], r"^[0-9a-f]{64}$")
+        self.assertEqual(first["examples"]["circle"]["source_sha256"], hashes["web/python/examples/circle.py"])
+        (self.root / "web/python/examples/circle.py").write_text("# changed\n", encoding="utf-8")
+        second = self.report()
+        self.assertNotEqual(first["examples"]["circle"]["source_sha256"], second["examples"]["circle"]["source_sha256"])
 
     def test_output_is_deterministic(self):
         self.assertEqual(self.report(), self.report())
 
     def test_symbol_filter_returns_relevant_ready_examples(self):
-        report = self.report()
-        selected = cap.select_report(report, ["Circle"], [])
-        self.assertEqual(list(selected["symbols"]), ["Circle"])
-        self.assertEqual(list(selected["examples"]), ["circle"])
-        self.assertIn("Text", report["symbols"])  # No mutation of input.
+        selected = cap.select_report(self.report(), ["Circle"], [])
+        self.assertEqual(set(selected["symbols"]), {"Circle"})
+        self.assertEqual(set(selected["examples"]), {"circle"})
 
     def test_unknown_symbol_and_example_fail(self):
         report = self.report()
-        for symbols, examples in ((["typo"], []), ([], ["typo"])):
-            with self.subTest(symbols=symbols, examples=examples):
-                with self.assertRaisesRegex(ValueError, "unknown"):
-                    cap.select_report(report, symbols, examples)
+        with self.assertRaisesRegex(ValueError, "unknown symbols"):
+            cap.select_report(report, ["Nope"], [])
+        with self.assertRaisesRegex(ValueError, "unknown examples"):
+            cap.select_report(report, [], ["nope"])
+
+    def test_supported_requires_export(self):
+        self.policy["overrides"]["Missing"] = {"status": "supported", "evidence": "none"}
+        self.save()
+        with self.assertRaisesRegex(ValueError, "export is absent"):
+            self.report()
+
+    def test_supported_requires_evidence(self):
+        del self.policy["overrides"]["Circle"]["evidence"]
+        self.save()
+        with self.assertRaisesRegex(ValueError, "requires declared evidence"):
+            self.report()
+
+    def test_blocked_export_with_ready_evidence_fails(self):
+        self.policy["overrides"]["Circle"] = {"status": "blocked", "reason": "bad"}
+        self.save()
+        with self.assertRaisesRegex(ValueError, "blocked export has ready tutorial evidence"):
+            self.report()
+
+    def test_unclassified_export_cannot_be_promoted(self):
+        del self.policy["overrides"]["Transform"]
+        self.save()
+        row = self.report()["symbols"]["Transform"]
+        self.assertEqual(row["classification_source"], "unclassified-export")
+        self.assertEqual(row["policy"]["status"], "partial")
+        self.assertIn("Statically exported", row["policy"]["reason"])
+
+    def test_restrictions_and_dependencies_survive(self):
+        self.policy["overrides"]["Transform"]["restriction"] = "same-family only"
+        self.policy["overrides"]["Transform"]["dependency"] = "supported mobject"
+        self.save()
+        row = self.report()["symbols"]["Transform"]["policy"]
+        self.assertEqual(row["restriction"], "same-family only")
+        self.assertEqual(row["dependency"], "supported mobject")
+
+    def test_ready_candidate_is_not_parity_qualified(self):
+        row = self.report()["examples"]["transform"]
+        self.assertEqual(row["status"], "ready")
+        self.assertEqual(row["parity_status"], "candidate")
+        self.assertNotIn("parity_fixture", row)
+
+    def test_qualified_label_needs_fixture(self):
+        self.tutorial["entries"][0]["parity_status"] = "parity-qualified"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "requires a parity fixture"):
+            self.report()
 
     def test_blocked_example_is_visible_but_not_ready_evidence(self):
-        selected = cap.select_report(self.report(), ["Axes"], ["plot"])
-        self.assertEqual(selected["examples"]["plot"]["status"], "blocked")
-        self.assertEqual(selected["symbols"]["Axes"]["ready_examples"], [])
+        report = self.report()
+        self.assertIn("plot", report["examples"])
+        self.assertEqual(report["examples"]["plot"]["status"], "blocked")
+        self.assertNotIn("source_sha256", report["examples"]["plot"])
+        self.assertEqual(report["symbols"]["Axes"]["ready_examples"], [])
+
+    def test_missing_inventory_fails(self):
+        (self.root / "compat/manim-v0.21.0.json").unlink()
+        with self.assertRaises(OSError):
+            self.report()
+
+    def test_malformed_inventory_fails(self):
+        (self.root / "compat/manim-v0.21.0.json").write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "expected a JSON object"):
+            self.report()
+
+    def test_version_mismatch_fails(self):
+        self.tutorial["reference"]["version"] = "0.20.0"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "versions differ"):
+            self.report()
+
+    def test_invalid_policy_status_fails(self):
+        self.policy["overrides"]["Circle"]["status"] = "working"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "invalid policy status"):
+            self.report()
+
+    def test_invalid_features_fail(self):
+        self.tutorial["entries"][0]["features"] = "Circle"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "features must be a string array"):
+            self.report()
+
+    def test_unknown_parity_label_fails(self):
+        self.tutorial["entries"][0]["parity_status"] = "gold"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "invalid parity_status"):
+            self.report()
+
+    def test_duplicate_example_fails(self):
+        self.tutorial["entries"].append(dict(self.tutorial["entries"][0]))
+        self.save()
+        with self.assertRaisesRegex(ValueError, "duplicate tutorial example id"):
+            self.report()
+
+    def test_missing_ready_example_fails(self):
+        (self.root / "web/python/examples/circle.py").unlink()
+        with self.assertRaisesRegex(ValueError, "missing or unconfined repository file"):
+            self.report()
+
+    def test_absolute_example_is_rejected(self):
+        self.tutorial["entries"][0]["path"] = "/tmp/scene.py"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "unsafe absolute example path"):
+            self.report()
+
+    def test_parent_traversal_is_rejected_even_when_file_exists(self):
+        (self.root / "web/escape.py").write_text("# escape\n", encoding="utf-8")
+        self.tutorial["entries"][0]["path"] = "python/examples/../../escape.py"
+        self.save()
+        with self.assertRaisesRegex(ValueError, "unsafe repository path"):
+            self.report()
+
+    def test_symlink_escape_is_rejected(self):
+        outside = Path(self.temp.name).parent / "outside-noon-capability.py"
+        outside.write_text("# outside\n", encoding="utf-8")
+        self.addCleanup(lambda: outside.unlink(missing_ok=True))
+        target = self.root / "web/python/examples/circle.py"
+        target.unlink()
+        target.symlink_to(outside)
+        with self.assertRaisesRegex(ValueError, "missing or unconfined repository file"):
+            self.report()
+
+    def test_noon_adapter_and_example_are_not_executed(self):
+        (self.root / "web/python/noon.py").write_text("raise RuntimeError('must not execute noon.py')\n", encoding="utf-8")
+        (self.root / "web/python/examples/circle.py").write_text("raise RuntimeError('must not execute scene')\n", encoding="utf-8")
+        report = self.report()
+        self.assertIn("Circle", report["symbols"])
+        self.assertRegex(report["examples"]["circle"]["source_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_static_module_exports_preserve_literal_and_unpacked_names(self):
+        (self.root / "web/python/_manim_more.py").write_text("EXPORTED = ('Line',)\n", encoding="utf-8")
+        (self.root / "web/python/_manim_compat.py").write_text(
+            "EXPORTED = ('Circle', 'Transform', 'Axes')\nfrom _manim_more import *\n", encoding="utf-8")
+        self.policy["overrides"]["Line"] = {"status": "partial", "reason": "line subset"}
+        self.save()
+        report = self.report()
+        self.assertIn("Line", report["symbols"])
+        self.assertTrue(report["symbols"]["Line"]["exported"])
 
     def test_cli_works_from_another_directory_without_site_packages(self):
         result = subprocess.run(
             [sys.executable, "-S", "-B", str(self.root / "scripts/noon-capabilities.py"), "--symbol", "Circle"],
-            cwd="/", capture_output=True, text=True, timeout=10,
+            cwd=Path(self.temp.name).parent, capture_output=True, text=True, timeout=10,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(list(json.loads(result.stdout)["symbols"]), ["Circle"])
-        self.assertEqual(result.stderr, "")
+        report = json.loads(result.stdout)
+        self.assertEqual(set(report["symbols"]), {"Circle"})
 
     def test_cli_invalid_query_has_no_success_output(self):
         result = subprocess.run(
@@ -263,6 +281,7 @@ class SkillTests(unittest.TestCase):
         for name in self.checker.COMMANDS:
             path = self.root / name
             if not path.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text("# fixture entrypoint\n", encoding="utf-8")
 
     def test_skill_valid_references(self):

--- a/skills/noon-authoring/SKILL.md
+++ b/skills/noon-authoring/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: noon-authoring
 description: Author and review Noon animation scenes using capability-qualified ManimCE-style Python or the shared Rust API. Use when a user asks to create, explain, repair, or verify a Noon animation, or when scene source imports noon. Not a generic ManimGL skill or a contract for modifying Noon internals.
-compatibility: Requires a trusted Noon repository checkout and Python 3.12+ for capability discovery. Previewing requires the repository's existing browser build and rendering environment; capability discovery alone does not render or install dependencies.
+compatibility: Requires a trusted Noon repository checkout, Python 3.12+, and Node 22+ for local capability/MCP tooling. Isolated preview additionally requires Docker, a built current browser package, and the repository-pinned preview runtime; capability discovery alone does not render or install dependencies.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Noon authoring
@@ -45,31 +45,101 @@ about an installed binary, the current GPU, or a live session. See
 3. Write ordinary `from noon import *` Python for the supported CE-like surface, or
    use the current shared Rust API. Keep the editable source as the deliverable.
    Do not import `manimlib`, invoke `manim`/`manimgl`, or silently switch renderers.
-4. Use the existing playground to render the scene. Inspect the intended initial
-   state, transition interiors, completion boundaries, and final membership. A
-   final blank frame after `FadeOut` can be correct; a successful run alone is not
-   visual verification. Apply the [verification checks](references/verification.md).
+4. Prefer the qualified local preview CLI or configured Noon MCP tools below when
+   available. Inspect the intended initial state, transition interiors, completion
+   boundaries, and final membership. A final blank frame after `FadeOut` can be
+   correct; a successful run alone is not visual verification. Apply the
+   [verification checks](references/verification.md).
 5. Revise source based on actual diagnostics and frames. Preserve the original
    mathematical and animation semantics; never conceal an unsupported operation by
    replacing `MathTex` with `Text` or removing an updater.
 
-## Current preview route
+## Qualified local preview route
 
-Use an already-built playground when available. To build one explicitly:
+The checkout-bound tooling package is private and is not published to npm. Install
+only its committed lockfile, with lifecycle hooks disabled:
+
+```bash
+cd /path/to/noon/tools/noon-mcp
+npm ci --ignore-scripts --no-audit --no-fund
+```
+
+The preview path also needs the current browser package and the pinned local Docker
+runtime. From the trusted checkout:
+
+```bash
+cd /path/to/noon
+bash scripts/build-web-demo.sh
+
+cd tools/noon-mcp
+NOON_PREVIEW_CACHE=/absolute/path/to/private-preview-cache \
+  node scripts/setup-preview-runtime.mjs
+```
+
+The setup helper prints the absolute `runtimeConfig` path. It pins the Playwright
+container/runtime and Pyodide payload, verifies their identities, and does not make
+the model choose Docker images, executables, checkout paths, seccomp profiles, or
+commands. Preview execution remains local, bounded, and `--network=none` inside the
+qualified Docker boundary.
+
+For a one-shot still-frame run, use the shared CLI over `AgentPreviewService`:
+
+```bash
+NOON_PREVIEW_RUNTIME_CONFIG=/absolute/path/to/runtime.json \
+  node /path/to/noon/tools/noon-mcp/bin/noon-preview.mjs \
+  --source /absolute/path/to/scene.py \
+  --output /absolute/path/to/preview-output \
+  --loop-duration 4 \
+  --time 1 --time 1.5 --time 3
+```
+
+The manifest and PNGs report observed source/build/requested-time/published-time/
+backend provenance. Sampling is forward-only; use a fresh run after source edits.
+Do not claim arbitrary seek or persistent live-object editing.
+
+When an MCP host is configured to launch `tools/noon-mcp/src/server.mjs` with
+`NOON_REPO`, `NOON_PYTHON`, and `NOON_PREVIEW_RUNTIME_CONFIG` as trusted startup
+environment, use these tools rather than inventing a second execution route:
+
+- `noon_capabilities` — static source/policy discovery, not a renderer claim.
+- `noon_reference` — hash-checked ready example source.
+- `noon_open_scene` — opens an isolated session and returns the initial PNG plus
+  coherent metadata.
+- `noon_sample_frames` — advances through nondecreasing times; at most 31 samples
+  in one call, with the shared retained-frame budget enforced across calls.
+- `noon_inspect` — metadata-only inspection of the last coherent retained state.
+- `noon_close_scene` — closes the owned session; the handle becomes stale.
+
+Session handles are transport-scoped capabilities. Treat stale/cross-scope errors,
+source failures, cancellation, and quota failures as real diagnostics. Cancellation,
+disconnect, and shutdown retire owned sessions/containers. Do not retry by bypassing
+the service or by starting an unrestricted browser.
+
+If Docker or the built browser package is unavailable, fall back to capability/source
+review and say that rendered verification was not performed. The older local playground
+remains useful for interactive development, but it is not a substitute for claiming
+qualified CLI/MCP evidence:
 
 ```bash
 bash scripts/build-web-demo.sh
 python3 -m http.server --bind 127.0.0.1 --directory web 8080
 ```
 
-Open the local playground, paste the source into **Python scene source**, and run
-it. The build can require downloads and substantial dependencies; it is not a side
-effect of capability discovery. Do not claim the preview ran when the required
-browser/WASM environment is unavailable.
+## Distribution identity
 
-There is not yet a supported `noon render` command or shipped Noon MCP preview
-server in this skill. The isolated runner and MCP adapter are tracked in #1197 and
-#1198. Do not invent their installation or tool commands.
+For reproducible setup/evaluation work, generate the checkout-bound agent manifest:
+
+```bash
+cd /path/to/noon/tools/noon-mcp
+node scripts/package-manifest.mjs
+```
+
+It records the private package/lock identities, direct dependency integrity/licenses,
+skill hash/version, capability-export provenance, runner source hashes, pinned
+Playwright/Pyodide identities, and environment requirements. A source-package manifest
+intentionally reports no loaded runtime build identity; actual preview results must
+supply the build identity observed by the running browser worker. See
+`THIRD_PARTY_NOTICES.md` for runtime provenance/license notices.
 
 ## Semantic boundaries
 

--- a/tools/noon-mcp/README.md
+++ b/tools/noon-mcp/README.md
@@ -11,12 +11,18 @@ second rendering implementation.
 
 Requirements for discovery are Node 22+, Python 3.12+, and a trusted Noon
 checkout on a POSIX host. The package is private and checkout-bound; it is not
-published to npm. Install its pinned, locked dependencies explicitly:
+published to npm. Install its pinned, locked dependencies explicitly and without
+lifecycle hooks:
 
 ```bash
 cd /path/to/noon/tools/noon-mcp
-npm ci --ignore-scripts
+npm ci --ignore-scripts --no-audit --no-fund
 ```
+
+A fresh checkout plus that command is the supported initial package setup. The
+Agent discovery workflow verifies it on fresh Linux and macOS hosted runners; the
+#1199 packaging job additionally emits the deterministic distribution manifest
+and exercises the real SDK client before any optional preview runtime is enabled.
 
 Configure an MCP host to launch the actual server module, not `npm start` (npm
 may write banners on the protocol channel). Replace the example absolute paths:
@@ -41,14 +47,40 @@ arguments. Missing configuration fails on stderr without emitting invalid
 stdout. The official MCP SDK owns stdio protocol handling; there is no custom
 JSON-RPC loop.
 
+### Distribution identity
+
+Generate the deterministic source-package manifest after the locked install:
+
+```bash
+npm run manifest
+```
+
+The manifest identifies the private package/lockfile, direct dependency versions,
+npm integrity strings and lockfile-declared licenses, `noon-authoring` skill
+version/hash, capability-export schema/provenance/input hashes, shared runner source
+hashes, pinned Playwright container identity, pinned Pyodide archive identity, and
+required Node/Python/Docker environment. It contains no generation timestamp.
+
+The source-package manifest deliberately records `loadedBuildIdentity: null`.
+A package or checkout hash is not evidence that a particular browser runtime was
+loaded. Actual preview results obtain build identity from the running browser worker
+and carry it with retained frame provenance.
+
+Runtime and dependency notices are in `THIRD_PARTY_NOTICES.md`. The initial package
+adds no copied external scene/asset corpus; any later evaluation corpus must be
+reviewed for redistribution provenance separately.
+
 ### Optional isolated preview
 
 Rendering additionally requires Docker with a reachable local daemon and the
-checkout's current browser package. Prepare the pinned, content-addressed Docker
-runtime with the existing setup helper:
+checkout's **current built browser package**. Build that package first from the
+trusted checkout, then prepare the pinned content-addressed Docker runtime:
 
 ```bash
-cd /path/to/noon/tools/noon-mcp
+cd /path/to/noon
+bash scripts/build-web-demo.sh
+
+cd tools/noon-mcp
 NOON_PREVIEW_CACHE=/absolute/path/to/private-preview-cache \
   node scripts/setup-preview-runtime.mjs
 ```
@@ -63,6 +95,20 @@ The preview runtime configuration is trusted startup configuration. Rendering
 tool arguments cannot choose another checkout, executable, Docker image,
 seccomp profile, command, or working directory.
 
+The same qualified service is also available as a one-shot CLI:
+
+```bash
+NOON_PREVIEW_RUNTIME_CONFIG=/absolute/path/to/runtime.json \
+  node bin/noon-preview.mjs \
+  --source /absolute/path/to/scene.py \
+  --output /absolute/path/to/preview-output \
+  --loop-duration 4 \
+  --time 1 --time 1.5 --time 3
+```
+
+Use a fresh run after editing source. The public preview contract is forward-only;
+it does not claim arbitrary seek or persistent live-object editing.
+
 ## Tools and evidence
 
 `noon_capabilities` accepts optional `symbols` and `examples` arrays, each
@@ -73,10 +119,9 @@ restrictions, and the distinction between API presence and declared behavioral
 support.
 
 `noon_reference` accepts one `example` ID. It resolves a currently ready example
-through that same inventory, confines the source to the checkout's example
-tree, checks the source hash, and returns at most 64 KiB of source. A file
-changed since the inventory scan fails instead of returning falsely attributed
-evidence.
+through that same inventory, confines the source to the checkout's example tree,
+checks the source hash, and returns at most 64 KiB of source. A file changed since
+the inventory scan fails instead of returning falsely attributed evidence.
 
 A ready fixture or a declared parity label is **not a test performed by these
 discovery tools**. Results explicitly report `behavioral_tests_run: false`.
@@ -128,12 +173,17 @@ providing arbitrary remote code execution.
 
 ```bash
 npm test
+npm run manifest
+NOON_REPO=/absolute/path/to/noon \
+NOON_PYTHON=/absolute/path/to/python3 \
+  npm run smoke:clean
 ```
 
 Unit tests exercise bounded discovery subprocesses, reference-file validation,
-rendering adapter mapping, structured errors, cancellation propagation, and
-artifact-delivery cleanup. The stdio tests start the real server through an MCP
-SDK client and verify discovery-only behavior and protocol-clean failures. The
-repository's Agent discovery MCP workflow additionally runs the real Docker
-preview, shared runner, CLI, and configured MCP rendering client against actual
-PNG frames and verifies deterministic provenance and cleanup.
+rendering adapter mapping, structured errors, cancellation propagation,
+artifact-delivery cleanup, and deterministic distribution identities. The stdio
+and clean-setup tests start the real server through an MCP SDK client and verify
+discovery-only behavior and protocol-clean failures. The repository's Agent
+discovery workflow additionally runs the real Docker preview, shared runner, CLI,
+and configured MCP rendering client against actual PNG frames and verifies
+deterministic provenance and cleanup.

--- a/tools/noon-mcp/THIRD_PARTY_NOTICES.md
+++ b/tools/noon-mcp/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,53 @@
+# Third-party notices for Noon local agent tooling
+
+This checkout-bound package does not copy a third-party scene corpus into Noon. The
+preview setup installs or fetches the pinned runtime components below, and the MCP
+package installs its JavaScript dependencies from the committed npm lockfile with
+lifecycle hooks disabled.
+
+## Playwright
+
+- Component: Playwright JavaScript package and official browser container runtime
+- Version: 1.62.1
+- Container base: pinned in `preview.Dockerfile` by OCI SHA-256 digest
+- Source: https://github.com/microsoft/playwright/tree/v1.62.1
+- License: Apache License 2.0
+- License text: https://github.com/microsoft/playwright/blob/v1.62.1/LICENSE
+
+Noon derives the upstream pinned Playwright seccomp profile for its nested Chromium
+sandbox contract. The setup helper verifies the exact upstream Git blob before
+writing the derived local profile; the derived profile remains subject to the
+applicable upstream license and is not a replacement Playwright distribution.
+
+## Pyodide
+
+- Component: `pyodide-core` runtime archive used by isolated Python previews
+- Version: 314.0.5
+- Archive identity: SHA-256 `f528dccea95fa8ec54295fd65bf86dd61183d11f0e52563dc8eadda45e0f78d6`
+- Source: https://github.com/pyodide/pyodide/tree/314.0.5
+- License: Mozilla Public License 2.0
+- License text: https://github.com/pyodide/pyodide/blob/314.0.5/LICENSE
+
+The preview image verifies the archive SHA-256 before extraction and serves the
+pinned runtime locally while the execution container remains `--network=none`.
+
+## Model Context Protocol TypeScript SDK and Zod
+
+Direct JavaScript dependencies are pinned by `package.json` and
+`package-lock.json`. The distribution manifest records their exact installed
+versions, npm integrity values, and lockfile-declared licenses. At this revision:
+
+- `@modelcontextprotocol/server` 2.0.0 — MIT
+- `@modelcontextprotocol/client` 2.0.0 — MIT (development/test client)
+- `zod` 4.2.0 — MIT
+
+Transitive package identities and licenses remain recorded in the committed npm
+lockfile and installed package metadata. Noon does not vendor their source into
+this directory.
+
+## External evaluation material
+
+The initial #1199 distribution/setup slice adds no external scene or asset corpus.
+Any future evaluation corpus copied from an external project must be reviewed for
+license/provenance independently before it is committed; a URL or compatibility
+reference alone is not permission to redistribute assets.

--- a/tools/noon-mcp/package.json
+++ b/tools/noon-mcp/package.json
@@ -7,7 +7,9 @@
   "engines": { "node": ">=22" },
   "scripts": {
     "start": "node src/server.mjs",
-    "test": "node --test test/*.test.mjs"
+    "test": "node --test test/*.test.mjs",
+    "manifest": "node scripts/package-manifest.mjs",
+    "smoke:clean": "node scripts/clean-setup-smoke.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",

--- a/tools/noon-mcp/scripts/clean-setup-smoke.mjs
+++ b/tools/noon-mcp/scripts/clean-setup-smoke.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverPath = path.join(packageRoot, "src", "server.mjs");
+const repoRoot = process.env.NOON_REPO;
+const python = process.env.NOON_PYTHON;
+
+if (!repoRoot || !path.isAbsolute(repoRoot)) throw new Error("NOON_REPO must name the trusted checkout with an absolute path");
+if (!python || !path.isAbsolute(python)) throw new Error("NOON_PYTHON must name Python 3.12+ with an absolute path");
+if (process.env.NOON_PREVIEW_RUNTIME_CONFIG) {
+  throw new Error("clean setup smoke intentionally verifies discovery before optional preview configuration");
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverPath],
+  env: {
+    PATH: process.env.PATH ?? "",
+    HOME: process.env.HOME ?? "",
+    NOON_REPO: repoRoot,
+    NOON_PYTHON: python,
+  },
+  stderr: "pipe",
+});
+const client = new Client({ name: "noon-clean-setup-smoke", version: "0.1.0" });
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), ["noon_capabilities", "noon_reference"]);
+
+  const capabilities = await client.callTool({
+    name: "noon_capabilities",
+    arguments: { symbols: ["Circle", "Transform"] },
+  });
+  assert.notEqual(capabilities.isError, true);
+  assert.equal(capabilities.structuredContent.kind, "noon-agent-capabilities");
+  assert.equal(capabilities.structuredContent.scope, "source-inventory");
+  assert.equal(capabilities.structuredContent.qualification.behavioral_tests_run, false);
+  assert.match(capabilities.structuredContent.provenance.input_sha256["scripts/noon-capabilities.py"], /^[0-9a-f]{64}$/);
+
+  const reference = await client.callTool({
+    name: "noon_reference",
+    arguments: { example: "parity-square-to-circle" },
+  });
+  assert.notEqual(reference.isError, true);
+  assert.match(reference.structuredContent.source, /class SquareToCircle/);
+  assert.match(reference.structuredContent.source_sha256, /^[0-9a-f]{64}$/);
+
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    packageRoot,
+    capabilityRevision: capabilities.structuredContent.provenance.revision,
+    referenceSha256: reference.structuredContent.source_sha256,
+  })}\n`);
+} finally {
+  await client.close().catch(() => {});
+}

--- a/tools/noon-mcp/scripts/clean-setup-smoke.mjs
+++ b/tools/noon-mcp/scripts/clean-setup-smoke.mjs
@@ -50,13 +50,13 @@ try {
   });
   assert.notEqual(reference.isError, true);
   assert.match(reference.structuredContent.source, /class SquareToCircle/);
-  assert.match(reference.structuredContent.source_sha256, /^[0-9a-f]{64}$/);
+  assert.match(reference.structuredContent.example.source_sha256, /^[0-9a-f]{64}$/);
 
   process.stdout.write(`${JSON.stringify({
     ok: true,
     packageRoot,
     capabilityRevision: capabilities.structuredContent.provenance.revision,
-    referenceSha256: reference.structuredContent.source_sha256,
+    referenceSha256: reference.structuredContent.example.source_sha256,
   })}\n`);
 } finally {
   await client.close().catch(() => {});

--- a/tools/noon-mcp/scripts/package-manifest.mjs
+++ b/tools/noon-mcp/scripts/package-manifest.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { buildDistributionManifest } from "../src/distribution-manifest.mjs";
+
+try {
+  const manifest = await buildDistributionManifest();
+  process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+} catch (error) {
+  process.stderr.write(`Noon distribution manifest failed: ${String(error?.message ?? error)}\n`);
+  process.exitCode = 1;
+}

--- a/tools/noon-mcp/src/distribution-manifest.mjs
+++ b/tools/noon-mcp/src/distribution-manifest.mjs
@@ -15,14 +15,30 @@ export const DISTRIBUTION_MANIFEST_SCHEMA_VERSION = 1;
 const PACKAGE_SOURCES = Object.freeze([
   "package.json",
   "package-lock.json",
+  "README.md",
   "preview.Dockerfile",
   "THIRD_PARTY_NOTICES.md",
-  "src/server.mjs",
+  "bin/noon-preview.mjs",
+  "src/discovery.mjs",
+  "src/distribution-manifest.mjs",
+  "src/preview-cli.mjs",
   "src/preview-isolation.mjs",
+  "src/preview-pyodide.mjs",
   "src/preview-runner.mjs",
+  "src/preview-seccomp.mjs",
   "src/preview-service.mjs",
   "src/preview-worker.mjs",
+  "src/rendering-contract.mjs",
+  "src/rendering-tools.mjs",
+  "src/server.mjs",
+  "scripts/clean-setup-smoke.mjs",
+  "scripts/package-manifest.mjs",
   "scripts/setup-preview-runtime.mjs",
+]);
+
+const CHECKOUT_RUNNER_SOURCES = Object.freeze([
+  "scripts/agent-preview-artifacts.mjs",
+  "scripts/agent-preview-sessions.mjs",
 ]);
 
 function sha256(bytes) {
@@ -136,12 +152,6 @@ export async function buildDistributionManifest({
 } = {}) {
   const packageReal = await realpath(packageRoot);
   const repoReal = await realpath(repoRoot);
-  const expectedPackage = await realpath(path.join(repoReal, "tools", "noon-mcp")).catch(() => null);
-  // A staged clean package copy is supported; the trusted checkout remains the
-  // capability/source authority and is always identified separately below.
-  if (expectedPackage === packageReal && !packageReal.startsWith(`${repoReal}${path.sep}`)) {
-    throw new Error("invalid checkout-bound package location");
-  }
 
   const packageJson = await jsonFile(packageReal, "package.json");
   const lock = await jsonFile(packageReal, "package-lock.json");
@@ -180,6 +190,7 @@ export async function buildDistributionManifest({
 
   const sourceSha256 = {};
   for (const relative of PACKAGE_SOURCES) sourceSha256[`tools/noon-mcp/${relative}`] = await fileSha256(packageReal, relative);
+  for (const relative of CHECKOUT_RUNNER_SOURCES) sourceSha256[relative] = await fileSha256(repoReal, relative);
   sourceSha256[skillPath] = await fileSha256(repoReal, skillPath);
   sourceSha256["scripts/noon-capabilities.py"] = await fileSha256(repoReal, "scripts/noon-capabilities.py");
 

--- a/tools/noon-mcp/src/distribution-manifest.mjs
+++ b/tools/noon-mcp/src/distribution-manifest.mjs
@@ -39,6 +39,14 @@ const PACKAGE_SOURCES = Object.freeze([
 const CHECKOUT_RUNNER_SOURCES = Object.freeze([
   "scripts/agent-preview-artifacts.mjs",
   "scripts/agent-preview-sessions.mjs",
+  "scripts/build-web-demo.sh",
+  "web/agent-preview-host.js",
+  "web/authoring-client.js",
+  "web/authoring-execution-client.js",
+  "web/manim-raster-host.js",
+  "web/provenanced-authoring-client.js",
+  "web/runtime-build-verifier.js",
+  "web/semantic-preview-session.js",
 ]);
 
 function sha256(bytes) {

--- a/tools/noon-mcp/src/distribution-manifest.mjs
+++ b/tools/noon-mcp/src/distribution-manifest.mjs
@@ -1,0 +1,234 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultPackageRoot = path.resolve(moduleDir, "..");
+const defaultRepoRoot = path.resolve(defaultPackageRoot, "../..");
+
+export const DISTRIBUTION_MANIFEST_SCHEMA_VERSION = 1;
+
+const PACKAGE_SOURCES = Object.freeze([
+  "package.json",
+  "package-lock.json",
+  "preview.Dockerfile",
+  "THIRD_PARTY_NOTICES.md",
+  "src/server.mjs",
+  "src/preview-isolation.mjs",
+  "src/preview-runner.mjs",
+  "src/preview-service.mjs",
+  "src/preview-worker.mjs",
+  "scripts/setup-preview-runtime.mjs",
+]);
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function regularFile(root, relative) {
+  if (typeof relative !== "string" || relative.length === 0 || path.isAbsolute(relative) || relative.includes("\0")) {
+    throw new TypeError(`invalid relative file path: ${String(relative)}`);
+  }
+  const rootReal = await realpath(root);
+  const resolved = await realpath(path.join(rootReal, relative));
+  const metadata = await stat(resolved);
+  if (!resolved.startsWith(`${rootReal}${path.sep}`) || !metadata.isFile()) {
+    throw new Error(`unconfined or non-file distribution input: ${relative}`);
+  }
+  return resolved;
+}
+
+async function fileSha256(root, relative) {
+  return sha256(await readFile(await regularFile(root, relative)));
+}
+
+async function jsonFile(root, relative) {
+  const value = JSON.parse(await readFile(await regularFile(root, relative), "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${relative} must contain a JSON object`);
+  }
+  return value;
+}
+
+async function command(executable, args, { cwd, timeout = 30_000, maxBuffer = 16 * 1024 * 1024 } = {}) {
+  const { stdout } = await execFileAsync(executable, args, {
+    cwd,
+    timeout,
+    maxBuffer,
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      LANG: "C.UTF-8",
+      LC_ALL: "C.UTF-8",
+      PYTHONNOUSERSITE: "1",
+      PYTHONDONTWRITEBYTECODE: "1",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+    },
+  });
+  return stdout.trim();
+}
+
+async function pythonIdentity(pythonExecutable, repoRoot) {
+  const output = await command(pythonExecutable, [
+    "-I", "-S", "-c",
+    "import json,sys; print(json.dumps({'executable':sys.executable,'version':list(sys.version_info[:3])}))",
+  ], { cwd: repoRoot, timeout: 10_000, maxBuffer: 64 * 1024 });
+  const identity = JSON.parse(output);
+  const version = identity?.version;
+  if (!Array.isArray(version) || version.length !== 3 || version.some((part) => !Number.isInteger(part))) {
+    throw new Error("Python returned an invalid version identity");
+  }
+  if (version[0] < 3 || (version[0] === 3 && version[1] < 12)) {
+    throw new Error(`Noon agent tooling requires Python 3.12+, found ${version.join(".")}`);
+  }
+  return Object.freeze({ executable: identity.executable, version: version.join(".") });
+}
+
+async function repositoryIdentity(repoRoot) {
+  try {
+    const top = await command("git", ["-C", repoRoot, "rev-parse", "--show-toplevel"], { timeout: 5_000, maxBuffer: 64 * 1024 });
+    if (await realpath(top) !== await realpath(repoRoot)) return { revision: null, dirty: null };
+    const revision = await command("git", ["-C", repoRoot, "rev-parse", "HEAD"], { timeout: 5_000, maxBuffer: 64 * 1024 });
+    const dirty = Boolean(await command("git", ["-C", repoRoot, "status", "--porcelain", "--untracked-files=normal"], {
+      timeout: 5_000,
+      maxBuffer: 1024 * 1024,
+    }));
+    return { revision, dirty };
+  } catch {
+    return { revision: null, dirty: null };
+  }
+}
+
+function requiredMatch(text, expression, label) {
+  const match = text.match(expression);
+  if (!match?.[1]) throw new Error(`cannot derive ${label} from pinned runtime source`);
+  return match[1];
+}
+
+function directDependencies(packageJson, lock) {
+  const requested = { ...(packageJson.dependencies ?? {}), ...(packageJson.devDependencies ?? {}) };
+  return Object.keys(requested).sort().map((name) => {
+    const row = lock.packages?.[`node_modules/${name}`];
+    if (!row || typeof row.version !== "string" || typeof row.integrity !== "string" || typeof row.license !== "string") {
+      throw new Error(`lockfile lacks complete identity for direct dependency ${name}`);
+    }
+    return {
+      name,
+      requested: requested[name],
+      version: row.version,
+      integrity: row.integrity,
+      license: row.license,
+      developmentOnly: packageJson.devDependencies?.[name] !== undefined,
+    };
+  });
+}
+
+export async function buildDistributionManifest({
+  packageRoot = defaultPackageRoot,
+  repoRoot = process.env.NOON_REPO || defaultRepoRoot,
+  pythonExecutable = process.env.NOON_PYTHON || "python3",
+} = {}) {
+  const packageReal = await realpath(packageRoot);
+  const repoReal = await realpath(repoRoot);
+  const expectedPackage = await realpath(path.join(repoReal, "tools", "noon-mcp")).catch(() => null);
+  // A staged clean package copy is supported; the trusted checkout remains the
+  // capability/source authority and is always identified separately below.
+  if (expectedPackage === packageReal && !packageReal.startsWith(`${repoReal}${path.sep}`)) {
+    throw new Error("invalid checkout-bound package location");
+  }
+
+  const packageJson = await jsonFile(packageReal, "package.json");
+  const lock = await jsonFile(packageReal, "package-lock.json");
+  if (packageJson.private !== true || packageJson.name !== lock.name || packageJson.version !== lock.version) {
+    throw new Error("package and lockfile identity disagree or package is not checkout-bound/private");
+  }
+  if (lock.lockfileVersion !== 3) throw new Error(`unsupported npm lockfile version: ${lock.lockfileVersion}`);
+  if (packageJson.engines?.node !== ">=22") throw new Error("package must declare Node >=22");
+
+  const nodeMajor = Number(process.versions.node.split(".", 1)[0]);
+  if (!Number.isInteger(nodeMajor) || nodeMajor < 22) {
+    throw new Error(`Noon MCP packaging requires Node 22+, found ${process.versions.node}`);
+  }
+  const python = await pythonIdentity(pythonExecutable, repoReal);
+
+  const capabilityText = await command(pythonExecutable, ["-B", path.join(repoReal, "scripts", "noon-capabilities.py")], {
+    cwd: repoReal,
+  });
+  const capability = JSON.parse(capabilityText);
+  if (capability?.kind !== "noon-agent-capabilities" || capability?.schema_version !== 1 || capability?.scope !== "source-inventory") {
+    throw new Error("capability exporter returned an incompatible schema");
+  }
+
+  const skillPath = "skills/noon-authoring/SKILL.md";
+  const skillText = await readFile(await regularFile(repoReal, skillPath), "utf8");
+  const skillVersion = requiredMatch(skillText, /^\s{2}version:\s*["']([^"']+)["']\s*$/m, "skill version");
+
+  const dockerfile = await readFile(await regularFile(packageReal, "preview.Dockerfile"), "utf8");
+  const runtime = {
+    playwrightVersion: requiredMatch(dockerfile, /playwright@([0-9]+\.[0-9]+\.[0-9]+)/, "Playwright version"),
+    playwrightImageDigest: requiredMatch(dockerfile, /^FROM\s+mcr\.microsoft\.com\/playwright@(sha256:[0-9a-f]{64})\s*$/m, "Playwright image digest"),
+    pyodideVersion: requiredMatch(dockerfile, /^ARG\s+PYODIDE_VERSION=([^\s]+)\s*$/m, "Pyodide version"),
+    pyodideCoreSha256: requiredMatch(dockerfile, /^ARG\s+PYODIDE_CORE_SHA256=([0-9a-f]{64})\s*$/m, "Pyodide core SHA-256"),
+    loadedBuildIdentity: null,
+  };
+
+  const sourceSha256 = {};
+  for (const relative of PACKAGE_SOURCES) sourceSha256[`tools/noon-mcp/${relative}`] = await fileSha256(packageReal, relative);
+  sourceSha256[skillPath] = await fileSha256(repoReal, skillPath);
+  sourceSha256["scripts/noon-capabilities.py"] = await fileSha256(repoReal, "scripts/noon-capabilities.py");
+
+  return Object.freeze({
+    schemaVersion: DISTRIBUTION_MANIFEST_SCHEMA_VERSION,
+    kind: "noon-agent-distribution",
+    package: {
+      name: packageJson.name,
+      version: packageJson.version,
+      private: true,
+      lockfileVersion: lock.lockfileVersion,
+      packageJsonSha256: await fileSha256(packageReal, "package.json"),
+      packageLockSha256: await fileSha256(packageReal, "package-lock.json"),
+      directDependencies: directDependencies(packageJson, lock),
+    },
+    environment: {
+      node: { required: packageJson.engines.node, observed: process.versions.node },
+      python: { required: ">=3.12", observed: python.version },
+      preview: {
+        dockerDaemonRequired: true,
+        supportedPlatform: "Linux container runtime through Docker; host setup is POSIX-oriented",
+        installCommand: "npm ci --ignore-scripts --no-audit --no-fund",
+        implicitLifecycleHooks: false,
+      },
+      trustedCheckoutRequired: true,
+    },
+    repository: await repositoryIdentity(repoReal),
+    skill: {
+      name: "noon-authoring",
+      version: skillVersion,
+      path: skillPath,
+      sha256: sourceSha256[skillPath],
+    },
+    capabilities: {
+      schemaVersion: capability.schema_version,
+      kind: capability.kind,
+      scope: capability.scope,
+      reference: capability.reference,
+      provenance: capability.provenance,
+      behavioralTestsRun: capability.qualification?.behavioral_tests_run === true,
+      exporterSha256: sourceSha256["scripts/noon-capabilities.py"],
+    },
+    runner: {
+      versions: runtime,
+      sourceSha256,
+    },
+    notices: {
+      path: "tools/noon-mcp/THIRD_PARTY_NOTICES.md",
+      sha256: sourceSha256["tools/noon-mcp/THIRD_PARTY_NOTICES.md"],
+    },
+  });
+}

--- a/tools/noon-mcp/test/distribution-manifest.test.mjs
+++ b/tools/noon-mcp/test/distribution-manifest.test.mjs
@@ -45,7 +45,7 @@ test("distribution manifest pins package, skill, capability and runner identitie
   assert.equal(first.environment.trustedCheckoutRequired, true);
 
   assert.equal(first.skill.name, "noon-authoring");
-  assert.equal(first.skill.version, "0.1.0");
+  assert.equal(first.skill.version, "0.2.0");
   assertSha(first.skill.sha256, "skill");
 
   assert.equal(first.capabilities.schemaVersion, 1);
@@ -63,5 +63,12 @@ test("distribution manifest pins package, skill, capability and runner identitie
   assert.equal(first.runner.versions.loadedBuildIdentity, null,
     "source package manifest must not pretend a runtime build was loaded");
   for (const [name, digest] of Object.entries(first.runner.sourceSha256)) assertSha(digest, `runner source ${name}`);
+  for (const required of [
+    "tools/noon-mcp/src/distribution-manifest.mjs",
+    "tools/noon-mcp/src/server.mjs",
+    "scripts/agent-preview-sessions.mjs",
+    "scripts/agent-preview-artifacts.mjs",
+    "skills/noon-authoring/SKILL.md",
+  ]) assertSha(first.runner.sourceSha256[required], required);
   assertSha(first.notices.sha256, "third-party notices");
 });

--- a/tools/noon-mcp/test/distribution-manifest.test.mjs
+++ b/tools/noon-mcp/test/distribution-manifest.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { buildDistributionManifest } from "../src/distribution-manifest.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(here, "../../..");
+const python = execFileSync("python3", ["-I", "-S", "-c", "import sys; print(sys.executable)"], { encoding: "utf8" }).trim();
+
+function assertSha(value, label) {
+  assert.match(value, /^[0-9a-f]{64}$/, `${label} must be a SHA-256 identity`);
+}
+
+test("distribution manifest pins package, skill, capability and runner identities deterministically", { timeout: 30_000 }, async () => {
+  const options = { packageRoot, repoRoot, pythonExecutable: python };
+  const first = await buildDistributionManifest(options);
+  const second = await buildDistributionManifest(options);
+  assert.deepEqual(second, first, "manifest must not contain timestamps or other nondeterministic fields");
+
+  assert.equal(first.schemaVersion, 1);
+  assert.equal(first.kind, "noon-agent-distribution");
+  assert.equal(first.package.name, "@noon-animation/mcp");
+  assert.equal(first.package.version, "0.1.0");
+  assert.equal(first.package.private, true);
+  assert.equal(first.package.lockfileVersion, 3);
+  assertSha(first.package.packageJsonSha256, "package.json");
+  assertSha(first.package.packageLockSha256, "package-lock.json");
+
+  const dependencies = Object.fromEntries(first.package.directDependencies.map((row) => [row.name, row]));
+  assert.equal(dependencies["@modelcontextprotocol/server"].version, "2.0.0");
+  assert.equal(dependencies["@modelcontextprotocol/server"].license, "MIT");
+  assert.equal(dependencies["@modelcontextprotocol/client"].version, "2.0.0");
+  assert.equal(dependencies["@modelcontextprotocol/client"].developmentOnly, true);
+  assert.equal(dependencies.zod.version, "4.2.0");
+
+  assert.equal(first.environment.node.required, ">=22");
+  assert.equal(first.environment.python.required, ">=3.12");
+  assert.equal(first.environment.preview.dockerDaemonRequired, true);
+  assert.equal(first.environment.preview.implicitLifecycleHooks, false);
+  assert.equal(first.environment.preview.installCommand, "npm ci --ignore-scripts --no-audit --no-fund");
+  assert.equal(first.environment.trustedCheckoutRequired, true);
+
+  assert.equal(first.skill.name, "noon-authoring");
+  assert.equal(first.skill.version, "0.1.0");
+  assertSha(first.skill.sha256, "skill");
+
+  assert.equal(first.capabilities.schemaVersion, 1);
+  assert.equal(first.capabilities.kind, "noon-agent-capabilities");
+  assert.equal(first.capabilities.scope, "source-inventory");
+  assert.equal(first.capabilities.behavioralTestsRun, false);
+  assert.equal(first.capabilities.reference.package, "manim");
+  assertSha(first.capabilities.exporterSha256, "capability exporter");
+  for (const [name, digest] of Object.entries(first.capabilities.provenance.input_sha256)) assertSha(digest, `capability input ${name}`);
+
+  assert.equal(first.runner.versions.playwrightVersion, "1.62.1");
+  assert.match(first.runner.versions.playwrightImageDigest, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(first.runner.versions.pyodideVersion, "314.0.5");
+  assert.equal(first.runner.versions.pyodideCoreSha256, "f528dccea95fa8ec54295fd65bf86dd61183d11f0e52563dc8eadda45e0f78d6");
+  assert.equal(first.runner.versions.loadedBuildIdentity, null,
+    "source package manifest must not pretend a runtime build was loaded");
+  for (const [name, digest] of Object.entries(first.runner.sourceSha256)) assertSha(digest, `runner source ${name}`);
+  assertSha(first.notices.sha256, "third-party notices");
+});


### PR DESCRIPTION
Advances #1199 with the first bounded packaging/setup slice on the merged runner + MCP baseline.

## Scope

- adds a deterministic `noon-agent-distribution` manifest covering the private MCP package/lockfile, direct dependency versions/integrity/licenses, `noon-authoring` skill version/hash, capability-export schema/provenance/input hashes, shared runner source hashes, pinned Playwright OCI identity and pinned Pyodide archive identity;
- keeps loaded runtime attribution explicit: the source-package manifest records `loadedBuildIdentity: null`; actual preview results remain authoritative for observed browser/WASM/worker build identity;
- adds third-party runtime/dependency provenance notices without copying an external scene/asset corpus;
- updates the first-party authoring skill to the now-qualified shared CLI/MCP preview route and its real forward-only/quota/session limitations;
- adds a fresh-runner packaging job: asserts no ambient `node_modules`, installs only the exact npm lockfile with lifecycle hooks disabled, emits the manifest, and exercises discovery through the real MCP SDK client;
- existing Docker isolation/runner/CLI/MCP qualification remains unchanged and still runs on this PR.

## Boundary

This does not add a second package/server/capability matrix/runner/session/artifact store/scene model or agent scheduler. Initial distribution remains checkout-bound as #1199 allows. Stochastic agent evaluation and the fixed deterministic task corpus are follow-up slices after this setup contract qualifies.

## Validation

Repository CI/self-review only per `AGENTS.override.md`. Keep draft until the new clean-package job, existing MCP contracts, real Docker path, PR Fast, architecture and dependency ratchets qualify the exact final head.