### PR TITLE
Converge authored/live boolean snapshot preparation

### DIFF
--- a/crates/noon/src/boolean_authoring.rs
+++ b/crates/noon/src/boolean_authoring.rs
@@ -3,19 +3,13 @@ use crate::{AuthoringError, ManimGeometryOptions, Mobject};
 use noon_core::{SemanticObjectState, SemanticStore};
 pub use noon_geometry::{BooleanOperation, BooleanPathError};
 
-pub(crate) fn boolean_options<E>(
+pub(crate) fn boolean_options<E: From<AuthoringError>>(
     store: &SemanticStore,
     operation: BooleanOperation,
     operands: &[Mobject],
     snapshot: impl FnMut(&Mobject) -> Result<SemanticObjectState, E>,
-) -> Result<ManimGeometryOptions, E>
-where
-    E: From<AuthoringError>,
-{
-    let states = operands
-        .iter()
-        .map(snapshot)
-        .collect::<Result<Vec<_>, _>>()?;
+) -> Result<ManimGeometryOptions, E> {
+    let states = operands.iter().map(snapshot).collect::<Result<Vec<_>, _>>()?;
     let paths = states
         .iter()
         .map(|state| crate::path_editing::world_path(store, state).map_err(E::from))

--- a/crates/noon/src/boolean_authoring.rs
+++ b/crates/noon/src/boolean_authoring.rs
@@ -2,35 +2,23 @@
 use crate::{AuthoringError, ManimGeometryOptions, Mobject};
 use noon_core::{SemanticObjectState, SemanticStore};
 pub use noon_geometry::{BooleanOperation, BooleanPathError};
-use std::{cell::RefCell, rc::Rc};
 
-/// Prepare one inert boolean result while leaving authored-vs-effective snapshot policy to the
-/// caller. Provenance, handle validation, world-path extraction and boolean construction are shared.
-pub(crate) fn prepare_boolean_options<E>(
-    store: &Rc<RefCell<SemanticStore>>,
+pub(crate) fn boolean_options<E>(
+    store: &SemanticStore,
     operation: BooleanOperation,
     operands: &[Mobject],
-    mut foreign_store: impl FnMut() -> E,
-    mut snapshot: impl FnMut(
-        &SemanticStore,
-        &Mobject,
-        SemanticObjectState,
-    ) -> Result<SemanticObjectState, E>,
+    snapshot: impl FnMut(&Mobject) -> Result<SemanticObjectState, E>,
 ) -> Result<ManimGeometryOptions, E>
 where
     E: From<AuthoringError>,
 {
-    let store_ref = store.borrow();
-    let paths = operands
+    let states = operands
         .iter()
-        .map(|object| {
-            if !Rc::ptr_eq(store, object.integration_store()) {
-                return Err(foreign_store());
-            }
-            let state = object.state().map_err(E::from)?;
-            let state = snapshot(&store_ref, object, state)?;
-            crate::path_editing::world_path(&store_ref, &state).map_err(E::from)
-        })
+        .map(snapshot)
+        .collect::<Result<Vec<_>, _>>()?;
+    let paths = states
+        .iter()
+        .map(|state| crate::path_editing::world_path(store, state).map_err(E::from))
         .collect::<Result<Vec<_>, _>>()?;
     let path = noon_geometry::boolean_paths(operation, &paths)
         .map_err(|error| E::from(AuthoringError::Boolean(error)))?;
@@ -54,12 +42,12 @@ impl ManimGeometryOptions {
                     operation,
                     count: 0,
                 }))?;
-        prepare_boolean_options(
-            first.integration_store(),
-            operation,
-            operands,
-            || AuthoringError::ForeignStore,
-            |_, _, state| Ok(state),
-        )
+        let store = first.integration_store();
+        boolean_options(&store.borrow(), operation, operands, |object| {
+            if !std::rc::Rc::ptr_eq(store, object.integration_store()) {
+                return Err(AuthoringError::ForeignStore);
+            }
+            object.state()
+        })
     }
 }

--- a/crates/noon/src/boolean_authoring.rs
+++ b/crates/noon/src/boolean_authoring.rs
@@ -9,7 +9,10 @@ pub(crate) fn boolean_options<E: From<AuthoringError>>(
     operands: &[Mobject],
     snapshot: impl FnMut(&Mobject) -> Result<SemanticObjectState, E>,
 ) -> Result<ManimGeometryOptions, E> {
-    let states = operands.iter().map(snapshot).collect::<Result<Vec<_>, _>>()?;
+    let states = operands
+        .iter()
+        .map(snapshot)
+        .collect::<Result<Vec<_>, _>>()?;
     let paths = states
         .iter()
         .map(|state| crate::path_editing::world_path(store, state).map_err(E::from))

--- a/crates/noon/src/boolean_authoring.rs
+++ b/crates/noon/src/boolean_authoring.rs
@@ -2,18 +2,39 @@
 use crate::{AuthoringError, ManimGeometryOptions, Mobject};
 use noon_core::{SemanticObjectState, SemanticStore};
 pub use noon_geometry::{BooleanOperation, BooleanPathError};
+use std::{cell::RefCell, rc::Rc};
 
-pub(crate) fn boolean_options(
-    store: &SemanticStore,
+/// Prepare one inert boolean result while leaving authored-vs-effective snapshot policy to the
+/// caller. Provenance, handle validation, world-path extraction and boolean construction are shared.
+pub(crate) fn prepare_boolean_options<E>(
+    store: &Rc<RefCell<SemanticStore>>,
     operation: BooleanOperation,
-    states: &[SemanticObjectState],
-) -> Result<ManimGeometryOptions, AuthoringError> {
-    let paths = states
+    operands: &[Mobject],
+    mut foreign_store: impl FnMut() -> E,
+    mut snapshot: impl FnMut(
+        &SemanticStore,
+        &Mobject,
+        SemanticObjectState,
+    ) -> Result<SemanticObjectState, E>,
+) -> Result<ManimGeometryOptions, E>
+where
+    E: From<AuthoringError>,
+{
+    let store_ref = store.borrow();
+    let paths = operands
         .iter()
-        .map(|state| crate::path_editing::world_path(store, state))
+        .map(|object| {
+            if !Rc::ptr_eq(store, object.integration_store()) {
+                return Err(foreign_store());
+            }
+            let state = object.state().map_err(E::from)?;
+            let state = snapshot(&store_ref, object, state)?;
+            crate::path_editing::world_path(&store_ref, &state).map_err(E::from)
+        })
         .collect::<Result<Vec<_>, _>>()?;
-    let path = noon_geometry::boolean_paths(operation, &paths).map_err(AuthoringError::Boolean)?;
-    ManimGeometryOptions::path(path)
+    let path = noon_geometry::boolean_paths(operation, &paths)
+        .map_err(|error| E::from(AuthoringError::Boolean(error)))?;
+    ManimGeometryOptions::path(path).map_err(E::from)
 }
 
 impl ManimGeometryOptions {
@@ -33,14 +54,12 @@ impl ManimGeometryOptions {
                     operation,
                     count: 0,
                 }))?;
-        let store = first.integration_store();
-        let mut states = Vec::with_capacity(operands.len());
-        for object in operands {
-            if !std::rc::Rc::ptr_eq(store, object.integration_store()) {
-                return Err(AuthoringError::ForeignStore);
-            }
-            states.push(object.state()?);
-        }
-        boolean_options(&store.borrow(), operation, &states)
+        prepare_boolean_options(
+            first.integration_store(),
+            operation,
+            operands,
+            || AuthoringError::ForeignStore,
+            |_, _, state| Ok(state),
+        )
     }
 }

--- a/crates/noon/src/live_session/boolean_geometry.rs
+++ b/crates/noon/src/live_session/boolean_geometry.rs
@@ -10,30 +10,26 @@ impl LiveSession<'_> {
         operation: BooleanOperation,
         operands: &[Mobject],
     ) -> Result<ManimGeometryOptions, LiveSessionError> {
-        crate::boolean_authoring::prepare_boolean_options(
-            self.store,
-            operation,
-            operands,
-            || LiveSessionError::ForeignMobjectStore,
-            |store, object, mut state| {
-                if self.session.semantic_object_is_reachable(object.node_id()) {
-                    let observed = self
-                        .session
-                        .effective_semantic_object(store, object.node_id())?;
-                    if !observed.authored_content_layout_applicable() {
-                        return Err(crate::AuthoringError::Unsupported(
-                            crate::UnsupportedAuthoringOperation::EffectivePathRenderOverride,
-                        )
-                        .into());
-                    }
-                    state.transform =
-                        crate::semantic_mobject::semantic_transform_with_effective_affine(
-                            state.transform,
-                            observed.object.transform,
-                        );
+        let store = self.store.borrow();
+        crate::boolean_authoring::boolean_options(&store, operation, operands, |object| {
+            self.require_mobject(object)?;
+            let mut state = object.state()?;
+            if self.session.semantic_object_is_reachable(object.node_id()) {
+                let observed = self
+                    .session
+                    .effective_semantic_object(&store, object.node_id())?;
+                if !observed.authored_content_layout_applicable() {
+                    return Err(crate::AuthoringError::Unsupported(
+                        crate::UnsupportedAuthoringOperation::EffectivePathRenderOverride,
+                    )
+                    .into());
                 }
-                Ok(state)
-            },
-        )
+                state.transform = crate::semantic_mobject::semantic_transform_with_effective_affine(
+                    state.transform,
+                    observed.object.transform,
+                );
+            }
+            Ok(state)
+        })
     }
 }

--- a/crates/noon/src/live_session/boolean_geometry.rs
+++ b/crates/noon/src/live_session/boolean_geometry.rs
@@ -10,16 +10,16 @@ impl LiveSession<'_> {
         operation: BooleanOperation,
         operands: &[Mobject],
     ) -> Result<ManimGeometryOptions, LiveSessionError> {
-        let states = operands
-            .iter()
-            .map(|object| {
-                self.require_mobject(object)?;
-                let mut state = object.state()?;
+        crate::boolean_authoring::prepare_boolean_options(
+            self.store,
+            operation,
+            operands,
+            || LiveSessionError::ForeignMobjectStore,
+            |store, object, mut state| {
                 if self.session.semantic_object_is_reachable(object.node_id()) {
-                    let store = self.store.borrow();
                     let observed = self
                         .session
-                        .effective_semantic_object(&store, object.node_id())?;
+                        .effective_semantic_object(store, object.node_id())?;
                     if !observed.authored_content_layout_applicable() {
                         return Err(crate::AuthoringError::Unsupported(
                             crate::UnsupportedAuthoringOperation::EffectivePathRenderOverride,
@@ -33,9 +33,7 @@ impl LiveSession<'_> {
                         );
                 }
                 Ok(state)
-            })
-            .collect::<Result<Vec<_>, LiveSessionError>>()?;
-        crate::boolean_authoring::boolean_options(&self.store.borrow(), operation, &states)
-            .map_err(Into::into)
+            },
+        )
     }
 }

--- a/crates/noon/src/live_session/boolean_geometry.rs
+++ b/crates/noon/src/live_session/boolean_geometry.rs
@@ -24,10 +24,11 @@ impl LiveSession<'_> {
                     )
                     .into());
                 }
-                state.transform = crate::semantic_mobject::semantic_transform_with_effective_affine(
-                    state.transform,
-                    observed.object.transform,
-                );
+                state.transform =
+                    crate::semantic_mobject::semantic_transform_with_effective_affine(
+                        state.transform,
+                        observed.object.transform,
+                    );
             }
             Ok(state)
         })

--- a/crates/noon/src/live_session/boolean_geometry.rs
+++ b/crates/noon/src/live_session/boolean_geometry.rs
@@ -24,11 +24,10 @@ impl LiveSession<'_> {
                     )
                     .into());
                 }
-                state.transform =
-                    crate::semantic_mobject::semantic_transform_with_effective_affine(
-                        state.transform,
-                        observed.object.transform,
-                    );
+                state.transform = crate::semantic_mobject::semantic_transform_with_effective_affine(
+                    state.transform,
+                    observed.object.transform,
+                );
             }
             Ok(state)
         })

--- a/crates/noon/tests/boolean_geometry.rs
+++ b/crates/noon/tests/boolean_geometry.rs
@@ -98,6 +98,58 @@ fn live_boolean_constructor_observes_current_affine_without_copying_paint() {
 }
 
 #[test]
+fn live_boolean_constructor_rejects_active_content_override_atomically() {
+    use noon::{AnimationOptions, AuthoringError, LiveSessionError, UnsupportedAuthoringOperation};
+
+    let scene = Scene::new();
+    let a = scene.circle(1.).unwrap();
+    let b = scene.square(2.).unwrap();
+    let mut session = scene.execution_session().unwrap();
+    let mut live = scene.live(&mut session);
+    live.declare_and_activate_create(&a, AnimationOptions::new())
+        .unwrap();
+    let revision = scene.revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
+
+    let error = live
+        .boolean_geometry_options(Op::Union, &[a, b])
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        LiveSessionError::Authoring(AuthoringError::Unsupported(
+            UnsupportedAuthoringOperation::EffectivePathRenderOverride
+        ))
+    ));
+    assert_eq!(scene.revision(), revision);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
+}
+
+#[test]
+fn live_boolean_constructor_preserves_foreign_store_error() {
+    let scene = Scene::new();
+    let a = scene.square(2.).unwrap();
+    let foreign = Scene::new().square(2.).unwrap();
+    let mut session = scene.execution_session().unwrap();
+    let live = scene.live(&mut session);
+
+    assert!(matches!(
+        live.boolean_geometry_options(Op::Union, &[a, foreign]),
+        Err(noon::LiveSessionError::ForeignMobjectStore)
+    ));
+}
+
+#[test]
 fn paired_boolean_example_executes_through_shared_runtime() {
     let mut session = noon::example_scenes::boolean_geometry::session().unwrap();
     session.seek(0.1).unwrap();

--- a/crates/noon/tests/boolean_geometry.rs
+++ b/crates/noon/tests/boolean_geometry.rs
@@ -83,14 +83,19 @@ fn live_boolean_constructor_observes_current_affine_without_copying_paint() {
     let mut live = scene.live(&mut session);
     let segment = live.play_animation(&animation).unwrap();
     live.advance_segment_to(segment, 1.).unwrap();
-    let options = live
+    let authored_options =
+        ManimGeometryOptions::boolean_geometry(Op::Union, &[a.clone(), b.clone()]).unwrap();
+    let live_options = live
         .boolean_geometry_options(Op::Union, &[a.clone(), b.clone()])
         .unwrap();
-    // Options are a snapshot; later execution cannot move the captured region.
+    // Options are snapshots; later execution cannot move either captured region.
     live.advance_segment_to(segment, 2.).unwrap();
     live.complete_segment(segment).unwrap();
-    let result = live.create_manim_geometry(options).unwrap();
+    let authored_result = live.create_manim_geometry(authored_options).unwrap();
+    let result = live.create_manim_geometry(live_options).unwrap();
+    let authored_bounds = authored_result.layout_bounds().unwrap().unwrap();
     let bounds = result.layout_bounds().unwrap().unwrap();
+    assert_eq!((authored_bounds.min_x, authored_bounds.max_x), (-1., 1.));
     assert_eq!((bounds.min_x, bounds.max_x), (-1., 3.));
     assert_eq!(a.layout_bounds().unwrap().unwrap().max_x, 5.);
     live.add(&result).unwrap();


### PR DESCRIPTION
## Summary

Advances #1482 under the simplification pilot in #1480.

- parameterizes the existing boolean preparation helper with a caller-supplied operand snapshot closure;
- keeps authored mode on authored state with the existing same-store failure;
- keeps live mode on one coherent publication, overlaying only effective affine state for reachable operands;
- keeps detached live operands on authored state and explicitly rejects active render-content overrides;
- adds focused regressions that distinguish authored vs live midpoint snapshots, preserve live render-content override rejection/atomicity, and preserve `ForeignMobjectStore`;
- introduces no new context/provider/policy type, no new authority, and no public API change.

## Simplification accounting

Owned production files only, after canonical rustfmt:

- physical LOC: **87 -> 85 (-2)**;
- operand snapshot/collection pipelines: **2 -> 1**;
- explicit conditional branches: **3 -> 3**. These remain because each is a real policy boundary: authored provenance, live reachability, and live render-content override rejection. There are no duplicated operation-specific conditional branches left to remove in this slice.

The shared helper still owns the existing world-path extraction and `noon_geometry::boolean_paths` algorithm. The closure owns only the authored-vs-effective snapshot distinction.

## Architecture / locality

Semantic Scene remains authored/base authority; Runtime remains effective-state authority. The returned `ManimGeometryOptions` is still inert until ordinary geometry construction allocates a resource/identity. Preparation remains O(number of operands + their selected path geometry) and does not inspect unrelated scene content.

No temporary migration seam.

## Reuse lesson

The useful seam here is local and narrow: when an authored/live pair already shares its operation algorithm, letting that existing helper accept the mode-specific snapshot closure can remove the duplicate preparation pipeline without adding a new abstraction. This is evidence for the #1480 reconciliation, not a recommendation to introduce a general snapshot/context trait before comparing #1481/#1483.

## Validation

Exact head: `450a4f4b16036c6d8ce2a143f68807b404d5823e`.

Passed on the exact head:

- PR Fast Gate: `cargo fmt --all -- --check`;
- PR Fast Gate: `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
- PR Fast Gate: workspace/all-features Rust lib tests;
- PR Fast Gate: web preflight and browser fast checks;
- Architecture Ratchets;
- Layer Dependency Ratchet;
- Native Host Smoke.

The focused `crates/noon/tests/boolean_geometry.rs` integration regressions are compiled/type-checked by the all-targets clippy gate. This connector session cannot directly execute `cargo test -p noon --test boolean_geometry` because it has neither a materialized repository checkout nor workflow-dispatch capability; direct execution of that integration target is the only validation item not independently observed here.

Closes #1482
Refs #1480