### PR TITLE
Upgrade Rust toolchain to 1.98.1

### DIFF
--- a/.github/actions/dev-wasm-build/action.yml
+++ b/.github/actions/dev-wasm-build/action.yml
@@ -29,6 +29,7 @@ runs:
       shell: bash
       run: |
         node .github/ci/wasm-build.mjs measure toolchain bash -euo pipefail -c '
+          rustup install
           rustup show active-toolchain
           rustup target add wasm32-unknown-unknown
         '

--- a/.github/workflows/authoring-wasm-footprint.yml
+++ b/.github/workflows/authoring-wasm-footprint.yml
@@ -27,9 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust and WASM target
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
 
       - name: Cache Cargo sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
-          rustup component add rustfmt clippy
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           path: |
             web/pkg
             web/python-worker.js
+            web/runtime-build-identity.json
             web/python/compat-bundle.*.json
             web/ci-artifact.json
             web/ci-Cargo.lock

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -61,9 +61,11 @@ jobs:
             pkg-config
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/native-host-smoke.yml
+++ b/.github/workflows/native-host-smoke.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Install virtual display and software Vulkan
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,9 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
 
       - name: Cache Cargo sources

--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -58,8 +58,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Cache Cargo sources
         uses: actions/cache@v6
         with:
@@ -81,8 +84,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Cache Cargo sources
         uses: actions/cache@v6
         with:
@@ -109,9 +115,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust and WASM target
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -46,9 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -56,9 +56,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-lifecycle-recovery.yml
+++ b/.github/workflows/playground-lifecycle-recovery.yml
@@ -32,9 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-playback-controls.yml
+++ b/.github/workflows/playground-playback-controls.yml
@@ -33,9 +33,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -77,6 +77,7 @@ jobs:
           for noon_checkout in baseline candidate; do
             (
               cd "$noon_checkout"
+              rustup install
               rustup show active-toolchain
               rustup target add wasm32-unknown-unknown
             )

--- a/.github/workflows/playground-resize-recovery.yml
+++ b/.github/workflows/playground-resize-recovery.yml
@@ -32,9 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
-          rustup component add rustfmt clippy
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6
@@ -62,8 +63,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/provider-features.yml
+++ b/.github/workflows/provider-features.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install the repository Rust toolchain and host test fonts
         run: |
+          rustup install
           rustup show
           rustup target add wasm32-unknown-unknown
           rustup component add rustfmt clippy
@@ -130,6 +131,7 @@ jobs:
           path: .provider-baseline
       - name: Install the repository Rust toolchain
         run: |
+          rustup install
           rustup show
           rustup target add wasm32-unknown-unknown
       - name: Measure identical defaults-disabled geometry on selected base

--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -45,9 +45,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -46,9 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -52,9 +52,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -48,8 +48,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"
 profile = "minimal"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

- pin Noon to Rust 1.98.1 instead of 1.98.0
- make hosted stable-toolchain CI honor `rust-toolchain.toml` rather than resetting the rustup default to floating `stable`
- explicitly `rustup install` the repository-selected toolchain before querying/using it, avoiding rustup's deprecated implicit auto-install path
- retain explicit WASM target setup where workflows need it and keep the exact Rust version in one repository-owned place
- preserve the existing WASM artifact/cache provenance contract, which already keys compiler identity from the exact repository pin
- include `web/runtime-build-identity.json` in CI's browser-package artifact; exact-head qualification exposed that downstream browser consumers otherwise receive a 404 even though the producer build/provenance check passes

## Scope / architecture

- maintenance-only toolchain and CI-policy change; no roadmap behavior or engine architecture changes
- no semantic/runtime/renderer ownership or public API changes
- no dependency, edition, MSRV-policy, or application-source changes
- intentional nightly fuzzing remains separate; this PR changes only stable-toolchain selection
- the runtime-identity artifact addition is CI plumbing only and reuses the identity file already produced and consumed elsewhere

## Validation

`rust-toolchain.toml` moves from 1.98.0 to 1.98.1; affected hosted workflows use `rustup install` and then verify/use the repository-selected toolchain rather than floating `rustup default stable`. `rustfmt`, `clippy`, and `wasm32-unknown-unknown` remain declared by `rust-toolchain.toml`.

On the prior exact head, Rust 1.98.1 already passed workspace formatting, full workspace Clippy with `-D warnings`, all workspace tests, the qualified WASM build, Authoring WASM Footprint, Native Host Smoke, architecture/layer ratchets, Shared Text, Agent discovery, and authoring recovery. The full CI consumer run exposed one pre-existing artifact omission: authoring/layout/painter-order checks all failed on the same missing `runtime-build-identity.json` HTTP 404, while the WebGPU 30-fixture renderer smoke itself passed. This PR now uploads that already-generated identity with `web-pkg`; final qualification is against the updated exact head.