### PR TITLE
Sync Rust 1.98.1 master into TangentLine replay

### DIFF
--- a/.github/actions/dev-wasm-build/action.yml
+++ b/.github/actions/dev-wasm-build/action.yml
@@ -29,6 +29,7 @@ runs:
       shell: bash
       run: |
         node .github/ci/wasm-build.mjs measure toolchain bash -euo pipefail -c '
+          rustup install
           rustup show active-toolchain
           rustup target add wasm32-unknown-unknown
         '

--- a/.github/workflows/authoring-wasm-footprint.yml
+++ b/.github/workflows/authoring-wasm-footprint.yml
@@ -27,9 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust and WASM target
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
 
       - name: Cache Cargo sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
-          rustup component add rustfmt clippy
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           path: |
             web/pkg
             web/python-worker.js
+            web/runtime-build-identity.json
             web/python/compat-bundle.*.json
             web/ci-artifact.json
             web/ci-Cargo.lock

--- a/.github/workflows/manim-raster-differential.yml
+++ b/.github/workflows/manim-raster-differential.yml
@@ -61,9 +61,11 @@ jobs:
             pkg-config
       - name: Install pinned ManimCE reference
         run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/native-host-smoke.yml
+++ b/.github/workflows/native-host-smoke.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Install virtual display and software Vulkan
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,9 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
 
       - name: Cache Cargo sources

--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -58,8 +58,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Cache Cargo sources
         uses: actions/cache@v6
         with:
@@ -81,8 +84,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Cache Cargo sources
         uses: actions/cache@v6
         with:
@@ -109,9 +115,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust and WASM target
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-authoring-recovery.yml
+++ b/.github/workflows/playground-authoring-recovery.yml
@@ -46,9 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-cross-browser.yml
+++ b/.github/workflows/playground-cross-browser.yml
@@ -56,9 +56,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-lifecycle-recovery.yml
+++ b/.github/workflows/playground-lifecycle-recovery.yml
@@ -32,9 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-playback-controls.yml
+++ b/.github/workflows/playground-playback-controls.yml
@@ -33,9 +33,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/playground-product-gate.yml
+++ b/.github/workflows/playground-product-gate.yml
@@ -77,6 +77,7 @@ jobs:
           for noon_checkout in baseline candidate; do
             (
               cd "$noon_checkout"
+              rustup install
               rustup show active-toolchain
               rustup target add wasm32-unknown-unknown
             )

--- a/.github/workflows/playground-resize-recovery.yml
+++ b/.github/workflows/playground-resize-recovery.yml
@@ -32,9 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust
         run: |
-          rustup default stable
-          rustup component add rustfmt clippy
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6
@@ -62,8 +63,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
 
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/provider-features.yml
+++ b/.github/workflows/provider-features.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install the repository Rust toolchain and host test fonts
         run: |
+          rustup install
           rustup show
           rustup target add wasm32-unknown-unknown
           rustup component add rustfmt clippy
@@ -130,6 +131,7 @@ jobs:
           path: .provider-baseline
       - name: Install the repository Rust toolchain
         run: |
+          rustup install
           rustup show
           rustup target add wasm32-unknown-unknown
       - name: Measure identical defaults-disabled geometry on selected base

--- a/.github/workflows/renderer-recovery.yml
+++ b/.github/workflows/renderer-recovery.yml
@@ -45,9 +45,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/retained-text-animation.yml
+++ b/.github/workflows/retained-text-animation.yml
@@ -46,9 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -52,9 +52,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
+      - name: Use repository-pinned Rust and WASM target
         run: |
-          rustup default stable
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
           rustup target add wasm32-unknown-unknown
       - name: Cache Cargo sources
         uses: actions/cache@v6

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -48,8 +48,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Use stable Rust
-        run: rustup default stable
+      - name: Use repository-pinned Rust
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"
 profile = "minimal"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Temporary integration PR only: merge current master `ed530cc90c02ebbb4a603df2d54442c33b804f9a` into `codex/b2-tangent-line-replay` so #1474 is qualified against the landed Rust 1.98.1 workflow/toolchain updates. Drift is disjoint from the 12-file TangentLine feature slice.