### PR TITLE
Add shared Arrow geometry queries

### DIFF
--- a/crates/noon-web/src/authoring_arrow.rs
+++ b/crates/noon-web/src/authoring_arrow.rs
@@ -196,12 +196,18 @@ impl WasmAuthoringArrowHandle {
 
     #[wasm_bindgen(js_name = vectorX)]
     pub fn vector_x(&self) -> Result<f64, JsValue> {
-        self.arrow.manim_vector().map(|vector| vector.0).map_err(js_error)
+        self.arrow
+            .manim_vector()
+            .map(|vector| vector.0)
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = vectorY)]
     pub fn vector_y(&self) -> Result<f64, JsValue> {
-        self.arrow.manim_vector().map(|vector| vector.1).map_err(js_error)
+        self.arrow
+            .manim_vector()
+            .map(|vector| vector.1)
+            .map_err(js_error)
     }
 
     pub fn length(&self) -> Result<f64, JsValue> {

--- a/crates/noon-web/src/authoring_arrow.rs
+++ b/crates/noon-web/src/authoring_arrow.rs
@@ -161,6 +161,72 @@ impl WasmAuthoringArrowHandle {
             .map(WasmAuthoringMobjectHandle::from_semantic_mobject)
             .ok_or_else(|| JsValue::from_str("Arrow has no start tip"))
     }
+
+    #[wasm_bindgen(js_name = startX)]
+    pub fn start_x(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_endpoints()
+            .map(|endpoints| endpoints.start.0)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = startY)]
+    pub fn start_y(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_endpoints()
+            .map(|endpoints| endpoints.start.1)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = endX)]
+    pub fn end_x(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_endpoints()
+            .map(|endpoints| endpoints.end.0)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = endY)]
+    pub fn end_y(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_endpoints()
+            .map(|endpoints| endpoints.end.1)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = vectorX)]
+    pub fn vector_x(&self) -> Result<f64, JsValue> {
+        self.arrow.manim_vector().map(|vector| vector.0).map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = vectorY)]
+    pub fn vector_y(&self) -> Result<f64, JsValue> {
+        self.arrow.manim_vector().map(|vector| vector.1).map_err(js_error)
+    }
+
+    pub fn length(&self) -> Result<f64, JsValue> {
+        self.arrow.manim_length().map_err(js_error)
+    }
+
+    pub fn angle(&self) -> Result<f64, JsValue> {
+        self.arrow.manim_angle().map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = unitVectorX)]
+    pub fn unit_vector_x(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_unit_vector()
+            .map(|vector| vector.0)
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = unitVectorY)]
+    pub fn unit_vector_y(&self) -> Result<f64, JsValue> {
+        self.arrow
+            .manim_unit_vector()
+            .map(|vector| vector.1)
+            .map_err(js_error)
+    }
 }
 
 #[wasm_bindgen]

--- a/crates/noon/src/arrow_queries.rs
+++ b/crates/noon/src/arrow_queries.rs
@@ -96,7 +96,10 @@ mod tests {
         arrow.family().scale(2.0, 2.0).unwrap();
         arrow
             .family()
-            .rotate(std::f64::consts::FRAC_PI_2, crate::ManimRotationPivot::Center)
+            .rotate(
+                std::f64::consts::FRAC_PI_2,
+                crate::ManimRotationPivot::Center,
+            )
             .unwrap();
 
         assert!((arrow.manim_length().unwrap() - before * 2.0).abs() < 2.0e-6);

--- a/crates/noon/src/arrow_queries.rs
+++ b/crates/noon/src/arrow_queries.rs
@@ -1,0 +1,118 @@
+//! Shared Manim-compatible Arrow observations over retained semantic components.
+//!
+//! These queries deliberately read the authoritative Arrow leaves rather than
+//! reconstructing geometry in a frontend. They therefore remain correct after
+//! ordinary shared family translation/rotation/scale operations and provide the
+//! observation seam needed by later Arrow-specific dependent mutations.
+
+use crate::{AuthoringError, ManimArrow, ManimLineEndpoints};
+
+impl ManimArrow {
+    /// Public Arrow endpoints in world space, including retained tips.
+    pub fn manim_endpoints(&self) -> Result<ManimLineEndpoints, AuthoringError> {
+        let start = match self.start_tip() {
+            Some(tip) => tip.manim_line_endpoints()?.start,
+            None => self.shaft().manim_line_endpoints()?.start,
+        };
+        // Arrow tip paths retain their public apex as the first path point.
+        let end = self.end_tip().manim_line_endpoints()?.start;
+        Ok(ManimLineEndpoints { start, end })
+    }
+
+    /// Equivalent to ManimCE `Line.get_vector()` projected into Noon's 2D scene.
+    pub fn manim_vector(&self) -> Result<(f64, f64), AuthoringError> {
+        let endpoints = self.manim_endpoints()?;
+        Ok((
+            endpoints.end.0 - endpoints.start.0,
+            endpoints.end.1 - endpoints.start.1,
+        ))
+    }
+
+    /// Equivalent to ManimCE `Line.get_length()` for the retained Arrow family.
+    pub fn manim_length(&self) -> Result<f64, AuthoringError> {
+        let (x, y) = self.manim_vector()?;
+        Ok(x.hypot(y))
+    }
+
+    /// Equivalent to ManimCE `Line.get_unit_vector()`; a degenerate Arrow
+    /// returns the zero vector, matching Manim's `normalize` fallback.
+    pub fn manim_unit_vector(&self) -> Result<(f64, f64), AuthoringError> {
+        let (x, y) = self.manim_vector()?;
+        let length = x.hypot(y);
+        if length == 0.0 {
+            Ok((0.0, 0.0))
+        } else {
+            Ok((x / length, y / length))
+        }
+    }
+
+    /// Equivalent to ManimCE `Line.get_angle()` in the XY plane.
+    pub fn manim_angle(&self) -> Result<f64, AuthoringError> {
+        let (x, y) = self.manim_vector()?;
+        Ok(y.atan2(x))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ManimArrowOptions, Scene};
+    use std::rc::Rc;
+
+    fn arrow(scene: &Scene) -> ManimArrow {
+        let mut options = ManimArrowOptions::arrow(-2.0, -1.0, 2.0, 1.0).unwrap();
+        options.set_buff(0.25).unwrap();
+        ManimArrow::create(Rc::clone(scene.integration_store()), options).unwrap()
+    }
+
+    #[test]
+    fn shared_queries_observe_public_tip_endpoints() {
+        let scene = Scene::new();
+        let arrow = arrow(&scene);
+        let endpoints = arrow.manim_endpoints().unwrap();
+        let dx = 4.0_f64;
+        let dy = 2.0_f64;
+        let raw_length = dx.hypot(dy);
+        let expected_length = raw_length - 0.5;
+        let direction = (dx / raw_length, dy / raw_length);
+
+        assert!((endpoints.start.0 - (-2.0 + direction.0 * 0.25)).abs() < 1.0e-6);
+        assert!((endpoints.start.1 - (-1.0 + direction.1 * 0.25)).abs() < 1.0e-6);
+        assert!((endpoints.end.0 - (2.0 - direction.0 * 0.25)).abs() < 1.0e-6);
+        assert!((endpoints.end.1 - (1.0 - direction.1 * 0.25)).abs() < 1.0e-6);
+        assert!((arrow.manim_length().unwrap() - expected_length).abs() < 1.0e-6);
+        assert!((arrow.manim_angle().unwrap() - dy.atan2(dx)).abs() < 1.0e-6);
+        let unit = arrow.manim_unit_vector().unwrap();
+        assert!((unit.0 - direction.0).abs() < 1.0e-6);
+        assert!((unit.1 - direction.1).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn queries_follow_shared_family_affine_edits_without_frontend_reconstruction() {
+        let scene = Scene::new();
+        let arrow = arrow(&scene);
+        let before = arrow.manim_length().unwrap();
+
+        arrow.family().scale(2.0, 2.0).unwrap();
+        arrow
+            .family()
+            .rotate(std::f64::consts::FRAC_PI_2, crate::ManimRotationPivot::Center)
+            .unwrap();
+
+        assert!((arrow.manim_length().unwrap() - before * 2.0).abs() < 2.0e-6);
+        let expected_angle = 2.0_f64.atan2(4.0) + std::f64::consts::FRAC_PI_2;
+        assert!((arrow.manim_angle().unwrap() - expected_angle).abs() < 2.0e-6);
+    }
+
+    #[test]
+    fn degenerate_arrow_unit_vector_matches_manim_zero_fallback() {
+        let scene = Scene::new();
+        let mut options = ManimArrowOptions::arrow(1.0, 2.0, 1.0, 2.0).unwrap();
+        options.set_buff(0.0).unwrap();
+        let arrow = ManimArrow::create(Rc::clone(scene.integration_store()), options).unwrap();
+
+        assert_eq!(arrow.manim_unit_vector().unwrap(), (0.0, 0.0));
+        assert_eq!(arrow.manim_angle().unwrap(), 0.0);
+        assert_eq!(arrow.manim_length().unwrap(), 0.0);
+    }
+}

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -53,6 +53,7 @@
 mod animation_authoring;
 mod arc_authoring;
 mod arrow_authoring;
+mod arrow_queries;
 mod authoring_error;
 mod boolean_authoring;
 mod camera_authoring;

--- a/web/python/_manim_arrow.py
+++ b/web/python/_manim_arrow.py
@@ -90,6 +90,10 @@ def _attach_arrow_family(self: "Arrow", created: object) -> None:
     end_tip = _leaf(engine_call(created.endTip))
     start_tip = _leaf(engine_call(created.startTip)) if bool(created.hasStartTip) else None
 
+    # Retain the aggregate Rust handle as the query authority. It owns no parallel
+    # Python semantic state: its observations are resolved from the same retained
+    # shaft/tip leaves exposed below.
+    self._semantic_arrow_handle = created
     self._semantic_family_handle = family
     self._shaft = shaft
     self.tip = end_tip
@@ -120,12 +124,15 @@ def _create(
     if color is not None:
         _shared._apply_constructor_color(options, _compat._as_color("color", color))
     created = engine_call(_create_arrow_handle, options)
-    try:
-        _attach_arrow_family(self, created)
-    finally:
-        release = getattr(created, "free", None)
-        if release is not None:
-            engine_call(release)
+    _attach_arrow_family(self, created)
+
+
+def _arrow_scalar(self: "Arrow", method: str) -> float:
+    handle = getattr(self, "_semantic_arrow_handle", None)
+    operation = getattr(handle, method, None) if handle is not None else None
+    if operation is None:
+        raise RuntimeError("Arrow observation requires the shared Rust authoring host")
+    return float(engine_call(operation, operation=f"Arrow.{method}"))
 
 
 def _validate_straight_arrow_options(
@@ -212,15 +219,34 @@ class Arrow(_compat.Group):
         )
 
     def get_start(self) -> _base.Vec2:
-        from _manim_path_queries import endpoint
-
-        return endpoint(self.start_tip if self.start_tip is not None else self._shaft, False)
+        return _base.Vec2(
+            _arrow_scalar(self, "startX"),
+            _arrow_scalar(self, "startY"),
+        )
 
     def get_end(self) -> _base.Vec2:
-        from _manim_path_queries import endpoint
+        return _base.Vec2(
+            _arrow_scalar(self, "endX"),
+            _arrow_scalar(self, "endY"),
+        )
 
-        # Rust builds the tip path with its public apex as the first retained point.
-        return endpoint(self.tip, False)
+    def get_vector(self) -> _base.Vec2:
+        return _base.Vec2(
+            _arrow_scalar(self, "vectorX"),
+            _arrow_scalar(self, "vectorY"),
+        )
+
+    def get_length(self) -> float:
+        return _arrow_scalar(self, "length")
+
+    def get_unit_vector(self) -> _base.Vec2:
+        return _base.Vec2(
+            _arrow_scalar(self, "unitVectorX"),
+            _arrow_scalar(self, "unitVectorY"),
+        )
+
+    def get_angle(self) -> float:
+        return _arrow_scalar(self, "angle")
 
     def get_tip(self):
         return self.tip

--- a/web/python/test_manim_arrow.py
+++ b/web/python/test_manim_arrow.py
@@ -58,6 +58,16 @@ class ManimArrowFacadeTests(unittest.TestCase):
                 def shaft(self): return self._shaft
                 def startTip(self): return self._start
                 def endTip(self): return self._end
+                def startX(self): calls.append(("query", "startX")); return -1.5
+                def startY(self): calls.append(("query", "startY")); return 0.5
+                def endX(self): calls.append(("query", "endX")); return 3.5
+                def endY(self): calls.append(("query", "endY")); return -2.5
+                def vectorX(self): calls.append(("query", "vectorX")); return 5.0
+                def vectorY(self): calls.append(("query", "vectorY")); return -3.0
+                def length(self): calls.append(("query", "length")); return 5.830951894845301
+                def unitVectorX(self): calls.append(("query", "unitVectorX")); return 0.8574929257125441
+                def unitVectorY(self): calls.append(("query", "unitVectorY")); return -0.5144957554275265
+                def angle(self): calls.append(("query", "angle")); return -0.5404195002705842
 
             class FakeOptions:
                 def __init__(self, kind, start, end):
@@ -122,13 +132,6 @@ class ManimArrowFacadeTests(unittest.TestCase):
             import _manim_arrow as arrows
             import noon
 
-            # Endpoint queries remain delegated to the established shared path-query module;
-            # replace only that projection in this native facade test.
-            import _manim_path_queries
-            _manim_path_queries.endpoint = lambda value, end: noon.Vec2(
-                float(value._semantic_handle.semanticSlot), 1.0 if end else 0.0
-            )
-
             arrow = arrows.Arrow(
                 (-2.0, 1.0),
                 (4.0, -3.0),
@@ -166,7 +169,27 @@ class ManimArrowFacadeTests(unittest.TestCase):
             assert double.has_start_tip()
             assert arrow.get_tip() is arrow.tip
             assert double.get_start_tip() is double.start_tip
-            assert arrow.get_end() == noon.Vec2(3.0, 0.0)
+
+            # Endpoint/vector/length/angle observations are also owned by the retained
+            # aggregate Rust handle, not recomputed from Python leaf geometry.
+            assert arrow.get_start() == noon.Vec2(-1.5, 0.5)
+            assert arrow.get_end() == noon.Vec2(3.5, -2.5)
+            assert arrow.get_vector() == noon.Vec2(5.0, -3.0)
+            assert abs(arrow.get_length() - 5.830951894845301) < 1e-12
+            assert arrow.get_unit_vector() == noon.Vec2(0.8574929257125441, -0.5144957554275265)
+            assert abs(arrow.get_angle() + 0.5404195002705842) < 1e-12
+            assert [call for call in calls if call[0] == "query"] == [
+                ("query", "startX"),
+                ("query", "startY"),
+                ("query", "endX"),
+                ("query", "endY"),
+                ("query", "vectorX"),
+                ("query", "vectorY"),
+                ("query", "length"),
+                ("query", "unitVectorX"),
+                ("query", "unitVectorY"),
+                ("query", "angle"),
+            ]
 
             # Unsupported ManimCE semantic breadth rejects rather than being approximated.
             before = list(calls)


### PR DESCRIPTION
## Summary

First bounded continuation of #77 after #1411, based on current master `7774295703bb0d1e592b2161a4ff63c7ae67d316`.

- adds Rust-owned Arrow endpoint/vector/length/unit-vector/angle observations over the retained shaft/tip semantic leaves;
- keeps the observation authoritative after ordinary shared family affine edits instead of reconstructing Arrow geometry in a frontend;
- exposes the same query seam through the existing WASM Arrow handle;
- keeps the aggregate shared Arrow handle in the thin Python facade and delegates `get_start`, `get_end`, `get_vector`, `get_length`, `get_unit_vector`, and `get_angle` to Rust;
- adds Rust tests for public tip endpoints, affine updates, and degenerate-vector behavior plus a native Python facade test proving those observations cross the shared handle rather than being recomputed in Python.

## Architecture note

I traced `Arrow.scale(factor, scale_tips=False)` against pinned ManimCE v0.21 before implementing it. Tip size is recoverable from retained tip geometry, but correct stroke recapping after a short-arrow shrink/grow requires Manim's original `initial_stroke_width`, which #1411 intentionally does not retain in current semantic state. I am not adding Python/wrapper-owned parallel state to fake this. The next mutation slice needs that dependency metadata represented in the shared semantic authority first.

## Scope still open

This PR does **not** claim the remaining #77 dependent-mutation breadth: Mobject-boundary endpoint construction, live Arrow construction, Arrow-specific scale semantics, curved `path_arc`, custom tips, or dashed/tangent objects.

Refs #77.