### PR TITLE
Converge z-index mutation preparation

### DIFF
--- a/crates/noon/src/live_session/z_index.rs
+++ b/crates/noon/src/live_session/z_index.rs
@@ -29,11 +29,9 @@ impl LiveSession<'_> {
         value: f64,
         family: bool,
     ) -> Result<(), LiveSessionError> {
-        if !Rc::ptr_eq(self.store, source.integration_store()) {
-            return Err(crate::AuthoringError::ForeignStore.into());
-        }
+        let transaction =
+            source.z_index_transaction(self.store.borrow().identity(), value, family)?;
         self.session.require_published_store(&self.store.borrow())?;
-        let transaction = source.z_index_transaction(value, family)?;
         self.apply(transaction).map(|_| ())
     }
 }

--- a/crates/noon/src/z_index.rs
+++ b/crates/noon/src/z_index.rs
@@ -1,6 +1,6 @@
 //! Shared authored painter priority; the renderer consumes only derived order.
 use crate::{AuthoringError, LayoutAnchor, Mobject, MobjectFamily};
-use noon_core::SemanticMutationTransaction;
+use noon_core::{SemanticMutationTransaction, SemanticStoreIdentity};
 
 impl LayoutAnchor {
     /// Read the selected root's own priority, including non-rendered family roots.
@@ -18,7 +18,8 @@ impl LayoutAnchor {
 
     /// Set priority on the selected root and optionally all unique descendants.
     pub fn set_z_index(&self, value: f64, family: bool) -> Result<(), AuthoringError> {
-        self.z_index_transaction(value, family)?
+        let store = self.integration_store().borrow().identity();
+        self.z_index_transaction(store, value, family)?
             .apply(&mut self.integration_store().borrow_mut())
             .map(|_| ())
             .map_err(AuthoringError::from)
@@ -26,11 +27,14 @@ impl LayoutAnchor {
 
     pub(crate) fn z_index_transaction(
         &self,
+        store: SemanticStoreIdentity,
         value: f64,
         family: bool,
     ) -> Result<SemanticMutationTransaction, AuthoringError> {
+        if self.integration_store().borrow().identity() != store {
+            return Err(AuthoringError::ForeignStore);
+        }
         let id = self.resolve()?;
-        self.z_index()?;
         let mut transaction = SemanticMutationTransaction::new();
         if family {
             for node in self


### PR DESCRIPTION
Closes #1481

Parent: #1480

## Summary

- move z-index mutation provenance validation into the existing shared `z_index_transaction` operation using the semantic store identity;
- route both authored and live mutation through that same transaction preparation;
- keep live publication atomic through `LiveSession::apply(...)`;
- remove the redundant authored `self.z_index()?` mutation preflight and rely on the canonical semantic transaction preflight for authoring-node/value validation;
- leave the live read path distinct so reachable objects still observe effective runtime state while detached objects/family roots retain authored observation semantics.

No public API, renderer authority, execution publication rule, or family traversal semantics change.

## Deletion / convergence accounting

Measured only across the two owned production files, with physical source lines and explicit `if`/`else` branch sites:

- physical LOC: **105 -> 107** (`+2`);
- nonblank LOC: **98 -> 100** (`+2`);
- total explicit `if`/`else` branch sites: **5 -> 5**;
- duplicated mutation-path store/provenance validation branches: **2 -> 1**.

This pilot is therefore **convergence, not net-LOC deletion**. The deleted duplicated logic is the local foreign-store branch in `LiveSession::set_z_index`; mutation provenance is now checked once by `LayoutAnchor::z_index_transaction`. The redundant authored `self.z_index()?` mutation preflight is also deleted because the canonical `SemanticMutationTransaction` owns authoring-node and finite-z-index validation atomically at apply time.

The remaining `Rc::ptr_eq` branch in `LiveSession::z_index` is intentional: it belongs to the distinct live observation path, which must choose effective runtime state for reachable leaves while preserving authored observation for detached objects/non-rendered family roots.

## Scope / ownership audit

- production diff is limited to `crates/noon/src/z_index.rs` and `crates/noon/src/live_session/z_index.rs`;
- re-audited current `master` (`d9fd2da3f8672e87ca80cd0b366cd2c84277b4ae`) and open PR changed-file lists before editing;
- no open PR owns either z-index file. #1413 touches the parent `live_session.rs` for family-state replacement but does not touch this z-index seam.

## Focused behavior coverage

Existing tests already cover the requested behavior, so this PR does not add test-only code:

- `crates/noon/tests/z_index.rs`: authored/live propagation, leaf/family-root/family-wide semantics, NaN rollback/atomicity, foreign-store rejection, painter-order locality, admission/readmission;
- `crates/noon/tests/animated_priority.rs`: effective live z-index observation versus authored state during driven/animated priority.

## Validation

Green on the exact PR code head `f966fa149644c4396955d6684502216bc1954c62`:

- Layer Dependency Ratchet;
- Architecture Ratchets, including the local architecture entrypoint;
- PR Fast Gate end-to-end;
- Native Host Smoke;
- PR Fast Gate Rust unit tests: `cargo test --workspace --all-features --lib`;
- PR Fast Gate formatting: `cargo fmt --all -- --check`;
- PR Fast Gate clippy: `cargo clippy --workspace --all-targets --all-features -- -D warnings`.

Issue-specific acceptance was independently rerun on a validation-only branch rooted at the same PR code SHA; the validation commit adds only the temporary workflow file. Run: https://github.com/yongkyuns/noon/actions/runs/34670852134

All passed:

- `bash scripts/check.sh fast d9fd2da3f8672e87ca80cd0b366cd2c84277b4ae`;
- `cargo test -p noon --all-features --test z_index --test animated_priority -- --nocapture`;
- `cargo test -p noon --lib` — variance pass 1;
- `cargo test -p noon --lib` — variance pass 2.

No production/test files outside the #1481 boundary were needed.