### PR TITLE
Add shared-Rust Brace geometry authoring

### DIFF
--- a/crates/noon-web/src/authoring_brace.rs
+++ b/crates/noon-web/src/authoring_brace.rs
@@ -1,0 +1,81 @@
+//! Thin WASM projection for shared Rust Brace geometry authoring.
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::prelude::*;
+
+use crate::authoring_error::js_error;
+use crate::{WasmAuthoringFamilyHandle, WasmAuthoringMobjectHandle, WasmManimGeometryOptions};
+
+#[wasm_bindgen]
+impl WasmAuthoringMobjectHandle {
+    /// Observe this object through shared Rust and return inert Brace geometry.
+    #[wasm_bindgen(js_name = beginBrace)]
+    pub fn begin_brace(
+        &self,
+        direction_x: f64,
+        direction_y: f64,
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<WasmManimGeometryOptions, JsValue> {
+        let object = self.semantic_mobject()?;
+        let target = noon::LayoutAnchor::from(&object);
+        noon::ManimGeometryOptions::brace(
+            &target,
+            (direction_x, direction_y),
+            buff,
+            sharpness,
+        )
+        .map(WasmManimGeometryOptions::from_options)
+        .map_err(js_error)
+    }
+}
+
+#[wasm_bindgen]
+impl WasmAuthoringFamilyHandle {
+    /// Observe this semantic family through shared Rust and return inert Brace geometry.
+    #[wasm_bindgen(js_name = beginBrace)]
+    pub fn begin_brace(
+        &self,
+        direction_x: f64,
+        direction_y: f64,
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<WasmManimGeometryOptions, JsValue> {
+        let family = self.semantic_family()?;
+        let target = noon::LayoutAnchor::from(&family);
+        noon::ManimGeometryOptions::brace(
+            &target,
+            (direction_x, direction_y),
+            buff,
+            sharpness,
+        )
+        .map(WasmManimGeometryOptions::from_options)
+        .map_err(js_error)
+    }
+}
+
+#[wasm_bindgen]
+impl WasmManimGeometryOptions {
+    /// Pure shared-Rust BraceBetweenPoints constructor; no temporary Line identity.
+    #[wasm_bindgen(js_name = braceBetweenPoints)]
+    pub fn brace_between_points(
+        point_1_x: f64,
+        point_1_y: f64,
+        point_2_x: f64,
+        point_2_y: f64,
+        direction_x: f64,
+        direction_y: f64,
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<Self, JsValue> {
+        noon::ManimGeometryOptions::brace_between_points(
+            (point_1_x, point_1_y),
+            (point_2_x, point_2_y),
+            (direction_x, direction_y),
+            buff,
+            sharpness,
+        )
+        .map(Self::from_options)
+        .map_err(js_error)
+    }
+}

--- a/crates/noon-web/src/authoring_brace.rs
+++ b/crates/noon-web/src/authoring_brace.rs
@@ -17,8 +17,8 @@ impl WasmAuthoringMobjectHandle {
         buff: f64,
         sharpness: f64,
     ) -> Result<WasmManimGeometryOptions, JsValue> {
-        let object = self.semantic_mobject()?;
-        let target = noon::LayoutAnchor::from(&object);
+        let object = self.semantic_mobject();
+        let target = noon::LayoutAnchor::from(object);
         noon::ManimGeometryOptions::brace(
             &target,
             (direction_x, direction_y),

--- a/crates/noon-web/src/authoring_brace.rs
+++ b/crates/noon-web/src/authoring_brace.rs
@@ -19,14 +19,9 @@ impl WasmAuthoringMobjectHandle {
     ) -> Result<WasmManimGeometryOptions, JsValue> {
         let object = self.semantic_mobject();
         let target = noon::LayoutAnchor::from(object);
-        noon::ManimGeometryOptions::brace(
-            &target,
-            (direction_x, direction_y),
-            buff,
-            sharpness,
-        )
-        .map(WasmManimGeometryOptions::from_options)
-        .map_err(js_error)
+        noon::ManimGeometryOptions::brace(&target, (direction_x, direction_y), buff, sharpness)
+            .map(WasmManimGeometryOptions::from_options)
+            .map_err(js_error)
     }
 }
 
@@ -43,14 +38,9 @@ impl WasmAuthoringFamilyHandle {
     ) -> Result<WasmManimGeometryOptions, JsValue> {
         let family = self.semantic_family()?;
         let target = noon::LayoutAnchor::from(&family);
-        noon::ManimGeometryOptions::brace(
-            &target,
-            (direction_x, direction_y),
-            buff,
-            sharpness,
-        )
-        .map(WasmManimGeometryOptions::from_options)
-        .map_err(js_error)
+        noon::ManimGeometryOptions::brace(&target, (direction_x, direction_y), buff, sharpness)
+            .map(WasmManimGeometryOptions::from_options)
+            .map_err(js_error)
     }
 }
 

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -6,6 +6,8 @@ mod authoring_arc;
 mod authoring_arrow;
 #[cfg(target_arch = "wasm32")]
 mod authoring_arrow_endpoints;
+#[cfg(target_arch = "wasm32")]
+mod authoring_brace;
 mod authoring_error;
 #[cfg(target_arch = "wasm32")]
 mod authoring_geometry;

--- a/crates/noon/src/geometry_authoring.rs
+++ b/crates/noon/src/geometry_authoring.rs
@@ -338,21 +338,9 @@ impl RawBracePath {
         path.line_rel(linear_section_length, 0.0);
         path.cubic_rel(0.05077, 0.0, 0.1629, -0.02346, 0.2307, -0.1455);
         path.line_rel(0.0, -0.007762);
+        path.cubic_rel(-1.78e-6, -0.0125, -0.0006365, -0.01311, -0.01216, -0.01311);
         path.cubic_rel(
-            -1.78e-6,
-            -0.0125,
-            -0.0006365,
-            -0.01311,
-            -0.01216,
-            -0.01311,
-        );
-        path.cubic_rel(
-            -0.006444,
-            -3.919e-8,
-            -0.009348,
-            2.448e-5,
-            -0.01091,
-            0.002563,
+            -0.006444, -3.919e-8, -0.009348, 2.448e-5, -0.01091, 0.002563,
         );
         path.cubic_rel(-0.0123, 0.01953, -0.03278, 0.05074, -0.08648, 0.07769);
         path.cubic_rel(-0.04491, 0.02187, -0.09416, 0.02597, -0.1246, 0.02636);
@@ -360,22 +348,10 @@ impl RawBracePath {
         path.cubic_rel(-0.04786, 0.0, -0.1502, 0.02094, -0.2185, 0.1256);
         path.cubic_rel(-0.06833, -0.1046, -0.1706, -0.1256, -0.2185, -0.1256);
         path.line_rel(-linear_section_length, 0.0);
-        path.cubic_rel(
-            -0.03046,
-            -0.0003899,
-            -0.07972,
-            -0.004491,
-            -0.1246,
-            -0.02636,
-        );
+        path.cubic_rel(-0.03046, -0.0003899, -0.07972, -0.004491, -0.1246, -0.02636);
         path.cubic_rel(-0.0537, -0.02695, -0.07418, -0.05816, -0.08648, -0.07769);
         path.cubic_rel(
-            -0.001562,
-            -0.002538,
-            -0.004467,
-            -0.002563,
-            -0.01091,
-            -0.002563,
+            -0.001562, -0.002538, -0.004467, -0.002563, -0.01091, -0.002563,
         );
         path.commands.push(RawPathCommand::Close);
         path
@@ -534,12 +510,7 @@ mod tests {
         let square = scene.square(2.0).unwrap();
         let revision = scene.revision();
         let error = scene
-            .brace(
-                &LayoutAnchor::from(&square),
-                (0.0, f64::NAN),
-                0.2,
-                2.0,
-            )
+            .brace(&LayoutAnchor::from(&square), (0.0, f64::NAN), 0.2, 2.0)
             .unwrap_err();
         assert!(matches!(error, AuthoringError::InvalidRenderNumber { .. }));
         assert_eq!(scene.revision(), revision);

--- a/crates/noon/src/geometry_authoring.rs
+++ b/crates/noon/src/geometry_authoring.rs
@@ -1,5 +1,13 @@
-//! The retained path used by the shared Manim Triangle constructor.
-use noon_core::{Vec2, VectorPath, TAU};
+//! Shared retained geometry authoring, including the canonical Manim Triangle and Brace paths.
+use crate::{
+    family_layout::union_bounds,
+    semantic_mobject::{authoring_render_f64, layout_for_content},
+    AuthoringError, LayoutAnchor, ManimGeometryOptions, Mobject, Scene,
+};
+use noon_core::{Bounds2D64, SemanticNodeKind, SemanticTransform2_5D, Vec2, VectorPath, TAU};
+use std::rc::Rc;
+
+const BRACE_DEFAULT_MIN_WIDTH: f64 = 0.90552;
 
 pub(crate) fn manim_triangle_path() -> VectorPath {
     let vertices: Vec<_> = (0..3)
@@ -13,4 +21,540 @@ pub(crate) fn manim_triangle_path() -> VectorPath {
         .line_to(vertices[1])
         .line_to(vertices[2])
         .close()
+}
+
+impl ManimGeometryOptions {
+    /// Construct the ManimCE v0.21 Brace path around an authored object or family.
+    ///
+    /// The target is observed without mutation. Upstream's temporary rotate/measure/
+    /// rotate-back sequence is evaluated mathematically against the same retained
+    /// semantic content so aliases never see a transient target transform.
+    pub fn brace(
+        target: &LayoutAnchor,
+        direction: (f64, f64),
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<Self, AuthoringError> {
+        let angle = brace_angle(direction)?;
+        let projected = projected_layout_bounds(target, -angle)?;
+        brace_options(projected, angle, buff, sharpness)
+    }
+
+    /// Construct ManimCE v0.21 BraceBetweenPoints without allocating a temporary Line.
+    pub fn brace_between_points(
+        point_1: (f64, f64),
+        point_2: (f64, f64),
+        mut direction: (f64, f64),
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<Self, AuthoringError> {
+        let point_1 = finite_point("point_1", point_1)?;
+        let point_2 = finite_point("point_2", point_2)?;
+        if direction == (0.0, 0.0) {
+            let line_x = point_2.0 - point_1.0;
+            let line_y = point_2.1 - point_1.1;
+            direction = (line_y, -line_x);
+        }
+        let angle = brace_angle(direction)?;
+        let projected_1 = rotate_point(point_1, -angle);
+        let projected_2 = rotate_point(point_2, -angle);
+        let projected = Bounds2D64 {
+            min_x: projected_1.0.min(projected_2.0),
+            min_y: projected_1.1.min(projected_2.1),
+            max_x: projected_1.0.max(projected_2.0),
+            max_y: projected_1.1.max(projected_2.1),
+        };
+        brace_options(projected, angle, buff, sharpness)
+    }
+}
+
+impl Scene {
+    /// Construct a detached Brace in this scene's semantic store.
+    pub fn brace(
+        &self,
+        target: &LayoutAnchor,
+        direction: (f64, f64),
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<Mobject, AuthoringError> {
+        if !Rc::ptr_eq(self.integration_store(), target.integration_store()) {
+            return Err(AuthoringError::ForeignStore);
+        }
+        self.geometry(ManimGeometryOptions::brace(
+            target, direction, buff, sharpness,
+        )?)
+    }
+
+    /// Construct a detached BraceBetweenPoints in this scene's semantic store.
+    pub fn brace_between_points(
+        &self,
+        point_1: (f64, f64),
+        point_2: (f64, f64),
+        direction: (f64, f64),
+        buff: f64,
+        sharpness: f64,
+    ) -> Result<Mobject, AuthoringError> {
+        self.geometry(ManimGeometryOptions::brace_between_points(
+            point_1, point_2, direction, buff, sharpness,
+        )?)
+    }
+}
+
+fn brace_options(
+    projected_target: Bounds2D64,
+    angle: f64,
+    buff: f64,
+    sharpness: f64,
+) -> Result<ManimGeometryOptions, AuthoringError> {
+    let buff = authoring_render_f64("brace buff", buff)?;
+    let sharpness = authoring_render_f64("brace sharpness", sharpness)?;
+    let target_width = authoring_render_f64("brace target width", projected_target.width())?;
+    let linear_section_length = authoring_render_f64(
+        "brace linear section length",
+        ((target_width * sharpness - BRACE_DEFAULT_MIN_WIDTH) / 2.0).max(0.0),
+    )?;
+    let raw = RawBracePath::manim_v021(linear_section_length);
+    let bounds = raw.bounds();
+    let raw_width = bounds.max_x - bounds.min_x;
+    debug_assert!(raw_width > 0.0);
+
+    // VMobjectFromSVGPath keeps SVG coordinates, then Brace.flip(RIGHT) mirrors Y.
+    // stretch_to_fit_width() scales X around the center and the following shift
+    // aligns the brace's upper-left corner to the target's lower-left + buff*DOWN.
+    // These two affine operations collapse to the expressions below.
+    let scale_x = target_width / raw_width;
+    let projected_top = -bounds.min_y;
+    let mut path = VectorPath::new();
+    for command in raw.commands {
+        path = match command {
+            RawPathCommand::Move(to) => path.move_to(lower_brace_point(
+                to,
+                bounds.min_x,
+                scale_x,
+                projected_target,
+                projected_top,
+                buff,
+                angle,
+            )?),
+            RawPathCommand::Line(to) => path.line_to(lower_brace_point(
+                to,
+                bounds.min_x,
+                scale_x,
+                projected_target,
+                projected_top,
+                buff,
+                angle,
+            )?),
+            RawPathCommand::Cubic {
+                control1,
+                control2,
+                to,
+            } => path.cubic_to(
+                lower_brace_point(
+                    control1,
+                    bounds.min_x,
+                    scale_x,
+                    projected_target,
+                    projected_top,
+                    buff,
+                    angle,
+                )?,
+                lower_brace_point(
+                    control2,
+                    bounds.min_x,
+                    scale_x,
+                    projected_target,
+                    projected_top,
+                    buff,
+                    angle,
+                )?,
+                lower_brace_point(
+                    to,
+                    bounds.min_x,
+                    scale_x,
+                    projected_target,
+                    projected_top,
+                    buff,
+                    angle,
+                )?,
+            ),
+            RawPathCommand::Close => path.close(),
+        };
+    }
+
+    let mut options = ManimGeometryOptions::path(path)?;
+    options.set_fill_opacity(1.0)?;
+    options.set_stroke_width(0.0)?;
+    Ok(options)
+}
+
+fn lower_brace_point(
+    raw: Point64,
+    raw_min_x: f64,
+    scale_x: f64,
+    target: Bounds2D64,
+    projected_top: f64,
+    buff: f64,
+    angle: f64,
+) -> Result<Vec2, AuthoringError> {
+    let flipped = (raw.x, -raw.y);
+    let projected = (
+        target.min_x + (flipped.0 - raw_min_x) * scale_x,
+        target.min_y - buff + (flipped.1 - projected_top),
+    );
+    let world = rotate_point(projected, angle);
+    Ok(Vec2::new(
+        authoring_render_f64("brace point.x", world.0)? as f32,
+        authoring_render_f64("brace point.y", world.1)? as f32,
+    ))
+}
+
+fn projected_layout_bounds(
+    target: &LayoutAnchor,
+    rotation: f64,
+) -> Result<Bounds2D64, AuthoringError> {
+    let node = target.resolve()?;
+    let store_rc = target.integration_store();
+    let leaves = {
+        let store = store_rc.borrow();
+        if matches!(
+            store.node(node).map(|node| node.kind()),
+            Some(SemanticNodeKind::Family(_))
+        ) {
+            store
+                .ordered_leaf_nodes(node)
+                .map_err(AuthoringError::from)?
+        } else {
+            vec![node]
+        }
+    };
+
+    let mut bounds = None;
+    let store = store_rc.borrow();
+    for leaf in leaves {
+        let state = store
+            .semantic_object_state_checked(leaf)
+            .map_err(AuthoringError::from)?;
+        let transform = rotate_transform_about_origin(state.transform, rotation)?;
+        union_bounds(
+            &mut bounds,
+            layout_for_content(&store, state.content, transform)?,
+        );
+    }
+    Ok(bounds.unwrap_or_else(|| Bounds2D64::point(0.0, 0.0)))
+}
+
+fn rotate_transform_about_origin(
+    mut transform: SemanticTransform2_5D,
+    angle: f64,
+) -> Result<SemanticTransform2_5D, AuthoringError> {
+    let angle = authoring_render_f64("brace target rotation", angle)?;
+    let (sine, cosine) = angle.sin_cos();
+    let x = transform.translation.x;
+    let y = transform.translation.y;
+    transform.translation.x =
+        authoring_render_f64("brace projected translation.x", x * cosine - y * sine)?;
+    transform.translation.y =
+        authoring_render_f64("brace projected translation.y", x * sine + y * cosine)?;
+    transform.rotation_z =
+        authoring_render_f64("brace projected rotation", transform.rotation_z + angle)?;
+    Ok(transform)
+}
+
+fn brace_angle(direction: (f64, f64)) -> Result<f64, AuthoringError> {
+    let direction = finite_point("brace direction", direction)?;
+    authoring_render_f64(
+        "brace angle",
+        -direction.0.atan2(direction.1) + std::f64::consts::PI,
+    )
+}
+
+fn finite_point(name: &str, point: (f64, f64)) -> Result<(f64, f64), AuthoringError> {
+    Ok((
+        authoring_render_f64(&format!("{name}.x"), point.0)?,
+        authoring_render_f64(&format!("{name}.y"), point.1)?,
+    ))
+}
+
+fn rotate_point(point: (f64, f64), angle: f64) -> (f64, f64) {
+    let (sine, cosine) = angle.sin_cos();
+    (
+        point.0 * cosine - point.1 * sine,
+        point.0 * sine + point.1 * cosine,
+    )
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Point64 {
+    x: f64,
+    y: f64,
+}
+
+impl Point64 {
+    const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    fn offset(self, dx: f64, dy: f64) -> Self {
+        Self::new(self.x + dx, self.y + dy)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RawPathCommand {
+    Move(Point64),
+    Line(Point64),
+    Cubic {
+        control1: Point64,
+        control2: Point64,
+        to: Point64,
+    },
+    Close,
+}
+
+#[derive(Debug)]
+struct RawBracePath {
+    current: Point64,
+    commands: Vec<RawPathCommand>,
+}
+
+impl RawBracePath {
+    fn manim_v021(linear_section_length: f64) -> Self {
+        let mut path = Self {
+            current: Point64::new(0.0, 0.0),
+            commands: Vec::with_capacity(28),
+        };
+        path.move_to(0.01216, 0.0);
+        path.cubic_rel(-0.01152, 0.0, -0.01216, 0.0006103, -0.01216, 0.01311);
+        path.line_rel(0.0, 0.007762);
+        path.cubic_rel(0.06776, 0.122, 0.1799, 0.1455, 0.2307, 0.1455);
+        path.line_rel(linear_section_length, 0.0);
+        path.cubic_rel(0.03046, 0.0003899, 0.07964, 0.00449, 0.1246, 0.02636);
+        path.cubic_rel(0.0537, 0.02695, 0.07418, 0.05816, 0.08648, 0.07769);
+        path.cubic_rel(0.001562, 0.002538, 0.004539, 0.002563, 0.01098, 0.002563);
+        path.cubic_rel(0.006444, -2e-8, 0.009421, -2.47e-5, 0.01098, -0.002563);
+        path.cubic_rel(0.0123, -0.01953, 0.03278, -0.05074, 0.08648, -0.07769);
+        path.cubic_rel(0.04491, -0.02187, 0.09409, -0.02597, 0.1246, -0.02636);
+        path.line_rel(linear_section_length, 0.0);
+        path.cubic_rel(0.05077, 0.0, 0.1629, -0.02346, 0.2307, -0.1455);
+        path.line_rel(0.0, -0.007762);
+        path.cubic_rel(
+            -1.78e-6,
+            -0.0125,
+            -0.0006365,
+            -0.01311,
+            -0.01216,
+            -0.01311,
+        );
+        path.cubic_rel(
+            -0.006444,
+            -3.919e-8,
+            -0.009348,
+            2.448e-5,
+            -0.01091,
+            0.002563,
+        );
+        path.cubic_rel(-0.0123, 0.01953, -0.03278, 0.05074, -0.08648, 0.07769);
+        path.cubic_rel(-0.04491, 0.02187, -0.09416, 0.02597, -0.1246, 0.02636);
+        path.line_rel(-linear_section_length, 0.0);
+        path.cubic_rel(-0.04786, 0.0, -0.1502, 0.02094, -0.2185, 0.1256);
+        path.cubic_rel(-0.06833, -0.1046, -0.1706, -0.1256, -0.2185, -0.1256);
+        path.line_rel(-linear_section_length, 0.0);
+        path.cubic_rel(
+            -0.03046,
+            -0.0003899,
+            -0.07972,
+            -0.004491,
+            -0.1246,
+            -0.02636,
+        );
+        path.cubic_rel(-0.0537, -0.02695, -0.07418, -0.05816, -0.08648, -0.07769);
+        path.cubic_rel(
+            -0.001562,
+            -0.002538,
+            -0.004467,
+            -0.002563,
+            -0.01091,
+            -0.002563,
+        );
+        path.commands.push(RawPathCommand::Close);
+        path
+    }
+
+    fn move_to(&mut self, x: f64, y: f64) {
+        self.current = Point64::new(x, y);
+        self.commands.push(RawPathCommand::Move(self.current));
+    }
+
+    fn line_rel(&mut self, dx: f64, dy: f64) {
+        self.current = self.current.offset(dx, dy);
+        self.commands.push(RawPathCommand::Line(self.current));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn cubic_rel(
+        &mut self,
+        control1_x: f64,
+        control1_y: f64,
+        control2_x: f64,
+        control2_y: f64,
+        to_x: f64,
+        to_y: f64,
+    ) {
+        let start = self.current;
+        let control1 = start.offset(control1_x, control1_y);
+        let control2 = start.offset(control2_x, control2_y);
+        let to = start.offset(to_x, to_y);
+        self.commands.push(RawPathCommand::Cubic {
+            control1,
+            control2,
+            to,
+        });
+        self.current = to;
+    }
+
+    fn bounds(&self) -> Bounds2D64 {
+        let mut bounds: Option<Bounds2D64> = None;
+        let mut include = |point: Point64| {
+            if let Some(bounds) = &mut bounds {
+                bounds.include(point.x, point.y);
+            } else {
+                bounds = Some(Bounds2D64::point(point.x, point.y));
+            }
+        };
+        for command in &self.commands {
+            match *command {
+                RawPathCommand::Move(point) | RawPathCommand::Line(point) => include(point),
+                RawPathCommand::Cubic {
+                    control1,
+                    control2,
+                    to,
+                } => {
+                    include(control1);
+                    include(control2);
+                    include(to);
+                }
+                RawPathCommand::Close => {}
+            }
+        }
+        bounds.expect("Brace template always contains points")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MobjectFamilyMember, DOWN, RIGHT};
+
+    const EPSILON: f64 = 2.0e-5;
+
+    #[test]
+    fn brace_matches_default_square_width_and_buffer_without_mutating_target() {
+        let scene = Scene::new();
+        let square = scene.square(2.0).unwrap();
+        let before = square.state().unwrap();
+
+        let brace = scene
+            .brace(
+                &LayoutAnchor::from(&square),
+                (DOWN.x as f64, DOWN.y as f64),
+                0.2,
+                2.0,
+            )
+            .unwrap();
+
+        assert_eq!(square.state().unwrap(), before);
+        assert!((brace.width().unwrap() - 2.0).abs() < EPSILON);
+        let target = square.layout_bounds().unwrap().unwrap();
+        let brace_bounds = brace.layout_bounds().unwrap().unwrap();
+        assert!((brace_bounds.max_y - (target.min_y - 0.2)).abs() < EPSILON);
+        assert_eq!(brace.wire_stroke_width().unwrap(), 0.0);
+        assert!(brace.wire_fill().unwrap().is_some());
+    }
+
+    #[test]
+    fn brace_observes_family_bounds_once_without_changing_members() {
+        let scene = Scene::new();
+        let mut left = scene.square(1.0).unwrap();
+        let mut right = scene.square(1.0).unwrap();
+        left.shift(-1.0, 0.0).unwrap();
+        right.shift(1.0, 0.0).unwrap();
+        let family = scene
+            .family(&[
+                MobjectFamilyMember::Mobject(&left),
+                MobjectFamilyMember::Mobject(&right),
+            ])
+            .unwrap();
+        let left_before = left.state().unwrap();
+        let right_before = right.state().unwrap();
+
+        let brace = scene
+            .brace(
+                &LayoutAnchor::from(&family),
+                (DOWN.x as f64, DOWN.y as f64),
+                0.2,
+                2.0,
+            )
+            .unwrap();
+
+        assert_eq!(left.state().unwrap(), left_before);
+        assert_eq!(right.state().unwrap(), right_before);
+        assert!((brace.width().unwrap() - 3.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn brace_between_points_auto_direction_matches_line_normal() {
+        let scene = Scene::new();
+        let brace = scene
+            .brace_between_points((-1.0, 0.0), (1.0, 0.0), (0.0, 0.0), 0.2, 2.0)
+            .unwrap();
+        let bounds = brace.layout_bounds().unwrap().unwrap();
+        assert!((bounds.max_y + 0.2).abs() < EPSILON);
+        assert!((brace.width().unwrap() - 2.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn right_facing_brace_uses_projected_target_extent() {
+        let scene = Scene::new();
+        let target = scene.rectangle(2.0, 3.0).unwrap();
+        let brace = scene
+            .brace(
+                &LayoutAnchor::from(&target),
+                (RIGHT.x as f64, RIGHT.y as f64),
+                0.2,
+                2.0,
+            )
+            .unwrap();
+        assert!((brace.height().unwrap() - 3.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn brace_rejects_non_finite_inputs_before_object_creation() {
+        let scene = Scene::new();
+        let square = scene.square(2.0).unwrap();
+        let revision = scene.revision();
+        let error = scene
+            .brace(
+                &LayoutAnchor::from(&square),
+                (0.0, f64::NAN),
+                0.2,
+                2.0,
+            )
+            .unwrap_err();
+        assert!(matches!(error, AuthoringError::InvalidRenderNumber { .. }));
+        assert_eq!(scene.revision(), revision);
+    }
+
+    #[test]
+    fn brace_rejects_foreign_target_without_observing_it() {
+        let scene = Scene::new();
+        let other = Scene::new();
+        let target = other.square(1.0).unwrap();
+        assert_eq!(
+            scene
+                .brace(&LayoutAnchor::from(&target), (0.0, -1.0), 0.2, 2.0)
+                .unwrap_err(),
+            AuthoringError::ForeignStore
+        );
+    }
 }

--- a/parity/manim-v0.21/core-examples/brace_geometry.py
+++ b/parity/manim-v0.21/core-examples/brace_geometry.py
@@ -1,0 +1,22 @@
+from manim import *
+
+
+class BraceGeometry(Scene):
+    def construct(self):
+        square = Square(2.0).shift(LEFT * 2.0)
+        lower = Brace(square, direction=DOWN, buff=0.2, color=BLUE)
+
+        rectangle = Rectangle(width=2.5, height=1.5).shift(RIGHT * 2.0)
+        side = Brace(rectangle, direction=RIGHT, buff=0.25, color=YELLOW)
+
+        between = BraceBetweenPoints(
+            (-1.25, 2.0, 0.0),
+            (1.25, 2.0, 0.0),
+            direction=UP,
+            buff=0.15,
+            sharpness=1.5,
+            color=RED,
+        )
+
+        self.add(square, lower, rectangle, side, between)
+        self.wait(0.2)

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -12,6 +12,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },
   { sourcePath: "python/_manim_shared_geometry.py", runtimePath: "/tmp/_manim_shared_geometry.py", label: "Noon shared Rust geometry adapter" },
   { sourcePath: "python/_manim_arc.py", runtimePath: "/tmp/_manim_arc.py", label: "Noon shared Rust Arc adapter" },
+  { sourcePath: "python/_manim_brace.py", runtimePath: "/tmp/_manim_brace.py", label: "Noon shared Rust Brace adapter" },
   { sourcePath: "python/_manim_arrow.py", runtimePath: "/tmp/_manim_arrow.py", label: "Noon shared Rust Arrow adapter" },
   { sourcePath: "python/_manim_dashed_line.py", runtimePath: "/tmp/_manim_dashed_line.py", label: "Noon shared DashedLine adapter" },
   { sourcePath: "python/_manim_animation_options.py", runtimePath: "/tmp/_manim_animation_options.py", label: "Noon Manim animation options" },

--- a/web/python/_manim_brace.py
+++ b/web/python/_manim_brace.py
@@ -1,0 +1,159 @@
+"""Thin Manim Brace adapters backed by shared Rust retained geometry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _noon_errors import engine_call
+
+import noon as _base
+import _manim_compat as _compat
+import _manim_semantic_handles as _shared
+
+
+def _require_geometry_host(name: str) -> None:
+    if _shared._create_geometry_handle is None:
+        raise RuntimeError(f"{name} requires the shared Rust authoring host")
+
+
+def _brace_target_handle(mobject: object):
+    if not isinstance(mobject, _base.Mobject):
+        raise TypeError("Brace target must be a Mobject")
+    if isinstance(mobject, _compat.Group):
+        handle = getattr(mobject, "_semantic_family_handle", None)
+    else:
+        handle = _shared._handle_for(mobject)
+    if handle is None or not hasattr(handle, "beginBrace"):
+        raise NotImplementedError(
+            "Brace target requires a current shared semantic object/family handle"
+        )
+    return handle
+
+
+def _brace_constructor_options(
+    options: dict[str, Any],
+    *,
+    stroke_width: float,
+    fill_opacity: float,
+    background_stroke_width: float,
+) -> dict[str, Any]:
+    background_width = _shared._ir._finite_number(
+        "background_stroke_width", background_stroke_width
+    )
+    if background_width != 0.0:
+        raise NotImplementedError(
+            "Brace background stroke is not represented by Noon's ordinary retained path style"
+        )
+    # background_stroke_color is visually inert while background_stroke_width == 0.
+    options.pop("background_stroke_color", None)
+    options["stroke_width"] = stroke_width
+    options["fill_opacity"] = fill_opacity
+    return options
+
+
+def _finish_candidate(
+    owner: _base.Mobject,
+    candidate: object,
+    name: str,
+    options: dict[str, Any],
+) -> None:
+    color = options.pop("color", None)
+    _shared._apply_shared_constructor_options(candidate, options)
+    if color is not None:
+        parsed = _shared._compat._as_color("color", color)
+        _shared._apply_constructor_color(candidate, parsed)
+    _shared._attach_geometry_options(owner, candidate, name)
+
+
+class Brace(_compat.VMobject):
+    """ManimCE v0.21 Brace whose path/layout policy is owned by shared Rust."""
+
+    def __init__(
+        self,
+        mobject: _base.Mobject,
+        direction: object = _base.DOWN,
+        buff: float = 0.2,
+        sharpness: float = 2.0,
+        stroke_width: float = 0.0,
+        fill_opacity: float = 1.0,
+        background_stroke_width: float = 0.0,
+        background_stroke_color: object = _base.BLACK,
+        **kwargs: Any,
+    ) -> None:
+        _require_geometry_host("Brace")
+        target = _brace_target_handle(mobject)
+        direction_value = _base._as_vec2(direction)
+        buff_value = _shared._ir._finite_number("buff", buff)
+        sharpness_value = _shared._ir._finite_number("sharpness", sharpness)
+        stroke_value = _shared._ir._finite_number("stroke_width", stroke_width)
+        fill_value = _shared._compat._opacity("fill_opacity", fill_opacity)
+        options = dict(kwargs)
+        options["background_stroke_color"] = background_stroke_color
+        options = _brace_constructor_options(
+            options,
+            stroke_width=stroke_value,
+            fill_opacity=fill_value,
+            background_stroke_width=background_stroke_width,
+        )
+        candidate = engine_call(
+            target.beginBrace,
+            direction_value.x,
+            direction_value.y,
+            buff_value,
+            sharpness_value,
+            operation="Brace",
+        )
+        _finish_candidate(self, candidate, "Brace", options)
+        self.buff = buff_value
+        self.sharpness = sharpness_value
+        self.direction = direction_value
+
+
+class BraceBetweenPoints(Brace):
+    """Brace between two points without allocating a temporary semantic Line."""
+
+    def __init__(
+        self,
+        point_1: object,
+        point_2: object,
+        direction: object = _base.ORIGIN,
+        **kwargs: Any,
+    ) -> None:
+        _require_geometry_host("BraceBetweenPoints")
+        first = _base._as_vec2(point_1)
+        second = _base._as_vec2(point_2)
+        direction_value = _base._as_vec2(direction)
+        options = dict(kwargs)
+        buff_value = _shared._ir._finite_number("buff", options.pop("buff", 0.2))
+        sharpness_value = _shared._ir._finite_number(
+            "sharpness", options.pop("sharpness", 2.0)
+        )
+        stroke_value = _shared._ir._finite_number(
+            "stroke_width", options.pop("stroke_width", 0.0)
+        )
+        fill_value = _shared._compat._opacity(
+            "fill_opacity", options.pop("fill_opacity", 1.0)
+        )
+        background_width = options.pop("background_stroke_width", 0.0)
+        options = _brace_constructor_options(
+            options,
+            stroke_width=stroke_value,
+            fill_opacity=fill_value,
+            background_stroke_width=background_width,
+        )
+        candidate = engine_call(
+            _shared._geometry_options.braceBetweenPoints,
+            first.x,
+            first.y,
+            second.x,
+            second.y,
+            direction_value.x,
+            direction_value.y,
+            buff_value,
+            sharpness_value,
+            operation="BraceBetweenPoints",
+        )
+        _finish_candidate(self, candidate, "BraceBetweenPoints", options)
+        self.buff = buff_value
+        self.sharpness = sharpness_value
+        self.direction = direction_value

--- a/web/python/examples/ordinary_brace_geometry.py
+++ b/web/python/examples/ordinary_brace_geometry.py
@@ -1,0 +1,23 @@
+"""Paired Brace/BraceBetweenPoints example over shared Rust retained geometry."""
+from noon import *
+
+
+class BraceGeometry(Scene):
+    def construct(self):
+        square = Square(2.0).shift(LEFT * 2.0)
+        lower = Brace(square, direction=DOWN, buff=0.2, color=BLUE)
+
+        rectangle = Rectangle(width=2.5, height=1.5).shift(RIGHT * 2.0)
+        side = Brace(rectangle, direction=RIGHT, buff=0.25, color=YELLOW)
+
+        between = BraceBetweenPoints(
+            (-1.25, 2.0, 0.0),
+            (1.25, 2.0, 0.0),
+            direction=UP,
+            buff=0.15,
+            sharpness=1.5,
+            color=RED,
+        )
+
+        self.add(square, lower, rectangle, side, between)
+        self.wait(0.2)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -775,6 +775,8 @@ _PUBLIC_EXPORTS = {
     "IN": "_manim_compat",
     "Arc": "_manim_arc",
     "ArcBetweenPoints": "_manim_arc",
+    "Brace": "_manim_brace",
+    "BraceBetweenPoints": "_manim_brace",
     "Arrow": "_manim_arrow",
     "Vector": "_manim_arrow",
     "DoubleArrow": "_manim_arrow",

--- a/web/python/test_manim_brace.py
+++ b/web/python/test_manim_brace.py
@@ -1,0 +1,139 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class ManimBraceFacadeTests(unittest.TestCase):
+    def test_brace_facade_stays_thin_over_shared_rust_geometry(self) -> None:
+        python_dir = Path(__file__).resolve().parent
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(
+            value for value in (str(python_dir), env.get("PYTHONPATH")) if value
+        )
+        source = textwrap.dedent(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            calls = []
+
+            import _typed_geometry_test_support as support
+
+            def path_options(tag):
+                value = support.FakeGeometryOptions({
+                    "vector_path": {
+                        "commands": [
+                            {"move_to": {"to": {"x": -1.0, "y": -1.0}}},
+                            {"cubic_to": {
+                                "control1": {"x": -0.5, "y": -1.2},
+                                "control2": {"x": 0.5, "y": -1.2},
+                                "to": {"x": 1.0, "y": -1.0},
+                            }},
+                        ],
+                        "tag": tag,
+                    }
+                })
+                value.setStrokeWidth(0.0)
+                value.setFillOpacity(1.0)
+                return value
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+                def beginBrace(self, direction_x, direction_y, buff, sharpness):
+                    calls.append((
+                        "brace", float(direction_x), float(direction_y),
+                        float(buff), float(sharpness),
+                    ))
+                    return path_options("brace")
+
+            def create_from_snapshot(value):
+                return FakeHandle(json.loads(value))
+
+            support.install_js_bridge(fake_js, create_from_snapshot)
+
+            def brace_between_points(x1, y1, x2, y2, dx, dy, buff, sharpness):
+                calls.append((
+                    "between", float(x1), float(y1), float(x2), float(y2),
+                    float(dx), float(dy), float(buff), float(sharpness),
+                ))
+                return path_options("between")
+
+            support.install_option_factory(
+                fake_js, "braceBetweenPoints", brace_between_points
+            )
+            sys.modules["js"] = fake_js
+
+            import noon
+            from noon import Brace, BraceBetweenPoints, Square
+
+            target = Square(2.0)
+            brace = Brace(
+                target,
+                direction=noon.DOWN,
+                buff=0.3,
+                sharpness=1.5,
+                color="#58C4DD",
+            )
+            between = BraceBetweenPoints(
+                (-2.0, 1.0, 0.0),
+                (3.0, -1.0, 0.0),
+                direction=noon.ORIGIN,
+                buff=0.1,
+                sharpness=2.5,
+            )
+
+            assert calls == [
+                ("brace", 0.0, -1.0, 0.3, 1.5),
+                ("between", -2.0, 1.0, 3.0, -1.0, 0.0, 0.0, 0.1, 2.5),
+            ]
+            assert brace.buff == 0.3
+            assert brace.sharpness == 1.5
+            assert brace.direction == noon.DOWN
+            assert brace.style["stroke_width"] == 0.0
+            assert brace.style["fill"]["alpha"] == 1.0
+            assert brace.style["fill"]["red"] == noon.BLUE.red
+            assert between.buff == 0.1
+            assert between.sharpness == 2.5
+            assert "Brace" in noon.__all__
+            assert "BraceBetweenPoints" in noon.__all__
+
+            before = list(calls)
+            for thunk in (
+                lambda: Brace(target, buff=float("nan")),
+                lambda: Brace(target, background_stroke_width=1.0),
+                lambda: BraceBetweenPoints((0, 0, 1), (1, 0, 0)),
+            ):
+                try:
+                    thunk()
+                except (TypeError, ValueError, NotImplementedError):
+                    pass
+                else:
+                    raise AssertionError("invalid Brace input unexpectedly succeeded")
+            assert calls == before
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Claims the bounded geometry-only portion of #84: `Brace` and `BraceBetweenPoints` from pinned ManimCE v0.21.

- reproduces the pinned cubic SVG-template geometry in shared Rust;
- derives direction-aligned target/family bounds without temporarily mutating the target;
- lowers each brace to one ordinary retained `VectorPath` with normal semantic identity/style/transform publication;
- exposes thin object/family WASM entry points and thin Python adapters;
- implements `BraceBetweenPoints` directly without allocating a synthetic semantic `Line`.

## Architecture boundary

No class-specific renderer/runtime authority, no Python geometry/layout implementation, and no target mutation while deriving a brace. Group/VGroup targets use the retained semantic family handle and shared Rust projection.

Explicitly out of scope here: `BraceLabel`/`BraceText` and text-part behavior (#83/B4), `ArcBrace`, updater/dynamic-content breadth, and renderer-specific composite primitives.

## Validation

- focused Rust tests cover object/family bounds, arbitrary direction, `BraceBetweenPoints` automatic normal selection, target immutability, foreign-store rejection, and atomic non-finite rejection;
- Python public exports and adapter tests are included;
- source-equivalent Noon/Manim v0.21 brace fixtures are included;
- browser compatibility bundle includes `_manim_brace.py`;
- all PR workflows are green on head `df7c7d596d74d73949adebdc1eeecd2509046f9a`, including PR Fast Gate, Manim raster differential, architecture/layer ratchets, WASM footprint, product gate, and the cross-browser matrix.

Refs #84
Refs #185