### PR TITLE
Activate flat unequal-family Transform through derived display state

### DIFF
--- a/crates/noon/src/execution_session.rs
+++ b/crates/noon/src/execution_session.rs
@@ -1,5 +1,8 @@
 mod callback;
 mod completion;
+mod family_transform;
+#[cfg(test)]
+mod family_transform_tests;
 mod publication;
 mod signal_timeline;
 pub use callback::{
@@ -27,13 +30,13 @@ use crate::execution_segment::{
 };
 use crate::live_session::{DrawBorderThenFillOptions, IndicateOptions, SubsetDisplayMode};
 use noon_compile::{
-    derive_prepared_scalar_animation_tracks,
+    derive_prepared_scalar_animation_tracks, lower_prepared_family_transform_channels,
     lower_prepared_scalar_signal_timeline_entries_with_resolver,
     lower_prepared_scalar_signal_timeline_entry, lower_prepared_semantic_animation_composition,
     lower_prepared_semantic_animation_schedule, lower_semantic_affine_animation_tracks,
     lower_semantic_animation_schedule, lower_semantic_execution, lower_semantic_execution_root,
-    lower_semantic_execution_root_with_animation_root_at, CompilePatchError,
-    EffectiveAnimationProperties, ExecutionMutationTransaction, ExecutionPatch,
+    lower_semantic_execution_root_with_animation_root_at, prepare_family_transform_activations,
+    CompilePatchError, EffectiveAnimationProperties, ExecutionMutationTransaction, ExecutionPatch,
     PreparedScalarAnimationTrackError, PreparedScalarSignalTimelineError,
     PreparedSemanticAnimationLoweringError, PreparedSemanticAnimationScheduleError,
     SemanticAffineAnimationTrackError, SemanticAnimationScheduleError, SemanticExecutionIndex,
@@ -50,8 +53,9 @@ use noon_core::{
     SemanticTransactionNodeRef, TimelineError, TrackDefinition, TrackId, TrackTiming,
 };
 use noon_runtime::{
-    EvaluationError, ExecutionSpatialIndex, FrameChanges, FrameState, RendererPublication,
-    RuntimeWakeState, SceneInstance, SpatialIndexUpdateStats, SpatialQueryStats,
+    DerivedDisplayAnimationPlan, DerivedDisplayObject, EvaluationError, ExecutionSpatialIndex,
+    FrameChanges, FrameState, RendererPublication, RuntimeWakeState, SceneInstance,
+    SpatialIndexUpdateStats, SpatialQueryStats,
 };
 
 const NATIVE_EVENT_SEQUENCE_WRAP: f32 = 1_000_000.0;
@@ -683,6 +687,9 @@ pub struct ExecutionSession {
     next_segment_sequence: Option<u64>,
     pending_segment_completion: Option<PendingSegmentCompletion>,
     completed_segment_sequence: Option<ExecutionSegmentSequence>,
+    derived_display_plan: Option<DerivedDisplayAnimationPlan>,
+    derived_display_objects: Vec<DerivedDisplayObject>,
+    derived_display_expire_after_publication: bool,
     last_callback_receipt: Option<CallbackPublicationReceipt>,
 }
 
@@ -715,6 +722,9 @@ impl Clone for ExecutionSession {
             next_segment_sequence: self.next_segment_sequence,
             pending_segment_completion: None,
             completed_segment_sequence: self.completed_segment_sequence,
+            derived_display_plan: None,
+            derived_display_objects: Vec::new(),
+            derived_display_expire_after_publication: false,
             last_callback_receipt: self.last_callback_receipt.clone(),
         }
     }
@@ -880,6 +890,9 @@ impl ExecutionSession {
             next_segment_sequence: Some(0),
             pending_segment_completion: None,
             completed_segment_sequence: None,
+            derived_display_plan: None,
+            derived_display_objects: Vec::new(),
+            derived_display_expire_after_publication: false,
             last_callback_receipt: None,
         }
     }
@@ -1095,7 +1108,21 @@ impl ExecutionSession {
 
     /// Consume one coherent renderer publication from this typed session.
     pub fn take_renderer_publication(&mut self) -> RendererPublication<'_> {
-        self.runtime.take_renderer_publication()
+        if let Some(plan) = self.derived_display_plan.as_ref() {
+            self.derived_display_objects = plan
+                .evaluate(self.runtime.frame().time)
+                .expect("validated derived family Transform plan must evaluate at runtime time");
+            if self.derived_display_expire_after_publication {
+                self.derived_display_plan = None;
+                self.derived_display_expire_after_publication = false;
+            }
+        } else {
+            self.derived_display_objects.clear();
+        }
+        self.runtime
+            .take_renderer_publication()
+            .with_derived_display_objects(&self.derived_display_objects)
+            .expect("compiler-owned family Transform rows retain valid painter anchors")
     }
 
     /// Evaluate deterministically at an absolute time.
@@ -1763,38 +1790,62 @@ impl ExecutionSession {
                 source,
                 target_state,
                 options,
-            } => {
-                let pairs = store
-                    .ordered_family_leaf_pairs(*source, *target_state)
-                    .map_err(|error| {
-                        ExecutionSessionAnimationError::InvalidComposition(error.to_string())
-                    })?;
-                let expanded = SemanticCompositionRequest::Composition {
-                    kind: SemanticAnimationCompositionKind::Parallel,
-                    children: pairs
-                        .into_iter()
-                        .map(
-                            |(source, target_state)| SemanticCompositionRequest::TransformTo {
-                                source,
-                                target_state,
-                                interpolation: noon_core::SemanticTransformInterpolation::Affine,
-                                complete_priority: false,
-                                // The family composition applies authored easing once.
-                                options: AnimationOptions::new().rate_func(RateFunction::Linear),
-                            },
-                        )
-                        .collect(),
-                    options: *options,
-                };
-                self.stage_composition_request(
-                    store,
-                    root,
-                    &expanded,
-                    declaration,
-                    admitted,
-                    removals,
-                )
-            }
+            } => match store.ordered_family_leaf_pairs(*source, *target_state) {
+                Ok(pairs) => {
+                    let expanded = SemanticCompositionRequest::Composition {
+                        kind: SemanticAnimationCompositionKind::Parallel,
+                        children: pairs
+                            .into_iter()
+                            .map(
+                                |(source, target_state)| SemanticCompositionRequest::TransformTo {
+                                    source,
+                                    target_state,
+                                    interpolation:
+                                        noon_core::SemanticTransformInterpolation::Affine,
+                                    complete_priority: false,
+                                    options: AnimationOptions::new()
+                                        .rate_func(RateFunction::Linear),
+                                },
+                            )
+                            .collect(),
+                        options: *options,
+                    };
+                    self.stage_composition_request(
+                        store,
+                        root,
+                        &expanded,
+                        declaration,
+                        admitted,
+                        removals,
+                    )
+                }
+                Err(error) => {
+                    let is_flat_family = |family: SemanticNodeId| {
+                        store
+                            .semantic_family_members_checked(family)
+                            .is_ok_and(|members| {
+                                members.iter().all(|member| {
+                                    store.node(*member).is_some_and(|node| {
+                                        matches!(
+                                            node.kind(),
+                                            noon_core::SemanticNodeKind::AuthoringObject
+                                        )
+                                    })
+                                })
+                            })
+                    };
+                    if !is_flat_family(*source) || !is_flat_family(*target_state) {
+                        return Err(ExecutionSessionAnimationError::InvalidComposition(
+                            error.to_string(),
+                        ));
+                    }
+                    Ok(declaration.create_family_transform_animation(
+                        *source,
+                        *target_state,
+                        *options,
+                    ))
+                }
+            },
             SemanticCompositionRequest::Indicate {
                 target,
                 indication,
@@ -3020,6 +3071,43 @@ impl ExecutionSession {
                 )
             })?;
 
+        if schedule.family_transforms().len() > 1
+            || (!schedule.family_transforms().is_empty()
+                && (!schedule.leaves().is_empty() || !schedule.scalar_leaves().is_empty()))
+        {
+            return Err(ExecutionSessionAnimationError::InvalidComposition(
+                "this bounded unequal-family Transform slice supports one family Transform plus timing-only composition nodes per activation".into(),
+            ));
+        }
+        let family_transform_activation = prepare_family_transform_activations(
+            &prepared,
+            &self.execution_index,
+            &schedule,
+            |object| {
+                let index = self.runtime.frame_index_for_object(object)?;
+                let frame = self.runtime.frame();
+                let row = frame.objects.get(index)?;
+                Some(EffectiveAnimationProperties {
+                    z_index: row.z_index,
+                    transform: row.transform,
+                    style: row.style,
+                    appearance: row.appearance,
+                    reveal: *frame.reveals.get(index)?,
+                })
+            },
+        )
+        .map_err(|error| ExecutionSessionAnimationError::InvalidComposition(error.to_string()))?;
+        let family_transform_channels =
+            lower_prepared_family_transform_channels(&prepared, &family_transform_activation)
+                .map_err(|error| {
+                    ExecutionSessionAnimationError::InvalidComposition(error.to_string())
+                })?;
+        let derived_display_plan = family_transform::build_derived_family_transform_plan(
+            &self.runtime,
+            &family_transform_channels,
+        )
+        .map_err(ExecutionSessionAnimationError::InvalidComposition)?;
+
         let mut projection_enrollments = Vec::new();
         let mut runtime_enrollment_inputs = Vec::new();
         let mut prepared_execution_signals = HashMap::new();
@@ -3139,8 +3227,12 @@ impl ExecutionSession {
         let mut segment =
             ExecutionSegment::from_duration(projection.start_time(), projection.run_time())?;
         let mut next_track_id = self.next_activation_track_id;
-        let mut definitions = Vec::with_capacity(projection.tracks().len());
-        let mut completions = Vec::with_capacity(projection.tracks().len());
+        let track_capacity = projection
+            .tracks()
+            .len()
+            .saturating_add(family_transform_channels.stable_tracks().len());
+        let mut definitions = Vec::with_capacity(track_capacity);
+        let mut completions = Vec::with_capacity(track_capacity);
         for track in projection.tracks() {
             let raw_id = next_track_id.ok_or(ExecutionSessionAnimationError::TrackIdExhausted)?;
             let track_id = TrackId::new(raw_id);
@@ -3156,6 +3248,28 @@ impl ExecutionSession {
                 track.property,
                 track_id,
                 end_time,
+                false,
+            ));
+            definitions.push(definition);
+            next_track_id = raw_id.checked_add(1);
+        }
+        for family_track in family_transform_channels.stable_tracks() {
+            let track = &family_track.track;
+            let raw_id = next_track_id.ok_or(ExecutionSessionAnimationError::TrackIdExhausted)?;
+            let track_id = TrackId::new(raw_id);
+            let definition = track
+                .with_track_id(track_id)
+                .map_err(ExecutionSessionAnimationError::PreparedTrack)?;
+            let end_time = execution_track_end_time(&definition)
+                .map_err(ExecutionSessionAnimationError::PreparedTrack)?;
+            completions.push((
+                track.target,
+                track.completion.clone(),
+                track.execution_object_id,
+                track.property,
+                track_id,
+                end_time,
+                family_track.retain_effective,
             ));
             definitions.push(definition);
             next_track_id = raw_id.checked_add(1);
@@ -3182,6 +3296,7 @@ impl ExecutionSession {
         let (token, next_segment_sequence) = if definitions.is_empty()
             && projection.family_animations().is_empty()
             && scalar_completions.is_empty()
+            && derived_display_plan.is_none()
         {
             (None, self.next_segment_sequence)
         } else {
@@ -3232,11 +3347,22 @@ impl ExecutionSession {
         let activation_scene_revision = self.publication_context().scene_revision();
 
         self.next_activation_track_id = next_track_id;
+        self.derived_display_plan = derived_display_plan;
+        self.derived_display_objects.clear();
+        self.derived_display_expire_after_publication = false;
         if let Some(token) = token {
             let entries = completions
                 .into_iter()
                 .map(
-                    |(target, completion, execution_object, property, track, end_time)| {
+                    |(
+                        target,
+                        completion,
+                        execution_object,
+                        property,
+                        track,
+                        end_time,
+                        retain_effective,
+                    )| {
                         SegmentCompletionEntry {
                             semantic_object: resolve_committed_node(target, &result),
                             completion,
@@ -3244,7 +3370,7 @@ impl ExecutionSession {
                             property,
                             track,
                             end_time,
-                            retain_effective: false,
+                            retain_effective,
                         }
                     },
                 )

--- a/crates/noon/src/execution_session/completion.rs
+++ b/crates/noon/src/execution_session/completion.rs
@@ -469,6 +469,9 @@ impl ExecutionSession {
         self.signal_timeline.commit_append(timeline);
         self.pending_segment_completion = None;
         self.completed_segment_sequence = Some(token.sequence());
+        if self.derived_display_plan.is_some() {
+            self.derived_display_expire_after_publication = true;
+        }
         self.last_callback_receipt = None;
         let publication = self.publication_context();
         self.callback_schedule

--- a/crates/noon/src/execution_session/family_transform.rs
+++ b/crates/noon/src/execution_session/family_transform.rs
@@ -1,0 +1,111 @@
+use noon_compile::PreparedFamilyTransformChannelProjection;
+use noon_runtime::{
+    DerivedDisplayAnimationOccurrence, DerivedDisplayAnimationPlan, DerivedDisplayAnimationTrack,
+    DerivedDisplayObjectState, SceneInstance,
+};
+
+/// Convert compiler-owned family-Transform padding channels into one runtime-only
+/// display plan while the activation frame is still authoritative.
+///
+/// Stable execution identity is used only to locate/copy the real source row. The
+/// resulting plan carries painter anchors and occurrence ordinals, never a synthetic
+/// semantic or execution object identity.
+pub(super) fn build_derived_family_transform_plan(
+    runtime: &SceneInstance,
+    projection: &PreparedFamilyTransformChannelProjection,
+) -> Result<Option<DerivedDisplayAnimationPlan>, String> {
+    if projection.derived_occurrences().is_empty() {
+        return Ok(None);
+    }
+
+    let frame = runtime.frame();
+    let mut occurrences = Vec::with_capacity(projection.derived_occurrences().len());
+    for occurrence in projection.derived_occurrences() {
+        let anchor_object_index = runtime
+            .frame_index_for_object(occurrence.anchor_execution_object_id)
+            .ok_or_else(|| {
+                format!(
+                    "derived family Transform occurrence {} has no live source execution row {}",
+                    occurrence.occurrence_index,
+                    occurrence.anchor_execution_object_id.get()
+                )
+            })?;
+        let row = frame.objects.get(anchor_object_index).ok_or_else(|| {
+            format!(
+                "derived family Transform occurrence {} source frame row {} is missing",
+                occurrence.occurrence_index, anchor_object_index
+            )
+        })?;
+        let base = DerivedDisplayObjectState {
+            z_index: row.z_index,
+            content: row.content.clone(),
+            text_bounds: row.text_bounds,
+            transform: row.transform,
+            style: row.style,
+            appearance: row.appearance,
+            presence: *frame.presences.get(anchor_object_index).ok_or_else(|| {
+                format!(
+                    "derived family Transform occurrence {} source presence row is missing",
+                    occurrence.occurrence_index
+                )
+            })?,
+            reveal: *frame.reveals.get(anchor_object_index).ok_or_else(|| {
+                format!(
+                    "derived family Transform occurrence {} source reveal row is missing",
+                    occurrence.occurrence_index
+                )
+            })?,
+            morph: *frame.morphs.get(anchor_object_index).ok_or_else(|| {
+                format!(
+                    "derived family Transform occurrence {} source morph row is missing",
+                    occurrence.occurrence_index
+                )
+            })?,
+            render_geometry: frame
+                .render_geometries
+                .get(anchor_object_index)
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "derived family Transform occurrence {} source render-geometry row is missing",
+                        occurrence.occurrence_index
+                    )
+                })?,
+            render_transform: *frame
+                .render_transforms
+                .get(anchor_object_index)
+                .ok_or_else(|| {
+                    format!(
+                        "derived family Transform occurrence {} source render-transform row is missing",
+                        occurrence.occurrence_index
+                    )
+                })?,
+        };
+        let tracks = occurrence
+            .tracks
+            .iter()
+            .map(|track| DerivedDisplayAnimationTrack {
+                property: track.property,
+                values: track.values.clone(),
+                timing: track.timing,
+                time_map: track.time_map.clone(),
+                transform_geometry_plan: track.transform_geometry_plan.clone(),
+            })
+            .collect();
+        occurrences.push(DerivedDisplayAnimationOccurrence {
+            anchor_object_index: u32::try_from(anchor_object_index).map_err(|_| {
+                format!(
+                    "derived family Transform occurrence {} source row exceeds u32 painter indexing",
+                    occurrence.occurrence_index
+                )
+            })?,
+            occurrence_index: occurrence.occurrence_index,
+            base,
+            tracks,
+        });
+    }
+
+    DerivedDisplayAnimationPlan::new(occurrences)
+        .map(Some)
+        .map_err(|error| error.to_string())
+}

--- a/crates/noon/src/execution_session/family_transform_tests.rs
+++ b/crates/noon/src/execution_session/family_transform_tests.rs
@@ -1,0 +1,143 @@
+use noon_core::{
+    AnimationOptions, RateFunction, SemanticObjectState, SemanticStore, SemanticVec3,
+    StoredGeometry,
+};
+
+use super::*;
+
+fn object(store: &mut SemanticStore, x: f64) -> SemanticNodeId {
+    let mut state = SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 });
+    state.transform.translation = SemanticVec3::new(x, 0.0, 0.0);
+    store.insert_semantic_object(state)
+}
+
+fn family(store: &mut SemanticStore, members: &[SemanticNodeId]) -> SemanticNodeId {
+    let family = store.insert_family();
+    for &member in members {
+        store.add_member(family, member).unwrap();
+    }
+    family
+}
+
+#[test]
+fn unequal_family_transform_publishes_one_identity_free_expansion_copy() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 0.0);
+    let s1 = object(&mut store, 2.0);
+    let source = family(&mut store, &[s0, s1]);
+    let t0 = object(&mut store, 10.0);
+    let t1 = object(&mut store, 12.0);
+    let t2 = object(&mut store, 14.0);
+    let target = family(&mut store, &[t0, t1, t2]);
+    let source_members = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+    let target_members = store
+        .semantic_family_members_checked(target)
+        .unwrap()
+        .to_vec();
+
+    let mut session = ExecutionSession::from_semantic_root(&store, source).unwrap();
+    let request = SemanticCompositionRequest::FamilyTransformTo {
+        source,
+        target_state: target,
+        options: AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear),
+    };
+    let segment = session
+        .declare_and_activate_composition(&mut store, source, &request, AnimationOptions::new())
+        .unwrap();
+
+    session.advance_segment_to(segment, 0.5).unwrap();
+    {
+        let publication = session.take_renderer_publication();
+        assert_eq!(publication.derived_display_objects().len(), 1);
+        let copy = &publication.derived_display_objects()[0];
+        assert!(copy.state().appearance > 0.0 && copy.state().appearance < 1.0);
+        assert_eq!(copy.anchor_object_index(), 0);
+    }
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_members
+    );
+    assert_eq!(
+        store.semantic_family_members_checked(target).unwrap(),
+        target_members
+    );
+
+    session.advance_segment_to(segment, 1.0).unwrap();
+    session.complete_segment(&mut store, segment).unwrap();
+    {
+        let publication = session.take_renderer_publication();
+        assert_eq!(publication.derived_display_objects().len(), 1);
+        assert_eq!(
+            publication.derived_display_objects()[0].state().appearance,
+            1.0
+        );
+    }
+    // Completion grants the endpoint one coherent publication, then the synthetic
+    // alignment occurrence disappears without changing semantic topology.
+    assert!(session
+        .take_renderer_publication()
+        .derived_display_objects()
+        .is_empty());
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_members
+    );
+}
+
+#[test]
+fn unequal_family_contraction_retains_only_effective_padding_fade() {
+    let mut store = SemanticStore::new();
+    let s0 = object(&mut store, 0.0);
+    let s1 = object(&mut store, 2.0);
+    let s2 = object(&mut store, 4.0);
+    let source = family(&mut store, &[s0, s1, s2]);
+    let t0 = object(&mut store, 10.0);
+    let t1 = object(&mut store, 14.0);
+    let target = family(&mut store, &[t0, t1]);
+    let source_members = store
+        .semantic_family_members_checked(source)
+        .unwrap()
+        .to_vec();
+
+    let mut session = ExecutionSession::from_semantic_root(&store, source).unwrap();
+    let request = SemanticCompositionRequest::FamilyTransformTo {
+        source,
+        target_state: target,
+        options: AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear),
+    };
+    let segment = session
+        .declare_and_activate_composition(&mut store, source, &request, AnimationOptions::new())
+        .unwrap();
+    session.advance_segment_to(segment, 1.0).unwrap();
+    assert!(session
+        .take_renderer_publication()
+        .derived_display_objects()
+        .is_empty());
+    session.complete_segment(&mut store, segment).unwrap();
+
+    let hidden_index = session
+        .execution_index
+        .execution_object_id(s1)
+        .and_then(|object| session.runtime.frame_index_for_object(object))
+        .unwrap();
+    assert_eq!(session.frame().objects[hidden_index].appearance, 0.0);
+    assert_eq!(
+        store.semantic_family_members_checked(source).unwrap(),
+        source_members
+    );
+    assert_eq!(
+        store
+            .semantic_object_state_checked(s1)
+            .unwrap()
+            .style
+            .object_opacity,
+        1.0
+    );
+}


### PR DESCRIPTION
## Summary

Wires the B3 flat unequal-family Transform compiler/runtime path into `ExecutionSession`, rebased against current `master`.

- preserves the existing strict/equal-family `ordered_family_leaf_pairs()` path and authoritative ordering/lag semantics;
- falls back to derived correspondence only for flat unequal families whose direct members are authoring objects;
- retains one runtime-only `DerivedDisplayAnimationPlan` for repeated source occurrences and publishes evaluated identity-free rows with the exact renderer publication;
- assigns TrackIds only to real stable-source tracks; derived copies receive no semantic ID, ObjectId, stable slot, or TrackId;
- propagates contraction `retain_effective` only to the padded-target appearance endpoint;
- keeps authored family membership and target topology unchanged;
- nested/mixed unequal family topology remains fail-closed.

## Current-master test contract

Flat one-member unequal targets are valid under this slice, so the historical rejection regression was stale. The branch folds the already-prepared #1451 correction into this root: the rejection fixture now uses a genuinely nested target family. This changes only the test contract; production unequal-family behavior is unchanged. #1451 is therefore redundant once this root lands.

## Exact-head qualification

Current head: `00c79f9d2e6d61d104ad5dc5c4e0ce8e6b38b11d`, based directly on `master` `6055960fca5fe664b2974726311dc838cc3486d6`. GitHub reports the PR mergeable, and `master` remained at that exact base through qualification.

All 9 exact-head workflows are green:
- Layer Dependency Ratchet — run `34756774229` / #2173;
- Native Host Smoke — run `34756774278` / #1117;
- PR Fast Gate — run `34756774226` / #2377;
- Architecture Ratchets — run `34756774233` / #2214;
- Shared text authoring — run `34756774215` / #766;
- Playground authoring recovery — run `34756774238` / #2206;
- Provider feature isolation — run `34756774220` / #706;
- Playground Product Gate — run `34756774244` / #1089;
- Playground cross-browser matrix — run `34756774237` / #2473, green on Chromium desktop, Firefox desktop, and WebKit mobile including the main-thread fallback.

The earlier WebKit-only failure on an older head was a playground module-import failure after a successful package build; this repaired exact head is the authoritative qualification.

## Remaining stack

The child renderer layer #1447 is restacked on this exact head and is itself qualified except for its still-running cross-browser matrix. Later B3 transient-presentation/path slices remain stacked above.

Refs #82.