### PR TITLE
Add deterministic agent integration evaluation corpus

### DIFF
--- a/.github/workflows/authoring-agent-discovery.yml
+++ b/.github/workflows/authoring-agent-discovery.yml
@@ -137,6 +137,10 @@ jobs:
             echo "Preview isolation source is not present; discovery-only change."
           fi
       - if: steps.source.outputs.enabled == 'true'
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - if: steps.source.outputs.enabled == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -211,6 +215,14 @@ jobs:
           else
             echo "MCP rendering smoke not present in this revision."
           fi
+      - if: steps.source.outputs.enabled == 'true'
+        name: Verify deterministic agent evaluation corpus
+        env:
+          NOON_PREVIEW_RUNTIME_CONFIG: ${{ runner.temp }}/noon-preview/runtime.json
+        working-directory: tools/noon-mcp
+        run: |
+          set -o pipefail
+          timeout --signal=TERM 420s node test/docker-evaluation-corpus.mjs | tee "$RUNNER_TEMP/noon-agent-evaluation.json"
       - name: Upload isolation evidence
         if: always() && steps.source.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
@@ -222,6 +234,7 @@ jobs:
             ${{ runner.temp }}/noon-preview-runner.json
             ${{ runner.temp }}/noon-preview-cli.json
             ${{ runner.temp }}/noon-preview-mcp.json
+            ${{ runner.temp }}/noon-agent-evaluation.json
             ${{ runner.temp }}/noon-preview/runtime.json
           if-no-files-found: warn
           retention-days: 14

--- a/tools/noon-mcp/eval/corpus.json
+++ b/tools/noon-mcp/eval/corpus.json
@@ -1,0 +1,135 @@
+{
+  "schema": 1,
+  "kind": "noon-deterministic-agent-evaluation-corpus",
+  "reference": {
+    "compatibility": "Manim Community v0.21.0",
+    "renderBackend": "WebGL2",
+    "sourcePolicy": "Ready tasks reference the maintained Noon/Manim example inventory by ID; no external scene or asset corpus is copied here."
+  },
+  "tasks": [
+    {
+      "id": "square-to-circle-lifecycle",
+      "kind": "render",
+      "covers": ["square-to-circle", "fade-lifecycle", "repeated-runs"],
+      "example": "parity-square-to-circle",
+      "requiredFeatures": ["Square", "Circle", "Create", "Transform", "FadeOut"],
+      "loopDurationSeconds": 4,
+      "sampleTimes": [0, 0.5, 1, 1.5, 2, 2.5, 3],
+      "expectedBackend": "WebGL2",
+      "expectedAuthoredDuration": 3,
+      "expectedFinalObjectCount": 0,
+      "repeatFresh": 2,
+      "hashRelations": [
+        { "op": "notEqual", "left": 0, "right": 1 },
+        { "op": "notEqual", "left": 2, "right": 3 },
+        { "op": "notEqual", "left": 4, "right": 5 },
+        { "op": "notEqual", "left": 5, "right": 6 }
+      ]
+    },
+    {
+      "id": "sequential-barrier-hold",
+      "kind": "render",
+      "covers": ["sequential-barriers"],
+      "example": "parity-different-rotations",
+      "requiredFeatures": ["animate", "Rotate", "wait"],
+      "loopDurationSeconds": 4,
+      "sampleTimes": [0, 1, 2, 3],
+      "expectedBackend": "WebGL2",
+      "expectedAuthoredDuration": 3,
+      "expectedFinalObjectCount": 2,
+      "repeatFresh": 1,
+      "hashRelations": [
+        { "op": "notEqual", "left": 0, "right": 1 },
+        { "op": "notEqual", "left": 1, "right": 2 },
+        { "op": "equal", "left": 2, "right": 3 }
+      ]
+    },
+    {
+      "id": "succession-composition",
+      "kind": "render",
+      "covers": ["composition"],
+      "example": "manim-succession-example",
+      "requiredFeatures": ["Succession", "Dot", "animate", "move_to"],
+      "loopDurationSeconds": 5,
+      "sampleTimes": [0, 1, 2, 3, 4],
+      "expectedBackend": "WebGL2",
+      "expectedAuthoredDuration": 4,
+      "expectedFinalObjectCount": 4,
+      "repeatFresh": 1,
+      "hashRelations": [
+        { "op": "notEqual", "left": 0, "right": 1 },
+        { "op": "notEqual", "left": 1, "right": 2 },
+        { "op": "notEqual", "left": 2, "right": 3 },
+        { "op": "notEqual", "left": 3, "right": 4 }
+      ]
+    },
+    {
+      "id": "native-text-static",
+      "kind": "render",
+      "covers": ["text"],
+      "example": "manim-example1-text",
+      "requiredFeatures": ["Text", "Scene.add", "retained-text"],
+      "loopDurationSeconds": 1,
+      "sampleTimes": [0],
+      "expectedBackend": "WebGL2",
+      "expectedAuthoredDuration": 0,
+      "expectedFinalObjectCount": 1,
+      "repeatFresh": 1,
+      "hashRelations": []
+    },
+    {
+      "id": "rotation-updater-callback",
+      "kind": "render",
+      "covers": ["callbacks"],
+      "example": "parity-rotation-updater",
+      "requiredFeatures": ["add_updater", "remove_updater", "rotate_about_origin", "wait", "host-callback-lifecycle"],
+      "loopDurationSeconds": 5,
+      "sampleTimes": [0, 1, 2, 3, 4, 4.5],
+      "expectedBackend": "WebGL2",
+      "expectedAuthoredDuration": 4.5,
+      "expectedFinalObjectCount": 2,
+      "repeatFresh": 1,
+      "hashRelations": [
+        { "op": "notEqual", "left": 0, "right": 1 },
+        { "op": "notEqual", "left": 1, "right": 2 },
+        { "op": "equal", "left": 1, "right": 3 },
+        { "op": "equal", "left": 0, "right": 4 },
+        { "op": "equal", "left": 4, "right": 5 }
+      ]
+    },
+    {
+      "id": "unsupported-plotting",
+      "kind": "capability",
+      "covers": ["unsupported-plotting"],
+      "example": "axes-and-plots",
+      "expectedStatus": "blocked",
+      "requiredFeatures": ["Axes", "plot", "NumberPlane"]
+    },
+    {
+      "id": "unsupported-latex-mathtex",
+      "kind": "capability",
+      "covers": ["unsupported-latex"],
+      "example": "text-and-math",
+      "expectedStatus": "blocked",
+      "requiredFeatures": ["Tex", "MathTex"]
+    },
+    {
+      "id": "unsupported-three-d",
+      "kind": "capability",
+      "covers": ["unsupported-3d"],
+      "example": "three-d",
+      "expectedStatus": "deferred",
+      "requiredFeatures": ["ThreeDScene", "ThreeDAxes", "Surface"]
+    },
+    {
+      "id": "cancel-stuck-after-first-frame",
+      "kind": "cancellation",
+      "covers": ["cancellation"],
+      "sourcePath": "eval/scenes/stuck_after_first_frame.py",
+      "loopDurationSeconds": 4,
+      "sampleTime": 0.2,
+      "abortAfterMs": 100,
+      "expectedInitialObjectCount": 1
+    }
+  ]
+}

--- a/tools/noon-mcp/eval/corpus.json
+++ b/tools/noon-mcp/eval/corpus.json
@@ -4,7 +4,7 @@
   "reference": {
     "compatibility": "Manim Community v0.21.0",
     "renderBackend": "WebGL2",
-    "sourcePolicy": "Ready tasks reference the maintained Noon/Manim example inventory by ID; no external scene or asset corpus is copied here."
+    "sourcePolicy": "Inventory-backed tasks resolve maintained Noon/Manim example IDs. Noon-owned eval fixtures are confined to eval/scenes and must declare maintained capability symbols. No external scene or asset corpus is copied here."
   },
   "tasks": [
     {
@@ -64,18 +64,21 @@
       ]
     },
     {
-      "id": "native-text-static",
+      "id": "native-text-hold",
       "kind": "render",
       "covers": ["text"],
-      "example": "manim-example1-text",
-      "requiredFeatures": ["Text", "Scene.add", "retained-text"],
-      "loopDurationSeconds": 1,
-      "sampleTimes": [0],
+      "sourcePath": "eval/scenes/native_text_hold.py",
+      "requiredSymbols": ["Text"],
+      "requiredFeatures": ["Text", "Scene.add", "wait", "retained-text"],
+      "loopDurationSeconds": 2,
+      "sampleTimes": [0, 1],
       "expectedBackend": "WebGL2",
-      "expectedAuthoredDuration": 0,
+      "expectedAuthoredDuration": 1,
       "expectedFinalObjectCount": 1,
       "repeatFresh": 1,
-      "hashRelations": []
+      "hashRelations": [
+        { "op": "equal", "left": 0, "right": 1 }
+      ]
     },
     {
       "id": "rotation-updater-callback",

--- a/tools/noon-mcp/eval/corpus.mjs
+++ b/tools/noon-mcp/eval/corpus.mjs
@@ -23,6 +23,8 @@ const CAPABILITY_STATUSES = new Set(["blocked", "deferred", "missing"]);
 const HASH_OPS = new Set(["equal", "notEqual"]);
 const ID = /^[a-z0-9][a-z0-9-]{0,127}$/;
 const FEATURE = /^[A-Za-z_][A-Za-z0-9_.-]{0,127}$/;
+const SYMBOL = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+const EVAL_SCENE = /^eval\/scenes\/[A-Za-z0-9_.-]+\.py$/;
 
 function record(value, label) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -47,8 +49,26 @@ function identifiers(value, label, pattern = ID) {
   return value;
 }
 
+function evalScenePath(value, label) {
+  if (typeof value !== "string" || !EVAL_SCENE.test(value) || value.split("/").includes("..")) {
+    throw new TypeError(`${label} must be a confined eval scene`);
+  }
+  return value;
+}
+
 function validateRender(task) {
-  if (typeof task.example !== "string" || !ID.test(task.example)) throw new TypeError(`${task.id}: invalid example ID`);
+  const hasExample = typeof task.example === "string";
+  const hasSourcePath = typeof task.sourcePath === "string";
+  if (hasExample === hasSourcePath) {
+    throw new TypeError(`${task.id}: render task requires exactly one inventory example or Noon-owned sourcePath`);
+  }
+  if (hasExample) {
+    if (!ID.test(task.example)) throw new TypeError(`${task.id}: invalid example ID`);
+    if (task.requiredSymbols !== undefined) throw new TypeError(`${task.id}: inventory example must not duplicate capability symbols`);
+  } else {
+    evalScenePath(task.sourcePath, `${task.id}.sourcePath`);
+    identifiers(task.requiredSymbols, `${task.id}.requiredSymbols`, SYMBOL);
+  }
   identifiers(task.requiredFeatures, `${task.id}.requiredFeatures`, FEATURE);
   boundedNumber(task.loopDurationSeconds, `${task.id}.loopDurationSeconds`, { min: Number.EPSILON });
   if (!Array.isArray(task.sampleTimes) || task.sampleTimes.length === 0 || task.sampleTimes[0] !== 0) {
@@ -86,10 +106,7 @@ function validateCapability(task) {
 }
 
 function validateCancellation(task) {
-  if (typeof task.sourcePath !== "string" || !/^eval\/scenes\/[A-Za-z0-9_.-]+\.py$/.test(task.sourcePath) ||
-      task.sourcePath.split("/").includes("..")) {
-    throw new TypeError(`${task.id}: cancellation source must be a confined eval scene`);
-  }
+  evalScenePath(task.sourcePath, `${task.id}.sourcePath`);
   boundedNumber(task.loopDurationSeconds, `${task.id}.loopDurationSeconds`, { min: Number.EPSILON });
   boundedNumber(task.sampleTime, `${task.id}.sampleTime`, { min: Number.EPSILON });
   boundedNumber(task.abortAfterMs, `${task.id}.abortAfterMs`, { min: 10, max: 5_000, integer: true });

--- a/tools/noon-mcp/eval/corpus.mjs
+++ b/tools/noon-mcp/eval/corpus.mjs
@@ -1,0 +1,128 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const DEFAULT_CORPUS_PATH = path.join(here, "corpus.json");
+
+const REQUIRED_COVERAGE = new Set([
+  "square-to-circle",
+  "sequential-barriers",
+  "fade-lifecycle",
+  "composition",
+  "text",
+  "callbacks",
+  "unsupported-plotting",
+  "unsupported-latex",
+  "unsupported-3d",
+  "cancellation",
+  "repeated-runs",
+]);
+const TASK_KINDS = new Set(["render", "capability", "cancellation"]);
+const CAPABILITY_STATUSES = new Set(["blocked", "deferred", "missing"]);
+const HASH_OPS = new Set(["equal", "notEqual"]);
+const ID = /^[a-z0-9][a-z0-9-]{0,127}$/;
+const FEATURE = /^[A-Za-z_][A-Za-z0-9_.-]{0,127}$/;
+
+function record(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} must be a JSON object`);
+  }
+  return value;
+}
+
+function boundedNumber(value, label, { min = 0, max = 600, integer = false } = {}) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max ||
+      (integer && !Number.isSafeInteger(value))) {
+    throw new RangeError(`${label} is outside its deterministic bound`);
+  }
+  return value;
+}
+
+function identifiers(value, label, pattern = ID) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || !pattern.test(item))) {
+    throw new TypeError(`${label} must be a non-empty bounded identifier array`);
+  }
+  if (new Set(value).size !== value.length) throw new Error(`${label} contains duplicates`);
+  return value;
+}
+
+function validateRender(task) {
+  if (typeof task.example !== "string" || !ID.test(task.example)) throw new TypeError(`${task.id}: invalid example ID`);
+  identifiers(task.requiredFeatures, `${task.id}.requiredFeatures`, FEATURE);
+  boundedNumber(task.loopDurationSeconds, `${task.id}.loopDurationSeconds`, { min: Number.EPSILON });
+  if (!Array.isArray(task.sampleTimes) || task.sampleTimes.length === 0 || task.sampleTimes[0] !== 0) {
+    throw new TypeError(`${task.id}: sampleTimes must start at authored time 0`);
+  }
+  let previous = -Infinity;
+  for (const [index, time] of task.sampleTimes.entries()) {
+    boundedNumber(time, `${task.id}.sampleTimes[${index}]`);
+    if (time < previous) throw new RangeError(`${task.id}: sampleTimes must be nondecreasing`);
+    previous = time;
+  }
+  if (typeof task.expectedBackend !== "string" || task.expectedBackend.trim() === "" || task.expectedBackend.length > 64) {
+    throw new TypeError(`${task.id}: expectedBackend must be bounded text`);
+  }
+  boundedNumber(task.expectedAuthoredDuration, `${task.id}.expectedAuthoredDuration`);
+  boundedNumber(task.expectedFinalObjectCount, `${task.id}.expectedFinalObjectCount`, { max: 1_000_000, integer: true });
+  boundedNumber(task.repeatFresh, `${task.id}.repeatFresh`, { min: 1, max: 3, integer: true });
+  if (!Array.isArray(task.hashRelations)) throw new TypeError(`${task.id}: hashRelations must be an array`);
+  for (const [index, relation] of task.hashRelations.entries()) {
+    record(relation, `${task.id}.hashRelations[${index}]`);
+    if (!HASH_OPS.has(relation.op)) throw new TypeError(`${task.id}: unknown hash relation ${String(relation.op)}`);
+    for (const side of ["left", "right"]) {
+      boundedNumber(relation[side], `${task.id}.hashRelations[${index}].${side}`, {
+        max: task.sampleTimes.length - 1,
+        integer: true,
+      });
+    }
+  }
+}
+
+function validateCapability(task) {
+  if (typeof task.example !== "string" || !ID.test(task.example)) throw new TypeError(`${task.id}: invalid example ID`);
+  if (!CAPABILITY_STATUSES.has(task.expectedStatus)) throw new TypeError(`${task.id}: invalid unsupported status`);
+  identifiers(task.requiredFeatures, `${task.id}.requiredFeatures`, FEATURE);
+}
+
+function validateCancellation(task) {
+  if (typeof task.sourcePath !== "string" || !/^eval\/scenes\/[A-Za-z0-9_.-]+\.py$/.test(task.sourcePath) ||
+      task.sourcePath.split("/").includes("..")) {
+    throw new TypeError(`${task.id}: cancellation source must be a confined eval scene`);
+  }
+  boundedNumber(task.loopDurationSeconds, `${task.id}.loopDurationSeconds`, { min: Number.EPSILON });
+  boundedNumber(task.sampleTime, `${task.id}.sampleTime`, { min: Number.EPSILON });
+  boundedNumber(task.abortAfterMs, `${task.id}.abortAfterMs`, { min: 10, max: 5_000, integer: true });
+  boundedNumber(task.expectedInitialObjectCount, `${task.id}.expectedInitialObjectCount`, { max: 1_000_000, integer: true });
+}
+
+export function validateEvaluationCorpus(input) {
+  const corpus = record(input, "evaluation corpus");
+  if (corpus.schema !== 1 || corpus.kind !== "noon-deterministic-agent-evaluation-corpus") {
+    throw new Error("evaluation corpus schema/kind mismatch");
+  }
+  record(corpus.reference, "evaluation corpus reference");
+  if (!Array.isArray(corpus.tasks) || corpus.tasks.length === 0 || corpus.tasks.length > 32) {
+    throw new RangeError("evaluation corpus must contain 1..32 tasks");
+  }
+  const ids = new Set();
+  const coverage = new Set();
+  for (const [index, raw] of corpus.tasks.entries()) {
+    const task = record(raw, `tasks[${index}]`);
+    if (typeof task.id !== "string" || !ID.test(task.id) || ids.has(task.id)) throw new Error(`invalid or duplicate task ID: ${String(task.id)}`);
+    ids.add(task.id);
+    if (!TASK_KINDS.has(task.kind)) throw new TypeError(`${task.id}: unknown task kind`);
+    for (const item of identifiers(task.covers, `${task.id}.covers`)) coverage.add(item);
+    if (task.kind === "render") validateRender(task);
+    else if (task.kind === "capability") validateCapability(task);
+    else validateCancellation(task);
+  }
+  const missing = [...REQUIRED_COVERAGE].filter((item) => !coverage.has(item));
+  if (missing.length) throw new Error(`evaluation corpus misses required coverage: ${missing.join(", ")}`);
+  return corpus;
+}
+
+export async function loadEvaluationCorpus(file = DEFAULT_CORPUS_PATH) {
+  const value = JSON.parse(await readFile(file, "utf8"));
+  return validateEvaluationCorpus(value);
+}

--- a/tools/noon-mcp/eval/scenes/native_text_hold.py
+++ b/tools/noon-mcp/eval/scenes/native_text_hold.py
@@ -1,0 +1,7 @@
+from noon import *
+
+
+class NativeTextHold(Scene):
+    def construct(self):
+        self.add(Text("Hello world").scale(3))
+        self.wait(1)

--- a/tools/noon-mcp/eval/scenes/stuck_after_first_frame.py
+++ b/tools/noon-mcp/eval/scenes/stuck_after_first_frame.py
@@ -1,0 +1,9 @@
+from noon import *
+
+
+class StuckAfterFirstFrame(Scene):
+    def construct(self):
+        self.add(Circle())
+        self.wait(0.1)
+        while True:
+            pass

--- a/tools/noon-mcp/test/docker-evaluation-corpus.mjs
+++ b/tools/noon-mcp/test/docker-evaluation-corpus.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -75,10 +75,29 @@ function assertHashRelations(task, hashes) {
   }
 }
 
+async function declaredSource(task) {
+  if (task.example) {
+    const reference = await discovery.reference({ example: task.example });
+    return { source: reference.source, sourceSha256: reference.example.source_sha256, sourceKind: "inventory-example" };
+  }
+
+  const evalRoot = await realpath(path.join(packageRoot, "eval"));
+  const sourceFile = await realpath(path.join(packageRoot, task.sourcePath));
+  assert.ok(sourceFile.startsWith(`${evalRoot}${path.sep}`), `${task.id} escaped the eval fixture root`);
+  const source = await readFile(sourceFile, "utf8");
+  const report = await discovery.capabilities({ symbols: task.requiredSymbols });
+  for (const symbol of task.requiredSymbols) {
+    const record = report.symbols[symbol];
+    assert.ok(record?.exported, `${task.id} requires exported capability ${symbol}`);
+    assert.ok(["supported", "partial"].includes(record.policy?.status),
+      `${task.id} requires available capability ${symbol}, got ${String(record.policy?.status)}`);
+  }
+  return { source, sourceSha256: sha256(Buffer.from(source, "utf8")), sourceKind: "noon-eval-fixture" };
+}
+
 async function renderOnce(task) {
-  const reference = await discovery.reference({ example: task.example });
-  const sourceSha256 = reference.example.source_sha256;
-  const opened = await service.open(scope, reference.source, { loopDurationSeconds: task.loopDurationSeconds });
+  const { source, sourceSha256, sourceKind } = await declaredSource(task);
+  const opened = await service.open(scope, source, { loopDurationSeconds: task.loopDurationSeconds });
   const { sessionId } = opened;
   try {
     const frames = [opened];
@@ -97,8 +116,9 @@ async function renderOnce(task) {
     assert.equal(final.authoredDuration, task.expectedAuthoredDuration, `${task.id} authored duration`);
     assert.equal(final.frame.objectCount, task.expectedFinalObjectCount, `${task.id} final object count`);
     assertHashRelations(task, hashes);
-    evidence.push({ id: task.id, sessionId, sourceSha256, hashes, finalObjectCount: final.frame.objectCount,
-      authoredDuration: final.authoredDuration, backend: final.frame.rendererBackend });
+    evidence.push({ id: task.id, sessionId, sourceKind, sourceSha256, hashes,
+      finalObjectCount: final.frame.objectCount, authoredDuration: final.authoredDuration,
+      backend: final.frame.rendererBackend });
     return hashes;
   } finally {
     const closed = await service.close(scope, sessionId, `${task.id} deterministic evaluation complete`);

--- a/tools/noon-mcp/test/docker-evaluation-corpus.mjs
+++ b/tools/noon-mcp/test/docker-evaluation-corpus.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { execFile, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import { loadEvaluationCorpus } from "../eval/corpus.mjs";
+import { createDiscovery } from "../src/discovery.mjs";
+import { loadPreviewRuntimeConfig } from "../src/preview-isolation.mjs";
+import { AgentPreviewService } from "../src/preview-service.mjs";
+
+const execFileAsync = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(packageRoot, "../..");
+const runtimeConfigPath = process.env.NOON_PREVIEW_RUNTIME_CONFIG;
+if (!runtimeConfigPath) throw new Error("NOON_PREVIEW_RUNTIME_CONFIG is required for deterministic corpus qualification");
+const python = process.env.NOON_PYTHON || execFileSync("python3", ["-I", "-S", "-c", "import sys; print(sys.executable)"], { encoding: "utf8" }).trim();
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+const corpus = await loadEvaluationCorpus();
+const isolationConfig = await loadPreviewRuntimeConfig({ repoRoot, configPath: runtimeConfigPath });
+const runtimeIdentity = JSON.parse(await readFile(path.join(repoRoot, "web/runtime-build-identity.json"), "utf8"));
+const expectedBuild = Object.freeze({
+  engineRevision: runtimeIdentity.sourceRevision ?? null,
+  wasmSha256: runtimeIdentity.files?.wasm?.sha256,
+  workerSha256: runtimeIdentity.files?.worker?.sha256,
+  buildId: runtimeIdentity.buildId,
+});
+const discovery = await createDiscovery({ repoRoot, pythonExecutable: python });
+const service = new AgentPreviewService({ isolationConfig });
+const scope = service.openScope();
+const evidence = [];
+
+function assertBuild(build, label) {
+  assert.deepEqual(build, expectedBuild, `${label} must report the browser-observed build identity`);
+}
+
+function assertFrame(entry, { task, time, sourceSha256, sessionId }) {
+  const { snapshot, artifact } = entry;
+  assert.equal(snapshot.state, "ready", `${task.id}@${time} must remain ready`);
+  assert.equal(snapshot.frame?.requestedTime, time, `${task.id}@${time} requested time`);
+  assert.equal(snapshot.frame?.publishedTime, time, `${task.id}@${time} published time`);
+  assert.equal(snapshot.frame?.rendererBackend, task.expectedBackend, `${task.id}@${time} backend`);
+  assert.ok(Number.isSafeInteger(snapshot.frame?.objectCount) && snapshot.frame.objectCount >= 0,
+    `${task.id}@${time} must expose a semantic object-count observation`);
+  assert.equal(artifact.mimeType, "image/png");
+  assert.ok(Number.isSafeInteger(artifact.width) && artifact.width > 0);
+  assert.ok(Number.isSafeInteger(artifact.height) && artifact.height > 0);
+  assert.ok(Number.isSafeInteger(artifact.byteLength) && artifact.byteLength > 0);
+  assert.match(artifact.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(artifact.provenance.sessionId, sessionId);
+  assert.equal(artifact.provenance.sourceSha256, sourceSha256);
+  assert.equal(artifact.provenance.requestedTime, time);
+  assert.equal(artifact.provenance.publishedTime, time);
+  assert.equal(artifact.provenance.backend, task.expectedBackend);
+  assertBuild(artifact.provenance.build, `${task.id}@${time}`);
+
+  const retained = service.getArtifact(scope, sessionId, artifact.id);
+  assert.deepEqual(retained.descriptor, artifact, `${task.id}@${time} retained descriptor drifted`);
+  assert.equal(retained.png.length, artifact.byteLength);
+  assert.equal(sha256(retained.png), artifact.sha256, `${task.id}@${time} retained PNG hash mismatch`);
+  return artifact.sha256;
+}
+
+function assertHashRelations(task, hashes) {
+  for (const relation of task.hashRelations) {
+    const left = hashes[relation.left], right = hashes[relation.right];
+    if (relation.op === "equal") assert.equal(left, right,
+      `${task.id} expected equal raster states at ${relation.left}/${relation.right}`);
+    else assert.notEqual(left, right,
+      `${task.id} expected distinct raster states at ${relation.left}/${relation.right}`);
+  }
+}
+
+async function renderOnce(task) {
+  const reference = await discovery.reference({ example: task.example });
+  const sourceSha256 = reference.example.source_sha256;
+  const opened = await service.open(scope, reference.source, { loopDurationSeconds: task.loopDurationSeconds });
+  const { sessionId } = opened;
+  try {
+    const frames = [opened];
+    if (task.sampleTimes.length > 1) {
+      frames.push(...await service.sampleFrames(scope, sessionId, task.sampleTimes.slice(1)));
+    }
+    assert.equal(frames.length, task.sampleTimes.length);
+    const hashes = frames.map((entry, index) => assertFrame(entry, {
+      task,
+      time: task.sampleTimes[index],
+      sourceSha256,
+      sessionId,
+    }));
+    const final = frames.at(-1).snapshot;
+    assert.equal(final.sourceState, "completed", `${task.id} source continuation must complete`);
+    assert.equal(final.authoredDuration, task.expectedAuthoredDuration, `${task.id} authored duration`);
+    assert.equal(final.frame.objectCount, task.expectedFinalObjectCount, `${task.id} final object count`);
+    assertHashRelations(task, hashes);
+    evidence.push({ id: task.id, sessionId, sourceSha256, hashes, finalObjectCount: final.frame.objectCount,
+      authoredDuration: final.authoredDuration, backend: final.frame.rendererBackend });
+    return hashes;
+  } finally {
+    const closed = await service.close(scope, sessionId, `${task.id} deterministic evaluation complete`);
+    assert.equal(closed.state, "closed");
+    assert.throws(() => service.inspect(scope, sessionId), /stale or cross-scope/,
+      `${task.id} handle must be stale after close`);
+  }
+}
+
+async function verifyUnsupported(task) {
+  const report = await discovery.capabilities({ examples: [task.example] });
+  const record = report.examples[task.example];
+  assert.equal(record.status, task.expectedStatus, `${task.id} support status changed`);
+  const features = new Set(record.features ?? []);
+  for (const feature of task.requiredFeatures) assert.ok(features.has(feature), `${task.id} lost ${feature}`);
+  assert.equal(record.runtime_verified, false);
+  await assert.rejects(discovery.reference({ example: task.example }), /not ready/);
+  evidence.push({ id: task.id, status: record.status, features: task.requiredFeatures });
+}
+
+async function verifyCancellation(task) {
+  const source = await readFile(path.join(packageRoot, task.sourcePath), "utf8");
+  const opened = await service.open(scope, source, { loopDurationSeconds: task.loopDurationSeconds });
+  assert.equal(opened.snapshot.frame?.objectCount, task.expectedInitialObjectCount,
+    `${task.id} must publish a useful first frame before the source stalls`);
+  const controller = new AbortController();
+  const reason = new Error("deterministic evaluation cancellation");
+  const pending = service.sample(scope, opened.sessionId, task.sampleTime, { signal: controller.signal });
+  pending.catch(() => {});
+  const timer = setTimeout(() => controller.abort(reason), task.abortAfterMs);
+  try {
+    await assert.rejects(pending, /deterministic evaluation cancellation/);
+  } finally {
+    clearTimeout(timer);
+  }
+  assert.throws(() => service.inspect(scope, opened.sessionId), /stale or cross-scope/,
+    "canceled session must be retired authoritatively");
+  assert.equal(service.stats.sessions, 0, "cancellation must release the runner session before recovery");
+  evidence.push({ id: task.id, canceled: true, sourceSha256: sha256(Buffer.from(source, "utf8")) });
+}
+
+let baselineRepeatTask = null;
+let baselineRepeatHashes = null;
+try {
+  for (const task of corpus.tasks.filter((item) => item.kind === "render")) {
+    const hashes = await renderOnce(task);
+    if (task.repeatFresh > 1) {
+      baselineRepeatTask = task;
+      baselineRepeatHashes = hashes;
+    }
+  }
+  for (const task of corpus.tasks.filter((item) => item.kind === "capability")) await verifyUnsupported(task);
+  const cancellation = corpus.tasks.find((item) => item.kind === "cancellation");
+  assert.ok(cancellation, "corpus must include cancellation");
+  await verifyCancellation(cancellation);
+
+  assert.ok(baselineRepeatTask && baselineRepeatHashes, "corpus must include a repeated fresh render task");
+  for (let run = 1; run < baselineRepeatTask.repeatFresh; run += 1) {
+    const freshHashes = await renderOnce(baselineRepeatTask);
+    assert.deepEqual(freshHashes, baselineRepeatHashes,
+      `${baselineRepeatTask.id} fresh run ${run + 1} must reproduce exact raster evidence after cancellation recovery`);
+  }
+
+  assert.equal(service.stats.sessions, 0);
+  assert.equal(service.stats.artifacts.artifacts, 0);
+  const { stdout: containers } = await execFileAsync("docker", [
+    "ps", "--filter", "label=com.noon.preview=true", "--format", "{{.ID}}",
+  ], { timeout: 10_000, maxBuffer: 64 * 1024 });
+  assert.equal(containers.trim(), "", "deterministic corpus must leave no owned preview container running");
+
+  console.log(JSON.stringify({
+    ok: true,
+    schema: corpus.schema,
+    kind: corpus.kind,
+    buildId: expectedBuild.buildId,
+    engineRevision: expectedBuild.engineRevision,
+    tasks: evidence,
+    cancellationRecovered: true,
+    repeatedRunEquivalent: true,
+  }));
+} finally {
+  await service.closeScope(scope, "deterministic corpus complete").catch(() => {});
+  await service.dispose("deterministic corpus shutdown").catch(() => {});
+  discovery.close();
+}

--- a/tools/noon-mcp/test/evaluation-corpus.test.mjs
+++ b/tools/noon-mcp/test/evaluation-corpus.test.mjs
@@ -20,26 +20,46 @@ function requireFeatures(record, required, label) {
   for (const feature of required) assert.ok(features.has(feature), `${label} lost required feature ${feature}`);
 }
 
-test("fixed agent evaluation corpus is grounded in the maintained capability/example inventory", { timeout: 30_000 }, async (t) => {
+async function evalFixture(task) {
+  const evalRoot = await realpath(path.join(packageRoot, "eval"));
+  const sourcePath = await realpath(path.join(packageRoot, task.sourcePath));
+  assert.ok(sourcePath.startsWith(`${evalRoot}${path.sep}`), `${task.id} escaped the eval fixture root`);
+  const source = await readFile(sourcePath);
+  assert.match(hash(source), /^[0-9a-f]{64}$/);
+  return source.toString("utf8");
+}
+
+test("fixed agent evaluation corpus is grounded in maintained inventories and declared Noon fixtures", { timeout: 30_000 }, async (t) => {
   const corpus = await loadEvaluationCorpus();
   assert.equal(corpus.reference.compatibility, "Manim Community v0.21.0");
   assert.equal(corpus.reference.renderBackend, "WebGL2");
 
   const discovery = await createDiscovery({ repoRoot, pythonExecutable: python });
   t.after(() => discovery.close());
-  const examples = corpus.tasks.filter((task) => task.kind !== "cancellation").map((task) => task.example);
-  const report = await discovery.capabilities({ examples });
+  const examples = corpus.tasks.filter((task) => task.example).map((task) => task.example);
+  const symbols = [...new Set(corpus.tasks.flatMap((task) => task.requiredSymbols ?? []))];
+  const report = await discovery.capabilities({ examples, symbols });
   assert.equal(report.qualification.behavioral_tests_run, false,
     "source inventory must not be mislabeled as deterministic render qualification");
 
   for (const task of corpus.tasks) {
     if (task.kind === "cancellation") {
-      const evalRoot = await realpath(path.join(packageRoot, "eval"));
-      const sourcePath = await realpath(path.join(packageRoot, task.sourcePath));
-      assert.ok(sourcePath.startsWith(`${evalRoot}${path.sep}`), `${task.id} escaped the eval fixture root`);
-      const source = await readFile(sourcePath);
-      assert.match(source.toString("utf8"), /while True:/, `${task.id} must remain the intentional stuck-source fixture`);
-      assert.match(hash(source), /^[0-9a-f]{64}$/);
+      const source = await evalFixture(task);
+      assert.match(source, /while True:/, `${task.id} must remain the intentional stuck-source fixture`);
+      continue;
+    }
+
+    if (task.kind === "render" && task.sourcePath) {
+      const source = await evalFixture(task);
+      assert.match(source, /from noon import \*/);
+      for (const symbol of task.requiredSymbols) {
+        const record = report.symbols[symbol];
+        assert.ok(record, `${task.id} lost capability symbol ${symbol}`);
+        assert.equal(record.exported, true, `${task.id} requires exported ${symbol}`);
+        assert.ok(["supported", "partial"].includes(record.policy.status),
+          `${task.id} requires an available capability classification for ${symbol}`);
+        assert.equal(record.runtime_verified, false);
+      }
       continue;
     }
 

--- a/tools/noon-mcp/test/evaluation-corpus.test.mjs
+++ b/tools/noon-mcp/test/evaluation-corpus.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { loadEvaluationCorpus } from "../eval/corpus.mjs";
+import { createDiscovery } from "../src/discovery.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(packageRoot, "../..");
+const python = execFileSync("python3", ["-I", "-S", "-c", "import sys; print(sys.executable)"], { encoding: "utf8" }).trim();
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+function requireFeatures(record, required, label) {
+  const features = new Set(record.features ?? []);
+  for (const feature of required) assert.ok(features.has(feature), `${label} lost required feature ${feature}`);
+}
+
+test("fixed agent evaluation corpus is grounded in the maintained capability/example inventory", { timeout: 30_000 }, async (t) => {
+  const corpus = await loadEvaluationCorpus();
+  assert.equal(corpus.reference.compatibility, "Manim Community v0.21.0");
+  assert.equal(corpus.reference.renderBackend, "WebGL2");
+
+  const discovery = await createDiscovery({ repoRoot, pythonExecutable: python });
+  t.after(() => discovery.close());
+  const examples = corpus.tasks.filter((task) => task.kind !== "cancellation").map((task) => task.example);
+  const report = await discovery.capabilities({ examples });
+  assert.equal(report.qualification.behavioral_tests_run, false,
+    "source inventory must not be mislabeled as deterministic render qualification");
+
+  for (const task of corpus.tasks) {
+    if (task.kind === "cancellation") {
+      const evalRoot = await realpath(path.join(packageRoot, "eval"));
+      const sourcePath = await realpath(path.join(packageRoot, task.sourcePath));
+      assert.ok(sourcePath.startsWith(`${evalRoot}${path.sep}`), `${task.id} escaped the eval fixture root`);
+      const source = await readFile(sourcePath);
+      assert.match(source.toString("utf8"), /while True:/, `${task.id} must remain the intentional stuck-source fixture`);
+      assert.match(hash(source), /^[0-9a-f]{64}$/);
+      continue;
+    }
+
+    const record = report.examples[task.example];
+    assert.ok(record, `${task.id} missing example ${task.example}`);
+    requireFeatures(record, task.requiredFeatures, task.id);
+    assert.equal(record.runtime_verified, false);
+
+    if (task.kind === "render") {
+      assert.equal(record.status, "ready", `${task.id} render source is no longer ready`);
+      assert.match(record.source_sha256, /^[0-9a-f]{64}$/);
+      const reference = await discovery.reference({ example: task.example });
+      assert.equal(reference.example.source_sha256, record.source_sha256);
+      assert.equal(reference.behavioral_tests_run, false);
+      assert.match(reference.source, /from noon import \*/);
+    } else {
+      assert.equal(record.status, task.expectedStatus, `${task.id} support classification changed`);
+      assert.equal(record.repository_path, undefined, `${task.id} must not masquerade as a ready source`);
+      await assert.rejects(discovery.reference({ example: task.example }), /not ready/);
+    }
+  }
+});


### PR DESCRIPTION
Advances #1199 with the mandatory deterministic evaluation slice on the merged packaging/setup baseline (#1443).

## Scope

- adds one fixed versioned corpus covering the required product cases: square-to-circle initial/intermediate/final lifecycle, sequential wait/barrier hold, fade lifecycle, Succession composition, retained native Text, host updater callbacks, explicit unsupported plotting/LaTeX/3D classifications, cancellation after a useful first frame, and deterministic repeated-run recovery;
- reuses maintained ready example IDs and the existing capability/reference exporter for inventory-backed tasks. Two small Noon-owned fixtures are confined under `eval/scenes`: an executable native-Text hold probe grounded in the maintained `Text` capability classification, and the bounded stuck-after-first-frame cancellation fixture. No external scene/asset corpus is copied;
- validates corpus structure and coverage deterministically, then checks referenced examples and declared fixture capabilities against the maintained inventories;
- runs render tasks through the existing `AgentPreviewService` and Docker-isolated Chromium path, verifying exact authored/requested/published times, semantic object-count observations, backend identity, retained PNG bytes/hashes, browser-observed build provenance, lifecycle closure/stale handles, unsupported-source rejection, cancellation cleanup, no leaked containers, and exact fresh-run raster reproducibility;
- adds no stochastic model/agent calls. Agent scoring remains a separate #1199 slice and cannot replace this mandatory deterministic gate.

## Boundary

No new scene model, semantic identity space, scheduler, runtime, renderer, runner, session registry, artifact store, MCP server, capability matrix, or agent orchestration layer. Assertions are fixed product expectations; this PR does not widen raster tolerances or weaken existing gates to admit the corpus.

## Qualification note

The first real Docker corpus run correctly exposed that `manim-example1-text` is a static add-only tutorial source and therefore produces no semantic continuation for the persistent preview runner. The runner was left unchanged. The Text task now uses the explicit `native_text_hold.py` product fixture (`Text` + `Scene.add` + `wait(1)`), requires the maintained exported/partial `Text` capability, and asserts an unchanged raster across the authored hold.

## Base

Based on merged `master` after #1443 landed. Recheck current master before merge and requalify any relevant integration movement.

## Validation

Repository CI/self-review only per `AGENTS.override.md`. The existing Agent discovery MCP workflow retains deterministic evaluation JSON beside the isolation/runner/CLI/MCP evidence. Keep draft until the source-contract tests and real Docker corpus qualification pass on the exact master-based combination.