### PR TITLE
Promote qualified static ArrowVectorField subset

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -81,7 +81,7 @@
     "Graph": {"status": "blocked", "category": "graph-network", "dependency": "#87"},
     "DiGraph": {"status": "blocked", "category": "graph-network", "dependency": "#87"},
     "VectorField": {"status": "blocked", "category": "visualization", "dependency": "#88"},
-    "ArrowVectorField": {"status": "blocked", "category": "visualization", "dependency": "#88"},
+    "ArrowVectorField": {"status": "partial", "category": "visualization", "dependency": "#88", "evidence": "parity/manim-v0.21/core-examples/arrow_vector_field.py; canonical arrow-vector-field-static semantic/raster differential", "reason": "Static preparation-time fields with explicit 2D x/y ranges, default norm colors, and default or custom length_func use shared Rust sampling/publication and are parity-qualified. Frame-derived default ranges, custom colors/color schemes, 3D, non-default opacity/vector_config, live construction, and StreamLines remain pending."},
     "StreamLines": {"status": "blocked", "category": "visualization", "dependency": "#88"},
     "BarChart": {"status": "blocked", "category": "visualization", "dependency": "#88/#85"},
     "SampleSpace": {"status": "blocked", "category": "visualization", "dependency": "#88"},

--- a/web/manim-compatibility-gallery.test.mjs
+++ b/web/manim-compatibility-gallery.test.mjs
@@ -13,7 +13,7 @@ const readyEntries = manifest.entries.filter((entry) => entry.status === "ready"
 const gallery = normalizeGalleryManifest(manifest);
 
 assert.equal(manifest.reference.version, "0.21.0");
-assert.equal(gallery.examples.length, 12);
+assert.equal(gallery.examples.length, 13);
 assert.deepEqual(
   gallery.examples.map((entry) => entry.id),
   [
@@ -29,6 +29,7 @@ assert.deepEqual(
     "compatible-text-family-fade",
     "compatible-text-family-reveal",
     "compatible-group-slicing",
+    "compatible-arrow-vector-field-static",
   ],
 );
 
@@ -123,6 +124,28 @@ assert.equal(
   slicingSource.replace("from noon import *", "from manim import *"),
   slicingCanonical,
   "group slicing gallery source must stay import-only equivalent to its canonical Manim fixture",
+);
+
+const vectorFieldEntry = readyEntries.find(
+  (entry) => entry.id === "compatible-arrow-vector-field-static",
+);
+assert.ok(vectorFieldEntry, "static ArrowVectorField must be a ready compatibility example");
+assert.equal(vectorFieldEntry.parity_status, "parity-qualified");
+assert.equal(vectorFieldEntry.parity_fixture, "arrow-vector-field-static");
+assert.ok(vectorFieldEntry.features.includes("pixel-parity"));
+assert.ok(vectorFieldEntry.features.includes("time-parity"));
+const vectorFieldSource = await readFile(
+  new URL(`./${vectorFieldEntry.path}`, import.meta.url),
+  "utf8",
+);
+const vectorFieldCanonical = await readFile(
+  new URL("../parity/manim-v0.21/core-examples/arrow_vector_field.py", import.meta.url),
+  "utf8",
+);
+assert.equal(
+  vectorFieldSource.replace("from noon import *", "from manim import *"),
+  vectorFieldCanonical,
+  "ArrowVectorField gallery source must stay import-only equivalent to its qualified canonical fixture",
 );
 
 console.log("✓ Noon-authored Manim-compatible gallery examples");

--- a/web/python/examples/manim_compatibility_manifest.json
+++ b/web/python/examples/manim_compatibility_manifest.json
@@ -186,6 +186,22 @@
     "thumbnail_alt": "Square below a circle and rectangle shifted upward through a VGroup slice",
     "thumbnail_time": 1.0,
     "order": 1120
-  }
+  },
+    {
+      "id": "compatible-arrow-vector-field-static",
+      "title": "ArrowVectorFieldStatic",
+      "summary": "Static rotational ArrowVectorField with explicit 2D ranges and Manim-compatible default length and norm-color behavior.",
+      "status": "ready",
+      "path": "python/examples/manim_compatible_arrow_vector_field.py",
+      "category": "manim-compatible/visualization",
+      "features": ["ArrowVectorField", "explicit 2D ranges", "static field", "default length", "default norm colors", "pixel-parity", "time-parity", "Manim-compatible"],
+      "reuse": "manim-compatible-parity-v0.21",
+      "parity_status": "parity-qualified",
+      "parity_fixture": "arrow-vector-field-static",
+      "thumbnail": "thumbnails/manim/compatible-arrow-vector-field-static.svg",
+      "thumbnail_alt": "Five by three rotational vector field with a zero vector at the center",
+      "thumbnail_time": 0.2,
+      "order": 1130
+    }
   ]
 }

--- a/web/python/examples/manim_compatible_arrow_vector_field.py
+++ b/web/python/examples/manim_compatible_arrow_vector_field.py
@@ -1,0 +1,12 @@
+from noon import *
+
+
+class ArrowVectorFieldStatic(Scene):
+    def construct(self):
+        field = ArrowVectorField(
+            lambda point: point[0] * UP - point[1] * RIGHT,
+            x_range=[-2.0, 2.0, 1.0],
+            y_range=[-1.0, 1.0, 1.0],
+        )
+        self.add(field)
+        self.wait(0.2)

--- a/web/thumbnails/manim/compatible-arrow-vector-field-static.svg
+++ b/web/thumbnails/manim/compatible-arrow-vector-field-static.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Static ArrowVectorField</title>
+  <desc id="desc">A five by three rotational vector field with arrows tangent to circles around an empty zero-vector center.</desc>
+  <defs>
+    <marker id="tip-green" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto" markerUnits="strokeWidth"><path d="M0 0 L8 4 L0 8 Z" fill="#83c167"/></marker>
+    <marker id="tip-yellow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto" markerUnits="strokeWidth"><path d="M0 0 L8 4 L0 8 Z" fill="#ffff00"/></marker>
+    <marker id="tip-red" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto" markerUnits="strokeWidth"><path d="M0 0 L8 4 L0 8 Z" fill="#fc6255"/></marker>
+  </defs>
+  <rect width="640" height="360" fill="#10141d"/>
+  <g fill="none" stroke-linecap="round" stroke-width="5">
+    <path d="M150 222 L169 259" stroke="#fc6255" marker-end="url(#tip-red)"/>
+    <path d="M232 233 L257 257" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+    <path d="M314 252 L338 252" stroke="#83c167" marker-end="url(#tip-green)"/>
+    <path d="M397 257 L422 233" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+    <path d="M471 259 L490 222" stroke="#fc6255" marker-end="url(#tip-red)"/>
+
+    <path d="M160 180 L160 221" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+    <path d="M240 180 L240 214" stroke="#83c167" marker-end="url(#tip-green)"/>
+    <path d="M400 180 L400 146" stroke="#83c167" marker-end="url(#tip-green)"/>
+    <path d="M480 180 L480 139" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+
+    <path d="M169 101 L150 138" stroke="#fc6255" marker-end="url(#tip-red)"/>
+    <path d="M257 103 L232 127" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+    <path d="M338 108 L314 108" stroke="#83c167" marker-end="url(#tip-green)"/>
+    <path d="M422 127 L397 103" stroke="#ffff00" marker-end="url(#tip-yellow)"/>
+    <path d="M490 138 L471 101" stroke="#fc6255" marker-end="url(#tip-red)"/>
+  </g>
+</svg>


### PR DESCRIPTION
Advances #88 under #954 by promoting only the ArrowVectorField subset already implemented and exact-output-qualified by #1433, #1437, and #1454.

### Scope
- classify `ArrowVectorField` as `partial` in the ManimCE v0.21 compatibility table, with the supported boundary stated explicitly;
- keep `VectorField` and `StreamLines` blocked;
- add a selectable compatibility-gallery example that is source-equivalent to the canonical `arrow-vector-field-static` parity fixture except for `from noon import *`;
- attach the gallery entry to that existing parity-qualified fixture and add a scene-specific static poster.

### Qualified subset
- preparation-time/static field construction;
- explicit 2D `x_range` and `y_range`;
- default norm-color behavior;
- default or custom `length_func`;
- shared Rust sampling/publication and ordinary nested Vector families.

### Explicitly not promoted
Frame-derived default ranges, custom/single colors or color schemes, 3D, non-default opacity/vector_config, live/dynamic field construction, and StreamLines remain pending under #88.

### Architecture / locality
This is promotion/evidence only. It adds no semantic authority, identity space, runtime, renderer behavior, serialization seam, or callback lifetime. The gallery example exercises the already-landed shared Rust authoring path; no Python callback survives construction. Runtime/locality characteristics are unchanged.

### Validation
The canonical `arrow-vector-field-static` semantic + WebGPU/WebGL raster differential already qualified on the merged implementation. This PR should additionally pass the normal exact-head repository/browser/gallery/compatibility gates before merge.

No automated/Codex review is requested or relied upon, per `AGENTS.override.md`.