### PR TITLE
Add reproducible stochastic agent comparison reporting

### DIFF
--- a/tools/noon-mcp/README.md
+++ b/tools/noon-mcp/README.md
@@ -66,9 +66,9 @@ A package or checkout hash is not evidence that a particular browser runtime was
 loaded. Actual preview results obtain build identity from the running browser worker
 and carry it with retained frame provenance.
 
-Runtime and dependency notices are in `THIRD_PARTY_NOTICES.md`. The initial package
-adds no copied external scene/asset corpus; any later evaluation corpus must be
-reviewed for redistribution provenance separately.
+Runtime and dependency notices are in `THIRD_PARTY_NOTICES.md`. The deterministic
+evaluation corpus uses maintained repository examples plus two small Noon-owned
+fixtures under `eval/scenes`; it does not copy an external scene/assets corpus.
 
 ### Optional isolated preview
 
@@ -120,8 +120,9 @@ support.
 
 `noon_reference` accepts one `example` ID. It resolves a currently ready example
 through that same inventory, confines the source to the checkout's example tree,
-checks the source hash, and returns at most 64 KiB of source. A file changed since
-the inventory scan fails instead of returning falsely attributed evidence.
+checks the source hash, and returns at most 64 KiB of source. A file
+changed since the inventory scan fails instead of returning falsely attributed
+evidence.
 
 A ready fixture or a declared parity label is **not a test performed by these
 discovery tools**. Results explicitly report `behavioral_tests_run: false`.
@@ -146,6 +147,32 @@ source/build/requested-time/published-time/backend provenance from the qualified
 runner path. Session handles are scope capabilities: stale and cross-scope use is
 rejected. Request cancellation, transport disconnect, signals, and shutdown flow
 through the shared session/runner cleanup path.
+
+## Evaluation
+
+`eval/corpus.json` is the mandatory deterministic product corpus. The Agent MCP
+workflow runs it through the same Docker-isolated `AgentPreviewService` path and
+checks semantic observations, backend-qualified retained PNG evidence, provenance,
+cancellation cleanup, unsupported classifications, and fresh-run determinism.
+These deterministic checks remain authoritative CI.
+
+Stochastic model evaluation is separate. `eval/agent-prompts.json` fixes one prompt
+for every deterministic task ID and defines three comparison modes: `docs-only`,
+`skill+runner`, and `skill+MCP`. `eval/agent-comparison.mjs` accepts only a complete
+three-mode matrix using one shared model/settings block and the current corpus and
+prompt-pack hashes. See `eval/AGENT_EVALUATION.md` for the collection/scoring
+contract.
+
+After real external runs have been collected:
+
+```bash
+node scripts/report-agent-evaluation.mjs /absolute/path/to/comparison.json --format markdown
+```
+
+The repository does not claim stochastic scores merely because the reporting
+pipeline is tested. Synthetic fixtures are marked `fixtureOnly: true`; the CLI
+refuses them unless `--allow-fixture` is explicitly supplied and labels their
+output as non-results.
 
 ## Boundaries
 
@@ -181,9 +208,10 @@ NOON_PYTHON=/absolute/path/to/python3 \
 
 Unit tests exercise bounded discovery subprocesses, reference-file validation,
 rendering adapter mapping, structured errors, cancellation propagation,
-artifact-delivery cleanup, and deterministic distribution identities. The stdio
-and clean-setup tests start the real server through an MCP SDK client and verify
-discovery-only behavior and protocol-clean failures. The repository's Agent
-discovery workflow additionally runs the real Docker preview, shared runner, CLI,
-and configured MCP rendering client against actual PNG frames and verifies
-deterministic provenance and cleanup.
+artifact-delivery cleanup, deterministic distribution identities, deterministic
+evaluation-corpus grounding, and stochastic comparison/reporting fairness rules.
+The stdio and clean-setup tests start the real server through an MCP SDK client
+and verify discovery-only behavior and protocol-clean failures. The repository's
+Agent discovery workflow additionally runs the real Docker preview, shared runner,
+CLI, configured MCP rendering client, and deterministic corpus against actual PNG
+frames and verifies deterministic provenance and cleanup.

--- a/tools/noon-mcp/eval/AGENT_EVALUATION.md
+++ b/tools/noon-mcp/eval/AGENT_EVALUATION.md
@@ -1,0 +1,88 @@
+# Noon stochastic agent evaluation
+
+This directory separates **mandatory deterministic product qualification** from
+**stochastic agent evaluation**. The deterministic corpus and Docker gate remain
+the product oracle. Stochastic results measure how an external model uses the
+available guidance/tools; they must never replace or weaken deterministic CI.
+
+## Comparison modes
+
+Every comparison uses the exact task prompts in `agent-prompts.json`, the same
+model identity/settings, the same repetition count, and the same landed
+`corpus.json` identity. Only the available Noon integration surface changes:
+
+| Mode | Agent-visible Noon integration |
+| --- | --- |
+| `docs-only` | Normal repository documentation only. No `noon-authoring` skill, preview runner/CLI, or MCP tools. The evaluator may execute the submitted source after the agent stops so correctness can still be scored. |
+| `skill+runner` | Same prompt/model settings plus the first-party `noon-authoring` skill, capability/reference data, and shared preview CLI/runner. No MCP tools. |
+| `skill+MCP` | Same prompt/model settings plus the first-party skill and the qualified local Noon MCP discovery/reference/preview tools. |
+
+Do not change system prompts, temperature, top-p, output-token limits, seed policy,
+context selection rules, task order, or repetition count between modes. If a
+provider/tool harness necessarily injects mode-specific tool schemas, record that
+as part of the mode boundary; do not compensate with a different model setting.
+
+## What a real run must record
+
+A comparison JSON uses `kind: "noon-agent-stochastic-comparison"`, `schema: 1`,
+and `fixtureOnly: false`. `eval/agent-comparison.mjs` rejects stale corpus or
+prompt-pack hashes, incomplete mode/task/repetition matrices, per-run model
+settings, unknown metric fields, and task-inappropriate result shapes.
+
+Each run records:
+
+- semantic correctness;
+- visual correctness for executable tasks;
+- unsupported-API suggestion correctness for blocked/deferred capability tasks;
+- repair iterations;
+- first-useful-frame latency for executable tasks;
+- input/output tokens, cached-input tokens, tool calls, and tool input/output tokens;
+- one or more evidence references (transcript, retained artifact, external run ID,
+  or another durable evidence locator).
+
+Use the external evaluation harness's native token accounting when available.
+Do not estimate missing token/tool metrics from text length. A failed run still
+needs explicit scores/usage/evidence so failure rates are not silently dropped.
+
+## Scoring discipline
+
+For supported authoring tasks, semantic and visual scores should be judged against
+the task intent and actual rendered evidence, not merely syntax success or a
+nonblank final frame. The landed deterministic corpus defines known-good product
+semantics and continues to catch engine/tooling regressions independently.
+
+For unsupported plotting, Tex/MathTex, and 3D tasks, a correct response recognizes
+the current capability status and gives an honest next step. Silently switching to
+another renderer, replacing equations with ordinary `Text`, fabricating 3D, or
+claiming unsupported APIs work is incorrect.
+
+The cancellation task is successful only when the agent obtains a useful first
+frame where its mode permits execution, uses bounded cancellation/recovery rather
+than waiting indefinitely, and reports evidence honestly.
+
+## Generate a report
+
+After collecting a complete real comparison set:
+
+```bash
+cd tools/noon-mcp
+node scripts/report-agent-evaluation.mjs /absolute/path/to/comparison.json --format markdown
+node scripts/report-agent-evaluation.mjs /absolute/path/to/comparison.json --format json
+```
+
+The reporter validates the file against the **current** corpus and prompt-pack
+hashes before aggregating the three modes. It reports semantic/visual/unsupported
+correctness rates, mean repair iterations, mean first-useful-frame latency, mean
+tokens, mean tool calls, and mean tool tokens.
+
+CI tests the reporting code with records explicitly marked `fixtureOnly: true`.
+The CLI refuses those records by default; `--allow-fixture` exists only for testing
+and the Markdown output is prominently marked `SYNTHETIC FIXTURE — NOT STOCHASTIC
+AGENT RESULTS`. No synthetic score belongs in a product comparison report.
+
+## Current status
+
+The repository contains the reproducible prompts, validation and aggregation
+contract. It intentionally contains **no claimed stochastic model scores** until
+real external runs using one fixed model/settings block and all three modes have
+been performed and their evidence retained.

--- a/tools/noon-mcp/eval/AGENT_EVALUATION.md
+++ b/tools/noon-mcp/eval/AGENT_EVALUATION.md
@@ -8,8 +8,9 @@ available guidance/tools; they must never replace or weaken deterministic CI.
 ## Comparison modes
 
 Every comparison uses the exact task prompts in `agent-prompts.json`, the same
-model identity/settings, the same repetition count, and the same landed
-`corpus.json` identity. Only the available Noon integration surface changes:
+model identity/settings, the same system prompt bytes, the same fixed task order,
+the same repetition count, and the same landed `corpus.json` identity. Only the
+available Noon integration surface changes:
 
 | Mode | Agent-visible Noon integration |
 | --- | --- |
@@ -18,7 +19,9 @@ model identity/settings, the same repetition count, and the same landed
 | `skill+MCP` | Same prompt/model settings plus the first-party skill and the qualified local Noon MCP discovery/reference/preview tools. |
 
 Do not change system prompts, temperature, top-p, output-token limits, seed policy,
-context selection rules, task order, or repetition count between modes. If a
+context selection rules, task order, or repetition count between modes. Record the
+SHA-256 of the exact common system-prompt bytes in `model.systemPromptSha256`.
+`taskOrder` must exactly match the current deterministic corpus order. If a
 provider/tool harness necessarily injects mode-specific tool schemas, record that
 as part of the mode boundary; do not compensate with a different model setting.
 
@@ -26,8 +29,8 @@ as part of the mode boundary; do not compensate with a different model setting.
 
 A comparison JSON uses `kind: "noon-agent-stochastic-comparison"`, `schema: 1`,
 and `fixtureOnly: false`. `eval/agent-comparison.mjs` rejects stale corpus or
-prompt-pack hashes, incomplete mode/task/repetition matrices, per-run model
-settings, unknown metric fields, and task-inappropriate result shapes.
+prompt-pack hashes, changed task order, incomplete mode/task/repetition matrices,
+per-run model settings, unknown metric fields, and task-inappropriate result shapes.
 
 Each run records:
 
@@ -40,9 +43,24 @@ Each run records:
 - one or more evidence references (transcript, retained artifact, external run ID,
   or another durable evidence locator).
 
-Use the external evaluation harness's native token accounting when available.
-Do not estimate missing token/tool metrics from text length. A failed run still
-needs explicit scores/usage/evidence so failure rates are not silently dropped.
+Use these metric definitions consistently:
+
+- **Repair iterations:** the count of candidate-source revisions after the first
+  submitted candidate and before the final scored answer. Pure explanation edits
+  without a changed candidate source do not increment it.
+- **First useful frame:** monotonic elapsed milliseconds from task delivery until
+  the evaluator first has a backend-qualified PNG from the current candidate that
+  is useful for judging the requested scene. In `docs-only`, this includes the
+  evaluator's first post-agent render of the submitted candidate. Capability-only
+  unsupported tasks record `null` because no honest rendered frame is expected.
+- **Token usage:** provider-reported input/output/cached-input counts. Do not infer
+  missing counts from character length.
+- **Tool overhead:** actual tool-call count plus provider/harness-reported tool
+  input/output token counts. A mode with no exposed tools records zeroes.
+
+A failed run still needs explicit scores/usage/evidence so failure rates are not
+silently dropped. Use the external evaluation harness's native accounting when
+available; do not estimate missing token/tool metrics.
 
 ## Scoring discipline
 
@@ -84,5 +102,5 @@ AGENT RESULTS`. No synthetic score belongs in a product comparison report.
 
 The repository contains the reproducible prompts, validation and aggregation
 contract. It intentionally contains **no claimed stochastic model scores** until
-real external runs using one fixed model/settings block and all three modes have
-been performed and their evidence retained.
+real external runs using one fixed model/settings/system-prompt/task-order block
+and all three modes have been performed and their evidence retained.

--- a/tools/noon-mcp/eval/agent-comparison.mjs
+++ b/tools/noon-mcp/eval/agent-comparison.mjs
@@ -20,10 +20,10 @@ const USAGE_KEYS = new Set([
 ]);
 const SET_KEYS = new Set([
   "schema", "kind", "evaluationId", "fixtureOnly", "repositoryRevision", "corpusSha256", "promptPackSha256",
-  "model", "repetitions", "runs",
+  "model", "taskOrder", "repetitions", "runs",
 ]);
 const MODEL_KEYS = new Set([
-  "provider", "name", "version", "temperature", "topP", "maxOutputTokens", "seedPolicy",
+  "provider", "name", "version", "temperature", "topP", "maxOutputTokens", "seedPolicy", "systemPromptSha256",
 ]);
 
 function sha256(bytes) {
@@ -83,6 +83,7 @@ function stableModel(model) {
   boundedNumber(row.topP, "model.topP", { max: 1 });
   boundedInt(row.maxOutputTokens, "model.maxOutputTokens", { min: 1, max: 1_000_000 });
   boundedText(row.seedPolicy, "model.seedPolicy", { max: 256 });
+  boundedText(row.systemPromptSha256, "model.systemPromptSha256", { max: 64, pattern: SHA256 });
   return Object.freeze({
     provider: row.provider,
     name: row.name,
@@ -91,6 +92,7 @@ function stableModel(model) {
     topP: row.topP,
     maxOutputTokens: row.maxOutputTokens,
     seedPolicy: row.seedPolicy,
+    systemPromptSha256: row.systemPromptSha256,
   });
 }
 
@@ -146,6 +148,10 @@ export function validateComparisonSet(input, context) {
   if (set.corpusSha256 !== context.corpusSha256) throw new Error("comparison corpus hash does not match the current deterministic corpus");
   if (set.promptPackSha256 !== context.promptPackSha256) throw new Error("comparison prompt-pack hash does not match the current prompt pack");
   const model = stableModel(set.model);
+  if (!Array.isArray(set.taskOrder) || set.taskOrder.length !== context.taskIds.length ||
+      set.taskOrder.some((taskId, index) => taskId !== context.taskIds[index])) {
+    throw new Error("taskOrder must exactly match the current fixed corpus order");
+  }
   boundedInt(set.repetitions, "repetitions", { min: 1, max: 20 });
   if (!Array.isArray(set.runs)) throw new TypeError("runs must be an array");
 
@@ -190,7 +196,7 @@ export function validateComparisonSet(input, context) {
     }
   }
   if (seen.size !== expected.size) throw new Error("comparison run matrix is incomplete");
-  return Object.freeze({ ...set, model });
+  return Object.freeze({ ...set, taskOrder: Object.freeze([...set.taskOrder]), model });
 }
 
 function summarizeMode(runs) {
@@ -226,6 +232,7 @@ export function aggregateComparison(set, context) {
     corpusSha256: validated.corpusSha256,
     promptPackSha256: validated.promptPackSha256,
     model: validated.model,
+    taskOrder: validated.taskOrder,
     repetitions: validated.repetitions,
     taskCount: context.taskIds.length,
     modes: byMode,
@@ -250,7 +257,7 @@ export function comparisonMarkdown(report) {
   }).join("\n");
   return `${banner}# Noon stochastic agent comparison\n\n` +
     `Evaluation: \`${report.evaluationId}\`  \nRepository: \`${report.repositoryRevision}\`  \nCorpus: \`${report.corpusSha256}\`  \nPrompt pack: \`${report.promptPackSha256}\`  \n` +
-    `Model: \`${report.model.provider}/${report.model.name}\`  \nRepetitions: ${report.repetitions}; tasks: ${report.taskCount}\n\n` +
+    `Model: \`${report.model.provider}/${report.model.name}\`  \nSystem prompt: \`${report.model.systemPromptSha256}\`  \nRepetitions: ${report.repetitions}; tasks: ${report.taskCount}\n\n` +
     `| Mode | Semantic | Visual | Unsupported API | Repairs | First useful frame (ms) | Tokens | Tool calls | Tool tokens |\n` +
     `| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n${rows}\n`;
 }

--- a/tools/noon-mcp/eval/agent-comparison.mjs
+++ b/tools/noon-mcp/eval/agent-comparison.mjs
@@ -1,0 +1,262 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const DEFAULT_CORPUS_PATH = path.join(here, "corpus.json");
+export const DEFAULT_PROMPT_PACK_PATH = path.join(here, "agent-prompts.json");
+export const EVALUATION_MODES = Object.freeze(["docs-only", "skill+runner", "skill+MCP"]);
+
+const ID = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const REVISION = /^[0-9a-f]{40}$/;
+const RUN_KEYS = new Set([
+  "mode", "taskId", "repetition", "status", "semanticCorrect", "visualCorrect",
+  "unsupportedApiSuggestionCorrect", "repairIterations", "firstUsefulFrameMs", "usage", "evidence", "notes",
+]);
+const USAGE_KEYS = new Set([
+  "inputTokens", "outputTokens", "cachedInputTokens", "toolCalls", "toolInputTokens", "toolOutputTokens",
+]);
+const SET_KEYS = new Set([
+  "schema", "kind", "evaluationId", "fixtureOnly", "repositoryRevision", "corpusSha256", "promptPackSha256",
+  "model", "repetitions", "runs",
+]);
+const MODEL_KEYS = new Set([
+  "provider", "name", "version", "temperature", "topP", "maxOutputTokens", "seedPolicy",
+]);
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+  return value;
+}
+
+function onlyKeys(value, allowed, label) {
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${label} contains unknown field ${key}`);
+}
+
+function boundedInt(value, label, { min = 0, max = 10_000_000 } = {}) {
+  if (!Number.isSafeInteger(value) || value < min || value > max) throw new RangeError(`${label} is outside its bound`);
+  return value;
+}
+
+function boundedNumber(value, label, { min = 0, max = 1_000_000_000 } = {}) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+    throw new RangeError(`${label} is outside its bound`);
+  }
+  return value;
+}
+
+function boundedText(value, label, { max = 4096, pattern } = {}) {
+  if (typeof value !== "string" || value.length === 0 || value.length > max || (pattern && !pattern.test(value))) {
+    throw new TypeError(`${label} must be bounded text`);
+  }
+  return value;
+}
+
+function boolOrNull(value, label) {
+  if (value !== null && typeof value !== "boolean") throw new TypeError(`${label} must be boolean or null`);
+  return value;
+}
+
+function mean(values) {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function rate(values) {
+  if (!values.length) return null;
+  return values.filter(Boolean).length / values.length;
+}
+
+function stableModel(model) {
+  const row = object(model, "model");
+  onlyKeys(row, MODEL_KEYS, "model");
+  boundedText(row.provider, "model.provider", { max: 128, pattern: ID });
+  boundedText(row.name, "model.name", { max: 256 });
+  if (row.version !== undefined) boundedText(row.version, "model.version", { max: 256 });
+  boundedNumber(row.temperature, "model.temperature", { max: 2 });
+  boundedNumber(row.topP, "model.topP", { max: 1 });
+  boundedInt(row.maxOutputTokens, "model.maxOutputTokens", { min: 1, max: 1_000_000 });
+  boundedText(row.seedPolicy, "model.seedPolicy", { max: 256 });
+  return Object.freeze({
+    provider: row.provider,
+    name: row.name,
+    ...(row.version === undefined ? {} : { version: row.version }),
+    temperature: row.temperature,
+    topP: row.topP,
+    maxOutputTokens: row.maxOutputTokens,
+    seedPolicy: row.seedPolicy,
+  });
+}
+
+function validateUsage(value, label) {
+  const usage = object(value, label);
+  onlyKeys(usage, USAGE_KEYS, label);
+  for (const key of USAGE_KEYS) boundedInt(usage[key], `${label}.${key}`, { max: 1_000_000_000 });
+  return usage;
+}
+
+function validateEvidence(value, label) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 32) throw new TypeError(`${label} must contain 1..32 entries`);
+  for (const [index, item] of value.entries()) boundedText(item, `${label}[${index}]`, { max: 2048 });
+  return value;
+}
+
+export async function loadEvaluationContext({ corpusPath = DEFAULT_CORPUS_PATH, promptPackPath = DEFAULT_PROMPT_PACK_PATH } = {}) {
+  const [corpusBytes, promptBytes] = await Promise.all([readFile(corpusPath), readFile(promptPackPath)]);
+  const corpus = JSON.parse(corpusBytes.toString("utf8"));
+  const prompts = JSON.parse(promptBytes.toString("utf8"));
+  if (corpus?.schema !== 1 || corpus.kind !== "noon-deterministic-agent-evaluation-corpus" || !Array.isArray(corpus.tasks)) {
+    throw new Error("deterministic corpus contract is incompatible");
+  }
+  if (prompts?.schema !== 1 || prompts.kind !== "noon-agent-stochastic-task-prompts" || !Array.isArray(prompts.tasks)) {
+    throw new Error("agent prompt pack contract is incompatible");
+  }
+  const corpusIds = corpus.tasks.map((task) => task.id);
+  const promptIds = prompts.tasks.map((task) => task.id);
+  if (new Set(corpusIds).size !== corpusIds.length || new Set(promptIds).size !== promptIds.length ||
+      corpusIds.length !== promptIds.length || corpusIds.some((id, index) => id !== promptIds[index])) {
+    throw new Error("agent prompt pack must cover the deterministic corpus in the same order");
+  }
+  for (const mode of EVALUATION_MODES) boundedText(prompts.modes?.[mode], `prompt mode ${mode}`, { max: 2048 });
+  return Object.freeze({
+    corpus,
+    prompts,
+    taskIds: Object.freeze([...corpusIds]),
+    taskKinds: Object.freeze(Object.fromEntries(corpus.tasks.map((task) => [task.id, task.kind]))),
+    corpusSha256: sha256(corpusBytes),
+    promptPackSha256: sha256(promptBytes),
+  });
+}
+
+export function validateComparisonSet(input, context) {
+  const set = object(input, "comparison set");
+  onlyKeys(set, SET_KEYS, "comparison set");
+  if (set.schema !== 1 || set.kind !== "noon-agent-stochastic-comparison") throw new Error("comparison set schema/kind mismatch");
+  boundedText(set.evaluationId, "evaluationId", { max: 128, pattern: ID });
+  if (typeof set.fixtureOnly !== "boolean") throw new TypeError("fixtureOnly must be explicit boolean");
+  boundedText(set.repositoryRevision, "repositoryRevision", { max: 40, pattern: REVISION });
+  boundedText(set.corpusSha256, "corpusSha256", { max: 64, pattern: SHA256 });
+  boundedText(set.promptPackSha256, "promptPackSha256", { max: 64, pattern: SHA256 });
+  if (set.corpusSha256 !== context.corpusSha256) throw new Error("comparison corpus hash does not match the current deterministic corpus");
+  if (set.promptPackSha256 !== context.promptPackSha256) throw new Error("comparison prompt-pack hash does not match the current prompt pack");
+  const model = stableModel(set.model);
+  boundedInt(set.repetitions, "repetitions", { min: 1, max: 20 });
+  if (!Array.isArray(set.runs)) throw new TypeError("runs must be an array");
+
+  const expected = new Set();
+  for (const mode of EVALUATION_MODES) {
+    for (const taskId of context.taskIds) {
+      for (let repetition = 1; repetition <= set.repetitions; repetition += 1) expected.add(`${mode}\0${taskId}\0${repetition}`);
+    }
+  }
+  if (set.runs.length !== expected.size) throw new Error(`comparison requires exactly ${expected.size} run records`);
+
+  const seen = new Set();
+  for (const [index, raw] of set.runs.entries()) {
+    const run = object(raw, `runs[${index}]`);
+    onlyKeys(run, RUN_KEYS, `runs[${index}]`);
+    if (!EVALUATION_MODES.includes(run.mode)) throw new TypeError(`runs[${index}].mode is invalid`);
+    if (!context.taskIds.includes(run.taskId)) throw new TypeError(`runs[${index}].taskId is not in the current corpus`);
+    boundedInt(run.repetition, `runs[${index}].repetition`, { min: 1, max: set.repetitions });
+    const key = `${run.mode}\0${run.taskId}\0${run.repetition}`;
+    if (!expected.has(key) || seen.has(key)) throw new Error(`duplicate or unexpected run record ${key}`);
+    seen.add(key);
+    if (!new Set(["completed", "failed"]).has(run.status)) throw new TypeError(`runs[${index}].status is invalid`);
+    if (typeof run.semanticCorrect !== "boolean") throw new TypeError(`runs[${index}].semanticCorrect must be boolean`);
+    boolOrNull(run.visualCorrect, `runs[${index}].visualCorrect`);
+    boolOrNull(run.unsupportedApiSuggestionCorrect, `runs[${index}].unsupportedApiSuggestionCorrect`);
+    boundedInt(run.repairIterations, `runs[${index}].repairIterations`, { max: 1000 });
+    if (run.firstUsefulFrameMs !== null) boundedNumber(run.firstUsefulFrameMs, `runs[${index}].firstUsefulFrameMs`, { max: 86_400_000 });
+    validateUsage(run.usage, `runs[${index}].usage`);
+    validateEvidence(run.evidence, `runs[${index}].evidence`);
+    if (run.notes !== undefined) boundedText(run.notes, `runs[${index}].notes`, { max: 4096 });
+
+    const kind = context.taskKinds[run.taskId];
+    if (kind === "capability") {
+      if (run.visualCorrect !== null || typeof run.unsupportedApiSuggestionCorrect !== "boolean" || run.firstUsefulFrameMs !== null) {
+        throw new Error(`${run.taskId}: capability runs require null visual/latency and a boolean unsupported-API score`);
+      }
+    } else {
+      if (typeof run.visualCorrect !== "boolean" || run.unsupportedApiSuggestionCorrect !== null ||
+          typeof run.firstUsefulFrameMs !== "number") {
+        throw new Error(`${run.taskId}: executable runs require visual/latency scores and null unsupported-API score`);
+      }
+    }
+  }
+  if (seen.size !== expected.size) throw new Error("comparison run matrix is incomplete");
+  return Object.freeze({ ...set, model });
+}
+
+function summarizeMode(runs) {
+  const executable = runs.filter((run) => run.visualCorrect !== null);
+  const unsupported = runs.filter((run) => run.unsupportedApiSuggestionCorrect !== null);
+  return Object.freeze({
+    runs: runs.length,
+    semanticCorrectRate: rate(runs.map((run) => run.semanticCorrect)),
+    visualCorrectRate: rate(executable.map((run) => run.visualCorrect)),
+    unsupportedApiSuggestionCorrectRate: rate(unsupported.map((run) => run.unsupportedApiSuggestionCorrect)),
+    meanRepairIterations: mean(runs.map((run) => run.repairIterations)),
+    meanFirstUsefulFrameMs: mean(executable.map((run) => run.firstUsefulFrameMs)),
+    meanInputTokens: mean(runs.map((run) => run.usage.inputTokens)),
+    meanOutputTokens: mean(runs.map((run) => run.usage.outputTokens)),
+    meanTotalTokens: mean(runs.map((run) => run.usage.inputTokens + run.usage.outputTokens)),
+    meanToolCalls: mean(runs.map((run) => run.usage.toolCalls)),
+    meanToolTokens: mean(runs.map((run) => run.usage.toolInputTokens + run.usage.toolOutputTokens)),
+  });
+}
+
+export function aggregateComparison(set, context) {
+  const validated = validateComparisonSet(set, context);
+  const byMode = Object.fromEntries(EVALUATION_MODES.map((mode) => [
+    mode,
+    summarizeMode(validated.runs.filter((run) => run.mode === mode)),
+  ]));
+  return Object.freeze({
+    schema: 1,
+    kind: "noon-agent-stochastic-comparison-report",
+    evaluationId: validated.evaluationId,
+    fixtureOnly: validated.fixtureOnly,
+    repositoryRevision: validated.repositoryRevision,
+    corpusSha256: validated.corpusSha256,
+    promptPackSha256: validated.promptPackSha256,
+    model: validated.model,
+    repetitions: validated.repetitions,
+    taskCount: context.taskIds.length,
+    modes: byMode,
+  });
+}
+
+function percent(value) {
+  return value === null ? "n/a" : `${(100 * value).toFixed(1)}%`;
+}
+
+function number(value, digits = 1) {
+  return value === null ? "n/a" : value.toFixed(digits);
+}
+
+export function comparisonMarkdown(report) {
+  const banner = report.fixtureOnly
+    ? "> **SYNTHETIC FIXTURE — NOT STOCHASTIC AGENT RESULTS.** This output only tests the reporting pipeline.\n\n"
+    : "";
+  const rows = EVALUATION_MODES.map((mode) => {
+    const value = report.modes[mode];
+    return `| ${mode} | ${percent(value.semanticCorrectRate)} | ${percent(value.visualCorrectRate)} | ${percent(value.unsupportedApiSuggestionCorrectRate)} | ${number(value.meanRepairIterations)} | ${number(value.meanFirstUsefulFrameMs)} | ${number(value.meanTotalTokens)} | ${number(value.meanToolCalls)} | ${number(value.meanToolTokens)} |`;
+  }).join("\n");
+  return `${banner}# Noon stochastic agent comparison\n\n` +
+    `Evaluation: \`${report.evaluationId}\`  \nRepository: \`${report.repositoryRevision}\`  \nCorpus: \`${report.corpusSha256}\`  \nPrompt pack: \`${report.promptPackSha256}\`  \n` +
+    `Model: \`${report.model.provider}/${report.model.name}\`  \nRepetitions: ${report.repetitions}; tasks: ${report.taskCount}\n\n` +
+    `| Mode | Semantic | Visual | Unsupported API | Repairs | First useful frame (ms) | Tokens | Tool calls | Tool tokens |\n` +
+    `| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n${rows}\n`;
+}
+
+export async function loadAndAggregateComparison(file, options = {}) {
+  const context = await loadEvaluationContext(options);
+  const input = JSON.parse(await readFile(file, "utf8"));
+  return { context, report: aggregateComparison(input, context) };
+}

--- a/tools/noon-mcp/eval/agent-prompts.json
+++ b/tools/noon-mcp/eval/agent-prompts.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "kind": "noon-agent-stochastic-task-prompts",
+  "modes": {
+    "docs-only": "Provide the task prompt and normal repository documentation only. Do not load the noon-authoring skill, preview CLI/runner, or MCP tools. The evaluator may execute the submitted source after the agent stops in order to score it.",
+    "skill+runner": "Provide the same task prompt and model settings, plus the first-party noon-authoring skill, capability exporter/reference files, and shared preview CLI/runner. Do not expose MCP tools.",
+    "skill+MCP": "Provide the same task prompt and model settings, plus the first-party noon-authoring skill and the qualified Noon MCP server, including discovery/reference and isolated preview tools."
+  },
+  "tasks": [
+    {
+      "id": "square-to-circle-lifecycle",
+      "prompt": "Author a Noon Python scene that creates a square, transforms it into a circle, and then fades the circle out. Return editable `from noon import *` source and verify the important initial, transition, and final states when your mode provides preview tools.",
+      "scoringFocus": "Correct Create -> Transform -> FadeOut lifecycle, final scene membership, and useful visual verification."
+    },
+    {
+      "id": "sequential-barrier-hold",
+      "prompt": "Author a Noon Python scene with two visible shapes where one rotation completes before a second, distinct rotation begins, followed by an authored hold with no visual change. Return editable source and verify the sequencing when your mode provides preview tools.",
+      "scoringFocus": "Sequential authoring barriers, distinct rotations, and a stable final hold."
+    },
+    {
+      "id": "succession-composition",
+      "prompt": "Author a Noon Python scene that uses supported animation composition to move four dots one after another rather than simultaneously. Return editable source and verify intermediate ordering when your mode provides preview tools.",
+      "scoringFocus": "Supported Succession-style composition and correct one-after-another motion."
+    },
+    {
+      "id": "native-text-hold",
+      "prompt": "Author a Noon Python scene that displays large native Text reading `Hello world` and holds it unchanged for one authored second. Return editable source and verify that the retained text remains stable when your mode provides preview tools.",
+      "scoringFocus": "Use supported native Text without substituting MathTex/Tex, and preserve a stable authored hold."
+    },
+    {
+      "id": "rotation-updater-callback",
+      "prompt": "Author a Noon Python scene that uses a supported updater/callback to rotate a square during authored waits, then removes the updater and demonstrates that the square stops changing. Return editable source and verify the callback lifecycle when your mode provides preview tools.",
+      "scoringFocus": "Updater registration/removal, authored-time callback behavior, and stable state after removal."
+    },
+    {
+      "id": "unsupported-plotting",
+      "prompt": "Create a Noon scene using Axes, NumberPlane, and function plotting. If the requested surface is not currently supported, do not fake it or silently switch renderers: explain the limitation and suggest the closest honest next step.",
+      "scoringFocus": "Recognize current plotting support status and avoid invented compatibility or semantic substitution."
+    },
+    {
+      "id": "unsupported-latex-mathtex",
+      "prompt": "Create a Noon scene containing a rendered LaTeX equation using Tex or MathTex. If the requested surface is not currently supported, do not replace the equation with ordinary Text: explain the limitation and suggest the closest honest next step.",
+      "scoringFocus": "Recognize current Tex/MathTex support status and avoid hiding the missing semantics with Text."
+    },
+    {
+      "id": "unsupported-three-d",
+      "prompt": "Create a Noon 3D scene with ThreeDScene, ThreeDAxes, and a Surface. If 3D is not currently available, say so explicitly and suggest how to track or scope the missing capability rather than inventing a 3D result.",
+      "scoringFocus": "Recognize deferred 3D support and avoid claiming an unavailable renderer/surface."
+    },
+    {
+      "id": "cancel-stuck-after-first-frame",
+      "prompt": "Work with a Noon scene that publishes a circle first and then becomes stuck in non-terminating Python work. When your mode provides preview execution, demonstrate bounded cancellation and recovery rather than waiting indefinitely. Report what evidence you obtained.",
+      "scoringFocus": "Useful first-frame behavior, bounded cancellation/recovery, and honest evidence reporting."
+    }
+  ]
+}

--- a/tools/noon-mcp/package.json
+++ b/tools/noon-mcp/package.json
@@ -9,7 +9,8 @@
     "start": "node src/server.mjs",
     "test": "node --test test/*.test.mjs",
     "manifest": "node scripts/package-manifest.mjs",
-    "smoke:clean": "node scripts/clean-setup-smoke.mjs"
+    "smoke:clean": "node scripts/clean-setup-smoke.mjs",
+    "eval:report": "node scripts/report-agent-evaluation.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",

--- a/tools/noon-mcp/scripts/report-agent-evaluation.mjs
+++ b/tools/noon-mcp/scripts/report-agent-evaluation.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+
+import { comparisonMarkdown, loadAndAggregateComparison } from "../eval/agent-comparison.mjs";
+
+function usage() {
+  return "usage: node scripts/report-agent-evaluation.mjs <comparison.json> [--format json|markdown] [--allow-fixture]";
+}
+
+const args = process.argv.slice(2);
+if (!args.length || args.includes("--help")) {
+  console.error(usage());
+  process.exit(args.includes("--help") ? 0 : 2);
+}
+const file = args.shift();
+let format = "markdown";
+let allowFixture = false;
+while (args.length) {
+  const flag = args.shift();
+  if (flag === "--format") {
+    format = args.shift();
+    if (!new Set(["json", "markdown"]).has(format)) throw new Error("--format must be json or markdown");
+  } else if (flag === "--allow-fixture") {
+    allowFixture = true;
+  } else {
+    throw new Error(`unknown argument: ${flag}`);
+  }
+}
+
+const { report } = await loadAndAggregateComparison(resolve(file));
+if (report.fixtureOnly && !allowFixture) {
+  throw new Error("synthetic fixture comparison refused; pass --allow-fixture only when testing the reporting pipeline");
+}
+if (format === "json") process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+else process.stdout.write(comparisonMarkdown(report));

--- a/tools/noon-mcp/test/agent-comparison.test.mjs
+++ b/tools/noon-mcp/test/agent-comparison.test.mjs
@@ -55,7 +55,9 @@ function syntheticSet(context, { repetitions = 2 } = {}) {
       topP: 1,
       maxOutputTokens: 4096,
       seedPolicy: "same external policy across all three modes",
+      systemPromptSha256: "a".repeat(64),
     },
+    taskOrder: [...context.taskIds],
     repetitions,
     runs,
   };
@@ -75,7 +77,9 @@ test("complete three-mode synthetic matrix aggregates the required comparison me
   const report = aggregateComparison(set, context);
   assert.equal(report.fixtureOnly, true);
   assert.equal(report.taskCount, context.taskIds.length);
+  assert.deepEqual(report.taskOrder, context.taskIds);
   assert.deepEqual(Object.keys(report.modes), EVALUATION_MODES);
+  assert.equal(report.model.systemPromptSha256, "a".repeat(64));
   assert.equal(report.modes["docs-only"].meanToolCalls, 0);
   assert.equal(report.modes["skill+runner"].meanToolCalls, 3);
   assert.equal(report.modes["skill+MCP"].meanToolCalls, 4);
@@ -85,9 +89,10 @@ test("complete three-mode synthetic matrix aggregates the required comparison me
   assert.ok(report.modes["docs-only"].meanFirstUsefulFrameMs > report.modes["skill+MCP"].meanFirstUsefulFrameMs);
   assert.match(comparisonMarkdown(report), /SYNTHETIC FIXTURE — NOT STOCHASTIC AGENT RESULTS/);
   assert.match(comparisonMarkdown(report), /First useful frame \(ms\)/);
+  assert.match(comparisonMarkdown(report), /System prompt: `a{64}`/);
 });
 
-test("comparison rejects stale corpus or prompt identities", async () => {
+test("comparison rejects stale corpus, prompt identities, or task order", async () => {
   const context = await loadEvaluationContext();
   const staleCorpus = syntheticSet(context);
   staleCorpus.corpusSha256 = "0".repeat(64);
@@ -96,6 +101,10 @@ test("comparison rejects stale corpus or prompt identities", async () => {
   const stalePrompts = syntheticSet(context);
   stalePrompts.promptPackSha256 = "1".repeat(64);
   assert.throws(() => validateComparisonSet(stalePrompts, context), /prompt-pack hash/);
+
+  const reordered = syntheticSet(context);
+  [reordered.taskOrder[0], reordered.taskOrder[1]] = [reordered.taskOrder[1], reordered.taskOrder[0]];
+  assert.throws(() => validateComparisonSet(reordered, context), /taskOrder/);
 });
 
 test("comparison rejects incomplete, duplicate, or mode-specific result shapes", async () => {
@@ -120,11 +129,15 @@ test("comparison rejects incomplete, duplicate, or mode-specific result shapes",
   assert.throws(() => validateComparisonSet(executable, context), /executable runs require visual\/latency/);
 });
 
-test("comparison schema is strict so per-run settings cannot silently differ by mode", async () => {
+test("comparison schema is strict so mode-specific model/settings cannot silently differ", async () => {
   const context = await loadEvaluationContext();
   const set = syntheticSet(context);
   set.runs[0].model = { name: "different-model" };
   assert.throws(() => validateComparisonSet(set, context), /unknown field model/);
+
+  const missingSystemPrompt = syntheticSet(context);
+  delete missingSystemPrompt.model.systemPromptSha256;
+  assert.throws(() => validateComparisonSet(missingSystemPrompt, context), /systemPromptSha256/);
 
   const unknownUsage = syntheticSet(context);
   unknownUsage.runs[0].usage.costUsd = 1;

--- a/tools/noon-mcp/test/agent-comparison.test.mjs
+++ b/tools/noon-mcp/test/agent-comparison.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  EVALUATION_MODES,
+  aggregateComparison,
+  comparisonMarkdown,
+  loadEvaluationContext,
+  validateComparisonSet,
+} from "../eval/agent-comparison.mjs";
+
+function syntheticSet(context, { repetitions = 2 } = {}) {
+  const runs = [];
+  for (const [modeIndex, mode] of EVALUATION_MODES.entries()) {
+    for (const [taskIndex, taskId] of context.taskIds.entries()) {
+      for (let repetition = 1; repetition <= repetitions; repetition += 1) {
+        const capability = context.taskKinds[taskId] === "capability";
+        runs.push({
+          mode,
+          taskId,
+          repetition,
+          status: "completed",
+          semanticCorrect: modeIndex > 0 || taskIndex % 2 === 0,
+          visualCorrect: capability ? null : modeIndex > 0,
+          unsupportedApiSuggestionCorrect: capability ? modeIndex > 0 : null,
+          repairIterations: Math.max(0, 2 - modeIndex),
+          firstUsefulFrameMs: capability ? null : 900 - modeIndex * 200 + taskIndex,
+          usage: {
+            inputTokens: 1000 + modeIndex * 100,
+            outputTokens: 400 + taskIndex,
+            cachedInputTokens: 0,
+            toolCalls: modeIndex === 0 ? 0 : 2 + modeIndex,
+            toolInputTokens: modeIndex === 0 ? 0 : 120,
+            toolOutputTokens: modeIndex === 0 ? 0 : 180,
+          },
+          evidence: [`fixture://${mode}/${taskId}/${repetition}`],
+          notes: "synthetic pipeline fixture",
+        });
+      }
+    }
+  }
+  return {
+    schema: 1,
+    kind: "noon-agent-stochastic-comparison",
+    evaluationId: "synthetic-report-contract",
+    fixtureOnly: true,
+    repositoryRevision: "612a76dc48ef8f8c0ea6a63e4ce45df541562e7d",
+    corpusSha256: context.corpusSha256,
+    promptPackSha256: context.promptPackSha256,
+    model: {
+      provider: "fixture",
+      name: "deterministic-test-double",
+      version: "1",
+      temperature: 0.7,
+      topP: 1,
+      maxOutputTokens: 4096,
+      seedPolicy: "same external policy across all three modes",
+    },
+    repetitions,
+    runs,
+  };
+}
+
+test("comparison context binds the prompt pack exactly to the deterministic corpus", async () => {
+  const context = await loadEvaluationContext();
+  assert.equal(context.taskIds.length, 9);
+  assert.equal(context.corpusSha256.length, 64);
+  assert.equal(context.promptPackSha256.length, 64);
+  assert.deepEqual(Object.keys(context.prompts.modes), EVALUATION_MODES);
+});
+
+test("complete three-mode synthetic matrix aggregates the required comparison metrics", async () => {
+  const context = await loadEvaluationContext();
+  const set = syntheticSet(context);
+  const report = aggregateComparison(set, context);
+  assert.equal(report.fixtureOnly, true);
+  assert.equal(report.taskCount, context.taskIds.length);
+  assert.deepEqual(Object.keys(report.modes), EVALUATION_MODES);
+  assert.equal(report.modes["docs-only"].meanToolCalls, 0);
+  assert.equal(report.modes["skill+runner"].meanToolCalls, 3);
+  assert.equal(report.modes["skill+MCP"].meanToolCalls, 4);
+  assert.equal(report.modes["skill+MCP"].semanticCorrectRate, 1);
+  assert.equal(report.modes["skill+MCP"].visualCorrectRate, 1);
+  assert.equal(report.modes["skill+MCP"].unsupportedApiSuggestionCorrectRate, 1);
+  assert.ok(report.modes["docs-only"].meanFirstUsefulFrameMs > report.modes["skill+MCP"].meanFirstUsefulFrameMs);
+  assert.match(comparisonMarkdown(report), /SYNTHETIC FIXTURE — NOT STOCHASTIC AGENT RESULTS/);
+  assert.match(comparisonMarkdown(report), /First useful frame \(ms\)/);
+});
+
+test("comparison rejects stale corpus or prompt identities", async () => {
+  const context = await loadEvaluationContext();
+  const staleCorpus = syntheticSet(context);
+  staleCorpus.corpusSha256 = "0".repeat(64);
+  assert.throws(() => validateComparisonSet(staleCorpus, context), /corpus hash/);
+
+  const stalePrompts = syntheticSet(context);
+  stalePrompts.promptPackSha256 = "1".repeat(64);
+  assert.throws(() => validateComparisonSet(stalePrompts, context), /prompt-pack hash/);
+});
+
+test("comparison rejects incomplete, duplicate, or mode-specific result shapes", async () => {
+  const context = await loadEvaluationContext();
+
+  const missing = syntheticSet(context);
+  missing.runs.pop();
+  assert.throws(() => validateComparisonSet(missing, context), /exactly/);
+
+  const duplicate = syntheticSet(context);
+  duplicate.runs[1] = { ...duplicate.runs[0] };
+  assert.throws(() => validateComparisonSet(duplicate, context), /duplicate or unexpected/);
+
+  const capability = syntheticSet(context);
+  const capabilityRun = capability.runs.find((run) => context.taskKinds[run.taskId] === "capability");
+  capabilityRun.visualCorrect = true;
+  assert.throws(() => validateComparisonSet(capability, context), /capability runs require null visual/);
+
+  const executable = syntheticSet(context);
+  const executableRun = executable.runs.find((run) => context.taskKinds[run.taskId] !== "capability");
+  executableRun.firstUsefulFrameMs = null;
+  assert.throws(() => validateComparisonSet(executable, context), /executable runs require visual\/latency/);
+});
+
+test("comparison schema is strict so per-run settings cannot silently differ by mode", async () => {
+  const context = await loadEvaluationContext();
+  const set = syntheticSet(context);
+  set.runs[0].model = { name: "different-model" };
+  assert.throws(() => validateComparisonSet(set, context), /unknown field model/);
+
+  const unknownUsage = syntheticSet(context);
+  unknownUsage.runs[0].usage.costUsd = 1;
+  assert.throws(() => validateComparisonSet(unknownUsage, context), /unknown field costUsd/);
+});


### PR DESCRIPTION
Advances the final implementation portion of #1199 after merged packaging (#1443) and deterministic product evaluation (#1445).

## Scope

- adds a fixed stochastic task-prompt pack keyed one-to-one and in-order to the landed deterministic corpus task IDs;
- defines the three required comparison modes: `docs-only`, `skill+runner`, and `skill+MCP`;
- adds a strict comparison validator requiring the current deterministic-corpus SHA-256, current prompt-pack SHA-256, exact fixed task order, one shared model/settings block including the common system-prompt SHA-256, and a complete identical mode × task × repetition matrix;
- records and aggregates semantic correctness, visual correctness, unsupported-API suggestion correctness, repair iterations, first-useful-frame latency, input/output token use, tool calls, and tool input/output tokens;
- rejects per-run model overrides, changed task order, stale corpus/prompt identities, incomplete/duplicate matrices, unknown metric fields, and task-inappropriate metric shapes;
- adds Markdown/JSON reporting plus a CLI that refuses `fixtureOnly: true` records unless `--allow-fixture` is explicitly requested; fixture Markdown is prominently labeled `SYNTHETIC FIXTURE — NOT STOCHASTIC AGENT RESULTS`;
- defines consistent repair-count, first-useful-frame, token and tool-overhead measurement rules. No stochastic model scores are claimed or checked in by this PR.

## Boundary

This is a validation/reporting format for **external stochastic runs**, not a nested agent orchestrator or model/provider integration. It does not change Noon semantics, runner/MCP behavior, the deterministic corpus, or any mandatory product gate. Deterministic Docker CI remains authoritative. CI exercises this reporting code only with explicitly synthetic records.

## Honest completion boundary

After this PR lands, the repository has a reproducible way to collect and compare the three modes using the same fixed prompts, task order, system prompt and model settings. #1199 should remain open until actual external model runs are performed and retained; this PR does not fabricate those outcomes.

## Validation

`npm test` covers prompt/corpus identity binding, complete three-mode matrices, aggregation, stale/incomplete/duplicate rejection, task-order/system-prompt fairness, metric-shape rules, per-run-model rejection, and synthetic-report labeling. Existing clean setup, real MCP, Docker deterministic corpus, PR Fast, architecture and dependency ratchets remain unchanged.