### PR TITLE
Evaluate identity-free derived Transform display rows

### DIFF
--- a/crates/noon-runtime/src/derived_display_evaluation.rs
+++ b/crates/noon-runtime/src/derived_display_evaluation.rs
@@ -1,0 +1,433 @@
+use noon_compile::TransformGeometryPlan;
+use noon_core::{
+    mapped_continuous_progress, CompositionTimeMap, ObjectContentRef, Property, TrackTiming,
+    TrackValues,
+};
+
+use crate::frame::FrameRowState;
+use crate::{DerivedDisplayObject, DerivedDisplayObjectState};
+
+/// One identity-free runtime channel for a transient derived display occurrence.
+///
+/// This execution data intentionally carries no `TrackId`, `ObjectId`, semantic node,
+/// or stable slot. The compiler has already prepared any geometry plan required by
+/// Morph evaluation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DerivedDisplayAnimationTrack {
+    pub property: Property,
+    pub values: TrackValues,
+    pub timing: TrackTiming,
+    pub time_map: CompositionTimeMap,
+    pub transform_geometry_plan: Option<TransformGeometryPlan>,
+}
+
+/// One plan-local visual occurrence anchored only for painter placement.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DerivedDisplayAnimationOccurrence {
+    pub anchor_object_index: u32,
+    pub occurrence_index: u32,
+    pub base: DerivedDisplayObjectState,
+    pub tracks: Vec<DerivedDisplayAnimationTrack>,
+}
+
+/// Renderer-publication overlay evaluated independently of stable `FrameState.objects`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DerivedDisplayAnimationPlan {
+    occurrences: Vec<DerivedDisplayAnimationOccurrence>,
+}
+
+impl DerivedDisplayAnimationPlan {
+    pub fn new(
+        occurrences: Vec<DerivedDisplayAnimationOccurrence>,
+    ) -> Result<Self, DerivedDisplayEvaluationError> {
+        let mut seen = std::collections::BTreeSet::new();
+        for occurrence in &occurrences {
+            if !seen.insert(occurrence.occurrence_index) {
+                return Err(DerivedDisplayEvaluationError::DuplicateOccurrence(
+                    occurrence.occurrence_index,
+                ));
+            }
+            if occurrence.tracks.is_empty() {
+                return Err(DerivedDisplayEvaluationError::EmptyOccurrence(
+                    occurrence.occurrence_index,
+                ));
+            }
+            for track in &occurrence.tracks {
+                track.time_map.validate().map_err(|_| {
+                    DerivedDisplayEvaluationError::InvalidTimeMap {
+                        occurrence_index: occurrence.occurrence_index,
+                        property: track.property,
+                    }
+                })?;
+            }
+        }
+        Ok(Self { occurrences })
+    }
+
+    pub fn occurrences(&self) -> &[DerivedDisplayAnimationOccurrence] {
+        &self.occurrences
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.occurrences.is_empty()
+    }
+
+    /// Evaluate one coherent derived display overlay.
+    ///
+    /// A mapped occurrence does not exist before its first channel begins. Once begun,
+    /// it remains at its mapped endpoint after the root interval. The owning session
+    /// decides when that retained effective presentation state is superseded; this
+    /// evaluator never turns it into semantic identity or stable execution storage.
+    pub fn evaluate(
+        &self,
+        time: f64,
+    ) -> Result<Vec<DerivedDisplayObject>, DerivedDisplayEvaluationError> {
+        if !time.is_finite() {
+            return Err(DerivedDisplayEvaluationError::InvalidTime(time));
+        }
+        let mut objects = Vec::with_capacity(self.occurrences.len());
+        for occurrence in &self.occurrences {
+            let first = &occurrence.tracks[0];
+            if mapped_continuous_progress(first.timing, &first.time_map, time).is_none() {
+                continue;
+            }
+
+            let base_content = occurrence.base.content.clone();
+            let mut row = row_from_derived(&occurrence.base);
+            for track in &occurrence.tracks {
+                let Some(progress) =
+                    mapped_continuous_progress(track.timing, &track.time_map, time)
+                else {
+                    continue;
+                };
+                apply_derived_track(
+                    &mut row,
+                    &base_content,
+                    track,
+                    progress,
+                    occurrence.occurrence_index,
+                )?;
+            }
+            objects.push(DerivedDisplayObject::new(
+                occurrence.anchor_object_index,
+                occurrence.occurrence_index,
+                derived_from_row(occurrence.base.text_bounds, base_content, row),
+            ));
+        }
+        Ok(objects)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DerivedDisplayEvaluationError {
+    InvalidTime(f64),
+    DuplicateOccurrence(u32),
+    EmptyOccurrence(u32),
+    InvalidTimeMap {
+        occurrence_index: u32,
+        property: Property,
+    },
+    UnsupportedProperty {
+        occurrence_index: u32,
+        property: Property,
+    },
+    InvalidValueKind {
+        occurrence_index: u32,
+        property: Property,
+    },
+    MissingGeometryPlan {
+        occurrence_index: u32,
+        property: Property,
+    },
+}
+
+impl std::fmt::Display for DerivedDisplayEvaluationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::InvalidTime(time) => write!(formatter, "invalid derived display time {time}"),
+            Self::DuplicateOccurrence(index) => {
+                write!(formatter, "derived display occurrence {index} is duplicated")
+            }
+            Self::EmptyOccurrence(index) => {
+                write!(formatter, "derived display occurrence {index} has no channels")
+            }
+            Self::InvalidTimeMap {
+                occurrence_index,
+                property,
+            } => write!(
+                formatter,
+                "derived display occurrence {occurrence_index} has invalid {property:?} time map"
+            ),
+            Self::UnsupportedProperty {
+                occurrence_index,
+                property,
+            } => write!(
+                formatter,
+                "derived display occurrence {occurrence_index} does not support {property:?} evaluation"
+            ),
+            Self::InvalidValueKind {
+                occurrence_index,
+                property,
+            } => write!(
+                formatter,
+                "derived display occurrence {occurrence_index} has invalid values for {property:?}"
+            ),
+            Self::MissingGeometryPlan {
+                occurrence_index,
+                property,
+            } => write!(
+                formatter,
+                "derived display occurrence {occurrence_index} lacks the compiled {property:?} geometry plan"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DerivedDisplayEvaluationError {}
+
+fn row_from_derived(base: &DerivedDisplayObjectState) -> FrameRowState {
+    FrameRowState {
+        z_index: base.z_index,
+        transform: base.transform,
+        style: base.style,
+        appearance: base.appearance,
+        presence: base.presence,
+        reveal: base.reveal,
+        morph: base.morph,
+        content_override: None,
+        render_geometry: base.render_geometry.clone(),
+        render_transform: base.render_transform,
+    }
+}
+
+fn derived_from_row(
+    text_bounds: Option<noon_core::Rect>,
+    base_content: ObjectContentRef,
+    row: FrameRowState,
+) -> DerivedDisplayObjectState {
+    DerivedDisplayObjectState {
+        z_index: row.z_index,
+        content: row.content_override.unwrap_or(base_content),
+        text_bounds,
+        transform: row.transform,
+        style: row.style,
+        appearance: row.appearance,
+        presence: row.presence,
+        reveal: row.reveal,
+        morph: row.morph,
+        render_geometry: row.render_geometry,
+        render_transform: row.render_transform,
+    }
+}
+
+fn apply_derived_track(
+    row: &mut FrameRowState,
+    base_content: &ObjectContentRef,
+    track: &DerivedDisplayAnimationTrack,
+    progress: f32,
+    occurrence_index: u32,
+) -> Result<(), DerivedDisplayEvaluationError> {
+    match track.property {
+        Property::Morph => {
+            let plan = track.transform_geometry_plan.as_ref().ok_or(
+                DerivedDisplayEvaluationError::MissingGeometryPlan {
+                    occurrence_index,
+                    property: track.property,
+                },
+            )?;
+            crate::apply_prepared_morph_values(
+                &mut row.as_mut(base_content),
+                &track.values,
+                plan,
+                progress,
+            )
+            .ok_or(DerivedDisplayEvaluationError::InvalidValueKind {
+                occurrence_index,
+                property: track.property,
+            })?;
+            Ok(())
+        }
+        Property::Position
+        | Property::Rotation
+        | Property::Scale
+        | Property::Fill
+        | Property::Stroke
+        | Property::StrokeWidth
+        | Property::Opacity
+        | Property::Appearance
+        | Property::Reveal => {
+            let value = crate::interpolate_track_values(&track.values, progress).ok_or(
+                DerivedDisplayEvaluationError::InvalidValueKind {
+                    occurrence_index,
+                    property: track.property,
+                },
+            )?;
+            crate::apply_evaluated_value(
+                &mut row.as_mut(base_content),
+                track.property,
+                value,
+                false,
+            );
+            Ok(())
+        }
+        Property::Presence | Property::ZIndex | Property::Transform => {
+            Err(DerivedDisplayEvaluationError::UnsupportedProperty {
+                occurrence_index,
+                property: track.property,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use noon_core::{Color, GeometryRef, RateFunction, Style, Transform2D, Vec2, VectorPath};
+
+    use super::*;
+
+    fn base(geometry: GeometryRef) -> DerivedDisplayObjectState {
+        DerivedDisplayObjectState {
+            z_index: 0.0,
+            content: ObjectContentRef::Geometry(geometry),
+            text_bounds: None,
+            transform: Transform2D::IDENTITY,
+            style: Style::default(),
+            appearance: 1.0,
+            presence: true,
+            reveal: 1.0,
+            morph: 0.0,
+            render_geometry: None,
+            render_transform: None,
+        }
+    }
+
+    fn track(property: Property, values: TrackValues) -> DerivedDisplayAnimationTrack {
+        DerivedDisplayAnimationTrack {
+            property,
+            values,
+            timing: TrackTiming::new(1.0, 2.0, RateFunction::Linear),
+            time_map: CompositionTimeMap::identity(),
+            transform_geometry_plan: None,
+        }
+    }
+
+    #[test]
+    fn derived_copy_is_absent_before_start_and_matches_endpoints() {
+        let occurrence = DerivedDisplayAnimationOccurrence {
+            anchor_object_index: 3,
+            occurrence_index: 7,
+            base: base(GeometryRef::circle(1.0)),
+            tracks: vec![
+                track(
+                    Property::Position,
+                    TrackValues::Vec2 {
+                        from: Vec2::ZERO,
+                        to: Vec2::new(10.0, 0.0),
+                    },
+                ),
+                track(
+                    Property::Appearance,
+                    TrackValues::Scalar { from: 0.0, to: 1.0 },
+                ),
+            ],
+        };
+        let plan = DerivedDisplayAnimationPlan::new(vec![occurrence]).unwrap();
+        assert!(plan.evaluate(0.5).unwrap().is_empty());
+
+        let start = plan.evaluate(1.0).unwrap();
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].anchor_object_index(), 3);
+        assert_eq!(start[0].occurrence_index(), 7);
+        assert_eq!(start[0].state().transform.translation, Vec2::ZERO);
+        assert_eq!(start[0].state().appearance, 0.0);
+
+        let middle = plan.evaluate(2.0).unwrap();
+        assert_eq!(middle[0].state().transform.translation, Vec2::new(5.0, 0.0));
+        assert_eq!(middle[0].state().appearance, 0.5);
+
+        let end = plan.evaluate(3.0).unwrap();
+        assert_eq!(end[0].state().transform.translation, Vec2::new(10.0, 0.0));
+        assert_eq!(end[0].state().appearance, 1.0);
+        assert_eq!(plan.evaluate(9.0).unwrap(), end);
+    }
+
+    #[test]
+    fn nested_time_map_controls_occurrence_lifetime_and_progress() {
+        let mut mapped = track(
+            Property::Position,
+            TrackValues::Vec2 {
+                from: Vec2::ZERO,
+                to: Vec2::new(8.0, 0.0),
+            },
+        );
+        mapped.timing = TrackTiming::new(0.0, 4.0, RateFunction::Linear);
+        mapped.time_map =
+            CompositionTimeMap::from_steps(vec![noon_core::CompositionTimeMapStep::new(
+                0.5,
+                0.5,
+                RateFunction::Linear,
+            )]);
+        let occurrence = DerivedDisplayAnimationOccurrence {
+            anchor_object_index: 0,
+            occurrence_index: 1,
+            base: base(GeometryRef::circle(1.0)),
+            tracks: vec![mapped],
+        };
+        let plan = DerivedDisplayAnimationPlan::new(vec![occurrence]).unwrap();
+        assert!(plan.evaluate(1.0).unwrap().is_empty());
+        assert_eq!(
+            plan.evaluate(3.0).unwrap()[0].state().transform.translation,
+            Vec2::new(4.0, 0.0)
+        );
+        assert_eq!(
+            plan.evaluate(4.0).unwrap()[0].state().transform.translation,
+            Vec2::new(8.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn prepared_morph_uses_compiled_geometry_plan_without_stable_identity() {
+        let source = VectorPath::new()
+            .move_to(Vec2::new(-1.0, 0.0))
+            .line_to(Vec2::new(1.0, 0.0));
+        let target = VectorPath::new()
+            .move_to(Vec2::new(0.0, -1.0))
+            .line_to(Vec2::new(0.0, 1.0));
+        let geometry = GeometryRef::path(source.with_morph_target(target));
+        let prepared = Arc::new(geometry.clone());
+        let occurrence = DerivedDisplayAnimationOccurrence {
+            anchor_object_index: 0,
+            occurrence_index: 2,
+            base: {
+                let mut state = base(geometry.clone());
+                state.style = Style {
+                    stroke: Some(Color::WHITE),
+                    fill: None,
+                    ..Style::default()
+                };
+                state
+            },
+            tracks: vec![DerivedDisplayAnimationTrack {
+                property: Property::Morph,
+                values: TrackValues::PreparedMorph {
+                    from: 0.0,
+                    to: 1.0,
+                    geometry,
+                    render_transform: None,
+                },
+                timing: TrackTiming::new(0.0, 2.0, RateFunction::Linear),
+                time_map: CompositionTimeMap::identity(),
+                transform_geometry_plan: Some(TransformGeometryPlan::PathPair {
+                    geometry: prepared,
+                    render_transform: None,
+                }),
+            }],
+        };
+        let plan = DerivedDisplayAnimationPlan::new(vec![occurrence]).unwrap();
+        let middle = plan.evaluate(1.0).unwrap();
+        assert_eq!(middle[0].state().morph, 0.5);
+        assert!(middle[0].state().render_geometry.is_some());
+    }
+}

--- a/crates/noon-runtime/src/lib.rs
+++ b/crates/noon-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![forbid(unsafe_code)]
 
+mod derived_display_evaluation;
 mod execution_slots;
 mod frame;
 mod prepared_frame;
@@ -9,6 +10,7 @@ mod reactive;
 mod renderer_publication;
 mod spatial_index;
 
+pub use derived_display_evaluation::*;
 pub use execution_slots::*;
 use frame::{frame_row_mut, EffectiveBoundsBasis, FrameRowMut, FrameRowState};
 pub use frame::{EffectiveObjectProperties, FrameChanges, FrameObjectState, FrameState};
@@ -1604,22 +1606,36 @@ fn apply_prepared_morph_track(
     track: &CompiledTrack,
     progress: f32,
 ) -> bool {
-    let TrackValues::PreparedMorph { from, to, .. } = &track.values else {
-        unreachable!("prepared Morph track must contain scalar endpoints");
+    let plan = track
+        .transform_geometry_plan
+        .as_ref()
+        .expect("prepared Morph track must carry compiled endpoint geometry");
+    apply_prepared_morph_values(row, &track.values, plan, progress)
+        .expect("prepared Morph track must contain matching scalar endpoints and path plan")
+}
+
+fn apply_prepared_morph_values(
+    row: &mut FrameRowMut<'_>,
+    values: &TrackValues,
+    plan: &TransformGeometryPlan,
+    progress: f32,
+) -> Option<bool> {
+    let TrackValues::PreparedMorph { from, to, .. } = values else {
+        return None;
     };
-    let Some(TransformGeometryPlan::PathPair {
+    let TransformGeometryPlan::PathPair {
         geometry,
         render_transform,
-    }) = track.transform_geometry_plan.as_ref()
+    } = plan
     else {
-        unreachable!("prepared Morph track must carry compiled endpoint geometry");
+        return None;
     };
     let morph = lerp(*from, *to, progress).clamp(0.0, 1.0);
     let mut changed = *row.morph != morph || *row.render_transform != *render_transform;
     *row.morph = morph;
     *row.render_transform = *render_transform;
     changed |= set_optional_geometry_if_changed(row.render_geometry, Some(geometry), true);
-    changed
+    Some(changed)
 }
 
 fn apply_transform_track(row: &mut FrameRowMut<'_>, track: &CompiledTrack, progress: f32) -> bool {
@@ -2031,24 +2047,26 @@ fn mapped_track_progress(track: &CompiledTrack, time: f64) -> Option<f32> {
 }
 
 fn interpolate(track: &CompiledTrack, progress: f32) -> EvaluatedValue {
-    match &track.values {
-        TrackValues::Scalar { from, to } => EvaluatedValue::Scalar(lerp(*from, *to, progress)),
-        TrackValues::Vec2 { from, to } => EvaluatedValue::Vec2(Vec2::new(
+    interpolate_track_values(&track.values, progress)
+        .expect("compiled continuous track carries an interpolable value kind")
+}
+
+fn interpolate_track_values(values: &TrackValues, progress: f32) -> Option<EvaluatedValue> {
+    match values {
+        TrackValues::Scalar { from, to } => {
+            Some(EvaluatedValue::Scalar(lerp(*from, *to, progress)))
+        }
+        TrackValues::Vec2 { from, to } => Some(EvaluatedValue::Vec2(Vec2::new(
             lerp(from.x, to.x, progress),
             lerp(from.y, to.y, progress),
-        )),
-        TrackValues::Color { from, to } => {
-            EvaluatedValue::Color(interpolate_optional_color(*from, *to, progress))
-        }
-        TrackValues::Bool { .. } | TrackValues::ZIndex { .. } => {
-            unreachable!("instant tracks are evaluated as discrete events")
-        }
-        TrackValues::Object { .. } => {
-            unreachable!("Transform tracks are evaluated atomically")
-        }
-        TrackValues::PreparedMorph { .. } => {
-            unreachable!("prepared Morph tracks install compiled geometry with scalar progress")
-        }
+        ))),
+        TrackValues::Color { from, to } => Some(EvaluatedValue::Color(interpolate_optional_color(
+            *from, *to, progress,
+        ))),
+        TrackValues::Bool { .. }
+        | TrackValues::ZIndex { .. }
+        | TrackValues::Object { .. }
+        | TrackValues::PreparedMorph { .. } => None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the runtime evaluator for source-padding family-Transform copies, stacked on #1440.

- introduces an identity-free derived display animation plan containing no semantic node, stable `ObjectId`, stable slot, or execution `TrackId`;
- evaluates the compiler-prepared channels using the same shared runtime interpolation helpers as stable tracks;
- reuses the canonical prepared-morph geometry path rather than implementing a second Transform engine;
- preserves nested composition time maps and exact root endpoints;
- derived rows are absent before their mapped start and remain at their endpoint until the owning session releases the plan;
- output is `DerivedDisplayObject` / `DerivedDisplayObjectState`, ready for renderer publication without entering `FrameState.objects`.

## Qualification

Exact production content passed on the qualifying branch before ancestry cleanup:

- focused derived display evaluator tests;
- full `cargo test -p noon-runtime --lib`;
- `cargo clippy -p noon-runtime --lib -- -D warnings`;
- rustfmt.

The branch has been reconstructed as one production-only commit `5007549b9012911364fe9718dd94c5dad7814158` directly on #1440. Temporary workflow files are absent.

## Remaining integration

`ExecutionSession` still needs to retain/evaluate this plan with the active segment and attach the resulting rows to renderer publication. The derived renderer/GPU path must then consume those rows.

Refs #82.