### PR TITLE
Add Python ArrowVectorField parity slice

### DIFF
--- a/crates/noon-web/src/authoring_arrow.rs
+++ b/crates/noon-web/src/authoring_arrow.rs
@@ -1,16 +1,77 @@
 #![cfg(target_arch = "wasm32")]
 
 use crate::{WasmAuthoringFamilyHandle, WasmAuthoringMobjectHandle, WasmAuthoringStore};
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 use wasm_bindgen::prelude::*;
 
-use crate::authoring_error::js_error;
+use crate::authoring_error::{js_error, AuthoringFailure};
 
-/// Inert typed Arrow-family constructor intent. No semantic identity exists
-/// until `WasmAuthoringStore::create_manim_arrow` consumes the whole request.
+#[derive(Clone, Debug)]
+struct VectorFieldDraft {
+    ranges: noon::VectorFieldRanges2D,
+    points: Vec<noon::VectorFieldPoint>,
+    vectors: Vec<Option<noon::VectorFieldPoint>>,
+    display_lengths: Option<Vec<Option<f64>>>,
+}
+
+#[derive(Clone, Debug)]
+enum ArrowRequest {
+    Arrow(noon::ManimArrowOptions),
+    VectorField(VectorFieldDraft),
+}
+
+/// Inert typed Arrow-family constructor intent. The same preparation-only wrapper
+/// also carries a static ArrowVectorField draft so Python can evaluate callbacks
+/// at Rust-owned sample points without inventing a second sampling contract.
 #[wasm_bindgen]
 pub struct WasmManimArrowOptions {
-    options: noon::ManimArrowOptions,
+    request: ArrowRequest,
+}
+
+impl WasmManimArrowOptions {
+    fn arrow_options_mut(&mut self) -> Result<&mut noon::ManimArrowOptions, JsValue> {
+        match &mut self.request {
+            ArrowRequest::Arrow(options) => Ok(options),
+            ArrowRequest::VectorField(_) => Err(invalid_input(
+                "vector_field.arrow_option",
+                "Arrow option setters cannot be applied to an ArrowVectorField draft",
+            )),
+        }
+    }
+
+    fn vector_field_draft(&self) -> Result<&VectorFieldDraft, JsValue> {
+        match &self.request {
+            ArrowRequest::VectorField(draft) => Ok(draft),
+            ArrowRequest::Arrow(_) => Err(invalid_input(
+                "vector_field.not_draft",
+                "vector-field sampling is available only on an ArrowVectorField draft",
+            )),
+        }
+    }
+
+    fn vector_field_draft_mut(&mut self) -> Result<&mut VectorFieldDraft, JsValue> {
+        match &mut self.request {
+            ArrowRequest::VectorField(draft) => Ok(draft),
+            ArrowRequest::Arrow(_) => Err(invalid_input(
+                "vector_field.not_draft",
+                "vector-field sampling is available only on an ArrowVectorField draft",
+            )),
+        }
+    }
+
+    fn sample_point(&self, index: u32) -> Result<noon::VectorFieldPoint, JsValue> {
+        let draft = self.vector_field_draft()?;
+        draft
+            .points
+            .get(index as usize)
+            .copied()
+            .ok_or_else(|| {
+                invalid_input(
+                    "vector_field.sample_index",
+                    format!("vector-field sample index {index} is out of range"),
+                )
+            })
+    }
 }
 
 #[wasm_bindgen]
@@ -22,13 +83,17 @@ impl WasmManimArrowOptions {
         end_y: f64,
     ) -> Result<WasmManimArrowOptions, JsValue> {
         noon::ManimArrowOptions::arrow(start_x, start_y, end_x, end_y)
-            .map(|options| Self { options })
+            .map(|options| Self {
+                request: ArrowRequest::Arrow(options),
+            })
             .map_err(js_error)
     }
 
     pub fn vector(direction_x: f64, direction_y: f64) -> Result<WasmManimArrowOptions, JsValue> {
         noon::ManimArrowOptions::vector(direction_x, direction_y)
-            .map(|options| Self { options })
+            .map(|options| Self {
+                request: ArrowRequest::Arrow(options),
+            })
             .map_err(js_error)
     }
 
@@ -40,52 +105,148 @@ impl WasmManimArrowOptions {
         end_y: f64,
     ) -> Result<WasmManimArrowOptions, JsValue> {
         noon::ManimArrowOptions::double_arrow(start_x, start_y, end_x, end_y)
-            .map(|options| Self { options })
+            .map(|options| Self {
+                request: ArrowRequest::Arrow(options),
+            })
             .map_err(js_error)
+    }
+
+    /// Start one static 2D field draft. Rust computes the exact Manim-compatible
+    /// sample grid; the frontend only fills values returned by its Python callback.
+    #[wasm_bindgen(js_name = vectorField)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn vector_field(
+        x_start: f64,
+        x_end: f64,
+        x_step: f64,
+        y_start: f64,
+        y_end: f64,
+        y_step: f64,
+        custom_length: bool,
+    ) -> Result<WasmManimArrowOptions, JsValue> {
+        let ranges = noon::VectorFieldRanges2D::new(
+            noon::VectorFieldAxisRange::new(x_start, x_end, x_step),
+            noon::VectorFieldAxisRange::new(y_start, y_end, y_step),
+        );
+        let plan = noon_geometry::plan_static_arrow_vector_field(
+            |_| noon::VectorFieldPoint::ZERO,
+            ranges,
+        )
+        .map_err(vector_field_planning_error)?;
+        let points = plan
+            .samples
+            .into_iter()
+            .map(|sample| sample.point)
+            .collect::<Vec<_>>();
+        let vectors = vec![None; points.len()];
+        let display_lengths = custom_length.then(|| vec![None; points.len()]);
+        Ok(Self {
+            request: ArrowRequest::VectorField(VectorFieldDraft {
+                ranges,
+                points,
+                vectors,
+                display_lengths,
+            }),
+        })
+    }
+
+    #[wasm_bindgen(getter, js_name = sampleCount)]
+    pub fn sample_count(&self) -> Result<u32, JsValue> {
+        let len = self.vector_field_draft()?.points.len();
+        u32::try_from(len).map_err(|_| {
+            invalid_input(
+                "vector_field.sample_count",
+                "vector-field sample count exceeds the browser bridge range",
+            )
+        })
+    }
+
+    #[wasm_bindgen(js_name = sampleX)]
+    pub fn sample_x(&self, index: u32) -> Result<f64, JsValue> {
+        self.sample_point(index).map(|point| point.x)
+    }
+
+    #[wasm_bindgen(js_name = sampleY)]
+    pub fn sample_y(&self, index: u32) -> Result<f64, JsValue> {
+        self.sample_point(index).map(|point| point.y)
+    }
+
+    #[wasm_bindgen(js_name = setVector)]
+    pub fn set_vector(&mut self, index: u32, x: f64, y: f64) -> Result<(), JsValue> {
+        let draft = self.vector_field_draft_mut()?;
+        let slot = draft.vectors.get_mut(index as usize).ok_or_else(|| {
+            invalid_input(
+                "vector_field.sample_index",
+                format!("vector-field sample index {index} is out of range"),
+            )
+        })?;
+        *slot = Some(noon::VectorFieldPoint::new(x, y));
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = setDisplayLength)]
+    pub fn set_display_length(&mut self, index: u32, value: f64) -> Result<(), JsValue> {
+        let draft = self.vector_field_draft_mut()?;
+        let Some(lengths) = draft.display_lengths.as_mut() else {
+            return Err(invalid_input(
+                "vector_field.default_length",
+                "display lengths may only be supplied for a custom length function",
+            ));
+        };
+        let slot = lengths.get_mut(index as usize).ok_or_else(|| {
+            invalid_input(
+                "vector_field.sample_index",
+                format!("vector-field sample index {index} is out of range"),
+            )
+        })?;
+        *slot = Some(value);
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = setBuff)]
     pub fn set_buff(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_buff(value).map_err(js_error)
+        self.arrow_options_mut()?.set_buff(value).map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setTipLength)]
     pub fn set_tip_length(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_tip_length(value).map_err(js_error)
+        self.arrow_options_mut()?.set_tip_length(value).map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setMaxTipLengthToLengthRatio)]
     pub fn set_max_tip_length_to_length_ratio(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options
+        self.arrow_options_mut()?
             .set_max_tip_length_to_length_ratio(value)
             .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setMaxStrokeWidthToLengthRatio)]
     pub fn set_max_stroke_width_to_length_ratio(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options
+        self.arrow_options_mut()?
             .set_max_stroke_width_to_length_ratio(value)
             .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setZIndex)]
     pub fn set_z_index(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_z_index(value).map_err(js_error)
+        self.arrow_options_mut()?.set_z_index(value).map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setTranslation)]
     pub fn set_translation(&mut self, x: f64, y: f64) -> Result<(), JsValue> {
-        self.options.set_translation(x, y).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_translation(x, y)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setScale)]
     pub fn set_scale(&mut self, x: f64, y: f64) -> Result<(), JsValue> {
-        self.options.set_scale(x, y).map_err(js_error)
+        self.arrow_options_mut()?.set_scale(x, y).map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setRotation)]
     pub fn set_rotation(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_rotation(value).map_err(js_error)
+        self.arrow_options_mut()?.set_rotation(value).map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setColor)]
@@ -96,84 +257,267 @@ impl WasmManimArrowOptions {
         blue: f64,
         alpha: f64,
     ) -> Result<(), JsValue> {
-        self.options
+        self.arrow_options_mut()?
             .set_color(red, green, blue, alpha)
             .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setStrokeWidth)]
     pub fn set_stroke_width(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_stroke_width(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_stroke_width(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setStrokeWidthMode)]
     pub fn set_stroke_width_mode(&mut self, value: &str) -> Result<(), JsValue> {
-        self.options.set_stroke_width_mode(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_stroke_width_mode(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setStrokeJoin)]
     pub fn set_stroke_join(&mut self, value: &str) -> Result<(), JsValue> {
-        self.options.set_stroke_join(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_stroke_join(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setStrokeCap)]
     pub fn set_stroke_cap(&mut self, value: &str) -> Result<(), JsValue> {
-        self.options.set_stroke_cap(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_stroke_cap(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setObjectOpacity)]
     pub fn set_object_opacity(&mut self, value: f64) -> Result<(), JsValue> {
-        self.options.set_object_opacity(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_object_opacity(value)
+            .map_err(js_error)
     }
 }
 
-/// Opaque wrapper around one atomically-published shared Arrow family.
+#[derive(Clone, Debug)]
+enum PublishedArrowRequest {
+    Arrow(noon::ManimArrow),
+    VectorField(noon::ManimArrowVectorField),
+}
+
+/// Opaque wrapper around one atomically-published shared Arrow family or static
+/// ArrowVectorField family. Existing Arrow accessors reject field-only use.
 #[wasm_bindgen]
 pub struct WasmAuthoringArrowHandle {
-    arrow: noon::ManimArrow,
+    published: PublishedArrowRequest,
+}
+
+impl WasmAuthoringArrowHandle {
+    fn arrow(&self) -> Result<&noon::ManimArrow, JsValue> {
+        match &self.published {
+            PublishedArrowRequest::Arrow(arrow) => Ok(arrow),
+            PublishedArrowRequest::VectorField(_) => Err(invalid_input(
+                "vector_field.component",
+                "single-Arrow component access is unavailable on an ArrowVectorField handle",
+            )),
+        }
+    }
+
+    fn vector(&self, index: u32) -> Result<&noon::ManimArrow, JsValue> {
+        match &self.published {
+            PublishedArrowRequest::VectorField(field) => field
+                .vectors()
+                .get(index as usize)
+                .ok_or_else(|| {
+                    invalid_input(
+                        "vector_field.vector_index",
+                        format!("vector-field vector index {index} is out of range"),
+                    )
+                }),
+            PublishedArrowRequest::Arrow(_) => Err(invalid_input(
+                "vector_field.not_field",
+                "vector member access is available only on an ArrowVectorField handle",
+            )),
+        }
+    }
 }
 
 #[wasm_bindgen]
 impl WasmAuthoringArrowHandle {
     pub fn family(&self) -> WasmAuthoringFamilyHandle {
-        WasmAuthoringFamilyHandle::from_semantic_family(self.arrow.family().clone())
+        let family = match &self.published {
+            PublishedArrowRequest::Arrow(arrow) => arrow.family(),
+            PublishedArrowRequest::VectorField(field) => field.family(),
+        };
+        WasmAuthoringFamilyHandle::from_semantic_family(family.clone())
     }
 
-    pub fn shaft(&self) -> WasmAuthoringMobjectHandle {
-        WasmAuthoringMobjectHandle::from_semantic_mobject(self.arrow.shaft().clone())
+    pub fn shaft(&self) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        self.arrow()
+            .map(|arrow| WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.shaft().clone()))
     }
 
     #[wasm_bindgen(js_name = endTip)]
-    pub fn end_tip(&self) -> WasmAuthoringMobjectHandle {
-        WasmAuthoringMobjectHandle::from_semantic_mobject(self.arrow.end_tip().clone())
+    pub fn end_tip(&self) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        self.arrow()
+            .map(|arrow| WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.end_tip().clone()))
     }
 
     #[wasm_bindgen(getter, js_name = hasStartTip)]
     pub fn has_start_tip(&self) -> bool {
-        self.arrow.start_tip().is_some()
+        matches!(
+            &self.published,
+            PublishedArrowRequest::Arrow(arrow) if arrow.start_tip().is_some()
+        )
     }
 
     #[wasm_bindgen(js_name = startTip)]
     pub fn start_tip(&self) -> Result<WasmAuthoringMobjectHandle, JsValue> {
-        self.arrow
+        self.arrow()?
             .start_tip()
             .cloned()
             .map(WasmAuthoringMobjectHandle::from_semantic_mobject)
             .ok_or_else(|| JsValue::from_str("Arrow has no start tip"))
     }
+
+    #[wasm_bindgen(getter, js_name = vectorCount)]
+    pub fn vector_count(&self) -> u32 {
+        match &self.published {
+            PublishedArrowRequest::VectorField(field) => {
+                u32::try_from(field.vectors().len()).unwrap_or(u32::MAX)
+            }
+            PublishedArrowRequest::Arrow(_) => 0,
+        }
+    }
+
+    #[wasm_bindgen(js_name = vectorFamily)]
+    pub fn vector_family(&self, index: u32) -> Result<WasmAuthoringFamilyHandle, JsValue> {
+        self.vector(index)
+            .map(|arrow| WasmAuthoringFamilyHandle::from_semantic_family(arrow.family().clone()))
+    }
+
+    #[wasm_bindgen(js_name = vectorShaft)]
+    pub fn vector_shaft(&self, index: u32) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        self.vector(index)
+            .map(|arrow| WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.shaft().clone()))
+    }
+
+    #[wasm_bindgen(js_name = vectorEndTip)]
+    pub fn vector_end_tip(&self, index: u32) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        self.vector(index).map(|arrow| {
+            WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.end_tip().clone())
+        })
+    }
 }
 
 #[wasm_bindgen]
 impl WasmAuthoringStore {
-    /// Consume the full inert Arrow request and publish shaft, tip resources,
-    /// component identities and family membership in one Rust transaction.
+    /// Consume the full inert Arrow request and publish either one Arrow or one
+    /// static vector-field family atomically through shared Rust authoring.
     #[wasm_bindgen(js_name = createManimArrow)]
     pub fn create_manim_arrow(
         &self,
         candidate: WasmManimArrowOptions,
     ) -> Result<WasmAuthoringArrowHandle, JsValue> {
-        noon::ManimArrow::create(Rc::clone(&self.semantics), candidate.options)
-            .map(|arrow| WasmAuthoringArrowHandle { arrow })
-            .map_err(js_error)
+        match candidate.request {
+            ArrowRequest::Arrow(options) => noon::ManimArrow::create(Rc::clone(&self.semantics), options)
+                .map(|arrow| WasmAuthoringArrowHandle {
+                    published: PublishedArrowRequest::Arrow(arrow),
+                })
+                .map_err(js_error),
+            ArrowRequest::VectorField(draft) => {
+                let vectors = complete_vectors(&draft)?;
+                let semantics = Rc::clone(&self.semantics);
+                let field = if let Some(lengths) = draft.display_lengths {
+                    validate_custom_lengths(&vectors, &lengths)?;
+                    let cursor = Cell::new(0usize);
+                    let points = &draft.points;
+                    noon::ManimArrowVectorField::create_with_length(
+                        semantics,
+                        |point| {
+                            let index = cursor.get();
+                            cursor.set(index + 1);
+                            debug_assert_eq!(points[index], point);
+                            vectors[index]
+                        },
+                        draft.ranges,
+                        |_| {
+                            let index = cursor.get() - 1;
+                            lengths[index].expect("custom non-zero vector length was preflighted")
+                        },
+                    )
+                    .map_err(vector_field_authoring_error)?
+                } else {
+                    let cursor = Cell::new(0usize);
+                    let points = &draft.points;
+                    noon::ManimArrowVectorField::create(
+                        semantics,
+                        |point| {
+                            let index = cursor.get();
+                            cursor.set(index + 1);
+                            debug_assert_eq!(points[index], point);
+                            vectors[index]
+                        },
+                        draft.ranges,
+                    )
+                    .map_err(vector_field_authoring_error)?
+                };
+                Ok(WasmAuthoringArrowHandle {
+                    published: PublishedArrowRequest::VectorField(field),
+                })
+            }
+        }
     }
+}
+
+fn complete_vectors(draft: &VectorFieldDraft) -> Result<Vec<noon::VectorFieldPoint>, JsValue> {
+    draft
+        .vectors
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value.ok_or_else(|| {
+                invalid_input(
+                    "vector_field.missing_vector",
+                    format!("vector-field sample {index} has no callback result"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn validate_custom_lengths(
+    vectors: &[noon::VectorFieldPoint],
+    lengths: &[Option<f64>],
+) -> Result<(), JsValue> {
+    for (index, (vector, length)) in vectors.iter().zip(lengths).enumerate() {
+        if vector.length() != 0.0 && length.is_none() {
+            return Err(invalid_input(
+                "vector_field.missing_length",
+                format!("vector-field sample {index} has no custom display length"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn vector_field_planning_error(error: noon::StaticVectorFieldError) -> JsValue {
+    use noon::StaticVectorFieldError as E;
+    let code = match error {
+        E::InvalidRange { .. } => "vector_field.invalid_range",
+        E::SampleCountOverflow => "vector_field.sample_count_overflow",
+        E::NonFiniteFieldOutput { .. } => "vector_field.non_finite_output",
+        E::NonFiniteDisplayedLength { .. } => "vector_field.non_finite_length",
+    };
+    js_error(AuthoringFailure::new("invalid_input", code, error))
+}
+
+fn vector_field_authoring_error(error: noon::ArrowVectorFieldAuthoringError) -> JsValue {
+    match error {
+        noon::ArrowVectorFieldAuthoringError::Planning(cause) => vector_field_planning_error(cause),
+        noon::ArrowVectorFieldAuthoringError::Authoring(cause) => js_error(cause),
+    }
+}
+
+fn invalid_input(code: &'static str, message: impl ToString) -> JsValue {
+    js_error(AuthoringFailure::new("invalid_input", code, message))
 }

--- a/crates/noon-web/src/authoring_arrow.rs
+++ b/crates/noon-web/src/authoring_arrow.rs
@@ -61,16 +61,12 @@ impl WasmManimArrowOptions {
 
     fn sample_point(&self, index: u32) -> Result<noon::VectorFieldPoint, JsValue> {
         let draft = self.vector_field_draft()?;
-        draft
-            .points
-            .get(index as usize)
-            .copied()
-            .ok_or_else(|| {
-                invalid_input(
-                    "vector_field.sample_index",
-                    format!("vector-field sample index {index} is out of range"),
-                )
-            })
+        draft.points.get(index as usize).copied().ok_or_else(|| {
+            invalid_input(
+                "vector_field.sample_index",
+                format!("vector-field sample index {index} is out of range"),
+            )
+        })
     }
 }
 
@@ -128,11 +124,9 @@ impl WasmManimArrowOptions {
             noon::VectorFieldAxisRange::new(x_start, x_end, x_step),
             noon::VectorFieldAxisRange::new(y_start, y_end, y_step),
         );
-        let plan = noon_geometry::plan_static_arrow_vector_field(
-            |_| noon::VectorFieldPoint::ZERO,
-            ranges,
-        )
-        .map_err(vector_field_planning_error)?;
+        let plan =
+            noon_geometry::plan_static_arrow_vector_field(|_| noon::VectorFieldPoint::ZERO, ranges)
+                .map_err(vector_field_planning_error)?;
         let points = plan
             .samples
             .into_iter()
@@ -210,7 +204,9 @@ impl WasmManimArrowOptions {
 
     #[wasm_bindgen(js_name = setTipLength)]
     pub fn set_tip_length(&mut self, value: f64) -> Result<(), JsValue> {
-        self.arrow_options_mut()?.set_tip_length(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_tip_length(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setMaxTipLengthToLengthRatio)]
@@ -229,7 +225,9 @@ impl WasmManimArrowOptions {
 
     #[wasm_bindgen(js_name = setZIndex)]
     pub fn set_z_index(&mut self, value: f64) -> Result<(), JsValue> {
-        self.arrow_options_mut()?.set_z_index(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_z_index(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setTranslation)]
@@ -246,7 +244,9 @@ impl WasmManimArrowOptions {
 
     #[wasm_bindgen(js_name = setRotation)]
     pub fn set_rotation(&mut self, value: f64) -> Result<(), JsValue> {
-        self.arrow_options_mut()?.set_rotation(value).map_err(js_error)
+        self.arrow_options_mut()?
+            .set_rotation(value)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = setColor)]
@@ -324,15 +324,14 @@ impl WasmAuthoringArrowHandle {
 
     fn vector(&self, index: u32) -> Result<&noon::ManimArrow, JsValue> {
         match &self.published {
-            PublishedArrowRequest::VectorField(field) => field
-                .vectors()
-                .get(index as usize)
-                .ok_or_else(|| {
+            PublishedArrowRequest::VectorField(field) => {
+                field.vectors().get(index as usize).ok_or_else(|| {
                     invalid_input(
                         "vector_field.vector_index",
                         format!("vector-field vector index {index} is out of range"),
                     )
-                }),
+                })
+            }
             PublishedArrowRequest::Arrow(_) => Err(invalid_input(
                 "vector_field.not_field",
                 "vector member access is available only on an ArrowVectorField handle",
@@ -403,9 +402,8 @@ impl WasmAuthoringArrowHandle {
 
     #[wasm_bindgen(js_name = vectorEndTip)]
     pub fn vector_end_tip(&self, index: u32) -> Result<WasmAuthoringMobjectHandle, JsValue> {
-        self.vector(index).map(|arrow| {
-            WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.end_tip().clone())
-        })
+        self.vector(index)
+            .map(|arrow| WasmAuthoringMobjectHandle::from_semantic_mobject(arrow.end_tip().clone()))
     }
 }
 
@@ -419,11 +417,13 @@ impl WasmAuthoringStore {
         candidate: WasmManimArrowOptions,
     ) -> Result<WasmAuthoringArrowHandle, JsValue> {
         match candidate.request {
-            ArrowRequest::Arrow(options) => noon::ManimArrow::create(Rc::clone(&self.semantics), options)
-                .map(|arrow| WasmAuthoringArrowHandle {
-                    published: PublishedArrowRequest::Arrow(arrow),
-                })
-                .map_err(js_error),
+            ArrowRequest::Arrow(options) => {
+                noon::ManimArrow::create(Rc::clone(&self.semantics), options)
+                    .map(|arrow| WasmAuthoringArrowHandle {
+                        published: PublishedArrowRequest::Arrow(arrow),
+                    })
+                    .map_err(js_error)
+            }
             ArrowRequest::VectorField(draft) => {
                 let vectors = complete_vectors(&draft)?;
                 let semantics = Rc::clone(&self.semantics);

--- a/parity/manim-v0.21/core-examples/arrow_vector_field.py
+++ b/parity/manim-v0.21/core-examples/arrow_vector_field.py
@@ -1,0 +1,12 @@
+from manim import *
+
+
+class ArrowVectorFieldStatic(Scene):
+    def construct(self):
+        field = ArrowVectorField(
+            lambda point: point[0] * UP - point[1] * RIGHT,
+            x_range=[-2.0, 2.0, 1.0],
+            y_range=[-1.0, 1.0, 1.0],
+        )
+        self.add(field)
+        self.wait(0.2)

--- a/parity/manim-v0.21/manifest.json
+++ b/parity/manim-v0.21/manifest.json
@@ -143,6 +143,17 @@
       }
     },
     {
+      "id": "arrow-vector-field-static",
+      "scene": "ArrowVectorFieldStatic",
+      "source": "parity/manim-v0.21/core-examples/arrow_vector_field.py",
+      "expected_duration": 0.2,
+      "raster_tolerance": {
+        "max_bounds_delta_px": 2,
+        "max_differing_ratio": 0.006,
+        "max_mean_absolute_channel_error": 0.5
+      }
+    },
+    {
       "id": "canonical-curve-layout",
       "scene": "OrdinaryCanonicalCurveLayout",
       "source": "parity/manim-v0.21/core-examples/canonical_curve_layout.py",

--- a/web/python/_manim_arrow.py
+++ b/web/python/_manim_arrow.py
@@ -440,13 +440,11 @@ class ArrowVectorField(_compat.VGroup):
             custom_length,
         )
         try:
-            import numpy as np
-
             sample_count = int(draft.sampleCount)
             for index in range(sample_count):
                 x = float(engine_call(draft.sampleX, index))
                 y = float(engine_call(draft.sampleY, index))
-                raw = _base._as_vec2(func(np.array([x, y, 0.0], dtype=float)))
+                raw = _base._as_vec2(func((x, y, 0.0)))
                 engine_call(draft.setVector, index, raw.x, raw.y)
                 if custom_length:
                     norm = raw.length()

--- a/web/python/_manim_arrow.py
+++ b/web/python/_manim_arrow.py
@@ -1,4 +1,4 @@
-"""Thin Manim-compatible Arrow family facade over shared Rust semantics."""
+"""Thin Manim-compatible Arrow families over shared Rust semantics."""
 
 from __future__ import annotations
 
@@ -219,7 +219,6 @@ class Arrow(_compat.Group):
     def get_end(self) -> _base.Vec2:
         from _manim_path_queries import endpoint
 
-        # Rust builds the tip path with its public apex as the first retained point.
         return endpoint(self.tip, False)
 
     def get_tip(self):
@@ -331,4 +330,167 @@ class DoubleArrow(Arrow):
         _create(self, options, color=color, kwargs=constructor_options)
 
 
-__all__ = ["Arrow", "Vector", "DoubleArrow"]
+_DEFAULT_VECTOR_FIELD_LENGTH = object()
+
+
+def _vector_field_range(name: str, value: object) -> tuple[list[float], list[float]]:
+    if value is None:
+        raise NotImplementedError(
+            f"ArrowVectorField {name}=None requires shared frame-derived default ranges"
+        )
+    try:
+        values = [float(component) for component in value]  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must contain two or three numeric values") from error
+    if len(values) == 2:
+        values.append(0.5)
+    elif len(values) != 3:
+        raise ValueError(f"{name} must contain [min, max] or [min, max, step]")
+    if any(not _base.math.isfinite(component) for component in values):
+        raise ValueError(f"{name} must contain finite values")
+    nominal = values.copy()
+    public = values.copy()
+    public[1] += public[2]
+    return nominal, public
+
+
+def _default_vector_field_length(norm: float) -> float:
+    return 0.45 / (1.0 + _base.math.exp(-float(norm)))
+
+
+def _attach_vector_field_member(created: object, index: int) -> Vector:
+    wrapper = object.__new__(Vector)
+    family = engine_call(created.vectorFamily, index)
+    shaft = _leaf(engine_call(created.vectorShaft, index), _compat.Line)
+    end_tip = _leaf(engine_call(created.vectorEndTip, index))
+    wrapper._semantic_family_handle = family
+    wrapper._shaft = shaft
+    wrapper.tip = end_tip
+    wrapper.start_tip = None
+    wrapper._semantic_member_wrappers = {
+        _shared._family_wrapper_key(member): member for member in (shaft, end_tip)
+    }
+    return wrapper
+
+
+class ArrowVectorField(_compat.VGroup):
+    """Static 2D ArrowVectorField prepared at Rust-owned Manim sample points."""
+
+    def __init__(
+        self,
+        func,
+        color=None,
+        color_scheme=None,
+        min_color_scheme_value: float = 0,
+        max_color_scheme_value: float = 2,
+        colors=None,
+        *,
+        x_range=None,
+        y_range=None,
+        z_range=None,
+        three_dimensions: bool = False,
+        length_func=_DEFAULT_VECTOR_FIELD_LENGTH,
+        opacity: float = 1.0,
+        vector_config=None,
+        **kwargs: Any,
+    ) -> None:
+        if _arrow_options is None or _create_arrow_handle is None:
+            raise RuntimeError("ArrowVectorField construction requires the shared Rust authoring host")
+        if _shared._live_constructor_context("ArrowVectorField") is not None:
+            raise NotImplementedError(
+                "live ArrowVectorField construction requires shared retained-family publication support"
+            )
+        if not callable(func):
+            raise TypeError("ArrowVectorField func must be callable")
+        if color is not None:
+            raise NotImplementedError("ArrowVectorField single-color mode is not part of this B5 slice")
+        if color_scheme is not None:
+            raise NotImplementedError("custom ArrowVectorField color_scheme is not part of this B5 slice")
+        if float(min_color_scheme_value) != 0.0 or float(max_color_scheme_value) != 2.0:
+            raise NotImplementedError("custom ArrowVectorField color-scheme bounds are not part of this B5 slice")
+        if colors is not None:
+            raise NotImplementedError("custom ArrowVectorField color lists are not part of this B5 slice")
+        if z_range is not None or three_dimensions:
+            raise NotImplementedError("3D ArrowVectorField requires the Phase B6/C 3D field contract")
+        opacity_value = _ir._finite_number("opacity", opacity)
+        if opacity_value != 1.0:
+            raise NotImplementedError("ArrowVectorField opacity other than 1.0 is not part of this B5 slice")
+        if vector_config not in (None, {}):
+            raise NotImplementedError("ArrowVectorField vector_config is not part of this B5 slice")
+        if kwargs:
+            raise TypeError(
+                "unsupported ArrowVectorField constructor option(s): "
+                + ", ".join(sorted(kwargs))
+            )
+
+        x_nominal, x_public = _vector_field_range("x_range", x_range)
+        y_nominal, y_public = _vector_field_range("y_range", y_range)
+        custom_length = length_func is not _DEFAULT_VECTOR_FIELD_LENGTH
+        if custom_length and not callable(length_func):
+            raise TypeError("ArrowVectorField length_func must be callable")
+
+        draft = engine_call(
+            _arrow_options.vectorField,
+            x_nominal[0],
+            x_nominal[1],
+            x_nominal[2],
+            y_nominal[0],
+            y_nominal[1],
+            y_nominal[2],
+            custom_length,
+        )
+        try:
+            import numpy as np
+
+            sample_count = int(draft.sampleCount)
+            for index in range(sample_count):
+                x = float(engine_call(draft.sampleX, index))
+                y = float(engine_call(draft.sampleY, index))
+                raw = _base._as_vec2(func(np.array([x, y, 0.0], dtype=float)))
+                engine_call(draft.setVector, index, raw.x, raw.y)
+                if custom_length:
+                    norm = raw.length()
+                    if norm != 0.0:
+                        display_length = _ir._finite_number(
+                            "length_func result", length_func(norm)
+                        )
+                        engine_call(draft.setDisplayLength, index, display_length)
+
+            created = engine_call(_create_arrow_handle, draft)
+        finally:
+            release = getattr(draft, "free", None)
+            if release is not None:
+                try:
+                    engine_call(release)
+                except Exception:
+                    pass
+
+        try:
+            self._semantic_family_handle = engine_call(created.family)
+            vector_count = int(created.vectorCount)
+            vectors = [
+                _attach_vector_field_member(created, index)
+                for index in range(vector_count)
+            ]
+            self._semantic_member_wrappers = {
+                _shared._family_wrapper_key(member): member for member in vectors
+            }
+        finally:
+            release = getattr(created, "free", None)
+            if release is not None:
+                engine_call(release)
+
+        self.func = func
+        self.x_range = x_public
+        self.y_range = y_public
+        self.z_range = [0.0, 0.5, 0.5]
+        self.ranges = [self.x_range, self.y_range, self.z_range]
+        self.length_func = (
+            length_func if custom_length else _default_vector_field_length
+        )
+        self.opacity = opacity_value
+        self.vector_config = {}
+        self.single_color = False
+
+
+__all__ = ["Arrow", "Vector", "DoubleArrow", "ArrowVectorField"]

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -82,7 +82,7 @@ class Vec2(tuple):
         divisor = float(scalar)
         if divisor == 0.0:
             raise ZeroDivisionError("cannot divide Vec2 by zero")
-        return self / divisor
+        return Vec2(self.x / divisor, self.y / divisor)
 
     def length(self) -> float:
         return math.hypot(self.x, self.y)
@@ -178,7 +178,7 @@ def color_from_hex(value: str | int) -> Color:
     return _hex_color(value)
 
 
-# Manim Community default palette. Base names alias their C shade.
+# Manim Community default palette. Base names alias the C shade.
 WHITE = _hex_color(0xFFFFFF)
 BLACK = _hex_color(0x000000)
 BLUE_A = _hex_color(0xC7E9F1)
@@ -353,7 +353,7 @@ class Mobject:
 
     def match_dim_size(self, mobject: Mobject, dim: int, **kwargs: Any) -> Mobject:
         from _manim_semantic_handles import _match_dim_size
-        return _match_dim_size(self, mobject, dim, **kwargs)
+        return _match_dim_size(self, mobject, dim, stretch=False, **kwargs) if False else _match_dim_size(self, mobject, dim, **kwargs)
 
     def generate_target(self, use_deepcopy: bool = False) -> Mobject:
         from _manim_compat import _mobject_generate_target
@@ -562,7 +562,10 @@ class Scene:
     """Python authoring facade; semantic operations require the shared Rust host."""
 
     def __init__(self) -> None:
+        # Derived wrapper/export identities only. These rows never carry scene
+        # content, painter order, animation tracks, or runtime state.
         self._owner = object()
+        # Derived host binding IDs map to the authoritative Rust handles.
         self._binding_handles: dict[int, object] = {}
         self._object_keys: dict[int, str] = {}
         self._object_key_ids: dict[str, int] = {}
@@ -591,6 +594,8 @@ class Scene:
         if not mobjects:
             return self
         self._edit_membership("add", mobjects, key=key)
+
+        # Python returns the wrapper for a single leaf, or the Scene for a batch.
         from _manim_compat import _leaf_mobjects
         leaves = [member for value in mobjects for member in _leaf_mobjects(value)]
         return leaves[0] if len(leaves) == 1 else self
@@ -706,6 +711,7 @@ class Scene:
 
 Object = Mobject
 
+# Public wrappers resolve from their defining modules without startup mutation.
 _PUBLIC_EXPORTS = {
     "Transform": "_manim_animate",
     "ReplacementTransform": "_manim_animate",

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -353,7 +353,7 @@ class Mobject:
 
     def match_dim_size(self, mobject: Mobject, dim: int, **kwargs: Any) -> Mobject:
         from _manim_semantic_handles import _match_dim_size
-        return _match_dim_size(self, mobject, dim, stretch=False, **kwargs) if False else _match_dim_size(self, mobject, dim, **kwargs)
+        return _match_dim_size(self, mobject, dim, **kwargs)
 
     def generate_target(self, use_deepcopy: bool = False) -> Mobject:
         from _manim_compat import _mobject_generate_target

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -82,7 +82,7 @@ class Vec2(tuple):
         divisor = float(scalar)
         if divisor == 0.0:
             raise ZeroDivisionError("cannot divide Vec2 by zero")
-        return Vec2(self.x / divisor, self.y / divisor)
+        return self / divisor
 
     def length(self) -> float:
         return math.hypot(self.x, self.y)
@@ -178,7 +178,7 @@ def color_from_hex(value: str | int) -> Color:
     return _hex_color(value)
 
 
-# Manim Community default palette. Base names alias the C shade.
+# Manim Community default palette. Base names alias their C shade.
 WHITE = _hex_color(0xFFFFFF)
 BLACK = _hex_color(0x000000)
 BLUE_A = _hex_color(0xC7E9F1)
@@ -562,10 +562,7 @@ class Scene:
     """Python authoring facade; semantic operations require the shared Rust host."""
 
     def __init__(self) -> None:
-        # Derived wrapper/export identities only. These rows never carry scene
-        # content, painter order, animation tracks, or runtime state.
         self._owner = object()
-        # Derived host binding IDs map to the authoritative Rust handles.
         self._binding_handles: dict[int, object] = {}
         self._object_keys: dict[int, str] = {}
         self._object_key_ids: dict[str, int] = {}
@@ -594,8 +591,6 @@ class Scene:
         if not mobjects:
             return self
         self._edit_membership("add", mobjects, key=key)
-
-        # Python returns the wrapper for a single leaf, or the Scene for a batch.
         from _manim_compat import _leaf_mobjects
         leaves = [member for value in mobjects for member in _leaf_mobjects(value)]
         return leaves[0] if len(leaves) == 1 else self
@@ -711,7 +706,6 @@ class Scene:
 
 Object = Mobject
 
-# Public wrappers resolve from their defining modules without startup mutation.
 _PUBLIC_EXPORTS = {
     "Transform": "_manim_animate",
     "ReplacementTransform": "_manim_animate",
@@ -770,6 +764,7 @@ _PUBLIC_EXPORTS = {
     "Arrow": "_manim_arrow",
     "Vector": "_manim_arrow",
     "DoubleArrow": "_manim_arrow",
+    "ArrowVectorField": "_manim_arrow",
     "Elbow": "_manim_shared_geometry",
     "RoundedRectangle": "_manim_shared_geometry",
     "SurroundingRectangle": "_manim_shared_geometry",


### PR DESCRIPTION
Advances #88 under #85/#954 and supplies the required #185 source-equivalent parity evidence for the merged #1433/#1437 static ArrowVectorField foundation.

This slice adds a thin preparation-time Web/Python `ArrowVectorField` facade without introducing a Python-owned sampling model. The existing `WasmManimArrowOptions` bridge can carry either one Arrow request or one static vector-field draft. Rust computes the exact Manim-compatible sample grid; Python evaluates the user `func` (and optional `length_func`) only at those Rust-provided points; Rust then validates, plans, colors, and atomically publishes ordinary nested Vector families through the existing shared authoring path. No callback survives construction and there is no runtime/renderer vector-field authority.

The Python surface covers the bounded static subset: explicit 2D `x_range`/`y_range`, pinned default norm color scheme, default or custom `length_func`, opacity 1, and default `vector_config`. Frame-derived default ranges, single/custom colors, custom color schemes, 3D fields, non-default opacity/vector config, live construction, and StreamLines remain explicitly unsupported rather than approximated.

`noon.py` differs from the merged base by exactly one lazy-export line. Existing Arrow/Vector/DoubleArrow use the same bridge and retain their existing semantics.

The canonical #176/#185 corpus now contains `ArrowVectorFieldStatic`, using the same source with only the standard `from manim import *` -> `from noon import *` adaptation. It exercises a 5×3 explicit grid, rotational vector function, zero-vector center, pinned default displayed-length behavior, and default norm color mapping. The manifest addition is exactly one fixture entry (+11 lines, no deletions) and initially uses the existing Arrow-family raster threshold rather than output-specific tuning.

Capability-table promotion remains out of scope for this PR. The slice is complete only when the exact-head normal gates and the pinned ManimCE v0.21 semantic/raster differential are green.

Branch base: post-#1437 master `7774295703bb0d1e592b2161a4ff63c7ae67d316`; recheck current master before merge.