### PR TITLE
Simplify authored/live path-alignment publication plumbing

### DIFF
--- a/crates/noon/src/live_session/path_alignment.rs
+++ b/crates/noon/src/live_session/path_alignment.rs
@@ -20,8 +20,8 @@ impl LiveSession<'_> {
             .publish(&mut store, |store, transaction| {
                 self.session
                     .apply_semantic_transaction_at_root(store, self.root, transaction)
-                    .map(|_| ())
                     .map_err(LiveSessionError::from)
-            })
+            })?;
+        Ok(())
     }
 }

--- a/crates/noon/src/live_session/path_alignment.rs
+++ b/crates/noon/src/live_session/path_alignment.rs
@@ -13,10 +13,10 @@ impl LiveSession<'_> {
         }
         self.session
             .require_resource_creation_at_root(&self.store.borrow(), self.root)?;
-        let a = self.capture_mobject_state(left)?;
-        let b = self.capture_mobject_state(right)?;
+        let left = (left.node_id(), self.capture_mobject_state(left)?);
+        let right = (right.node_id(), self.capture_mobject_state(right)?);
         let mut store = self.store.borrow_mut();
-        crate::path_alignment::prepare_alignment(&store, (left.node_id(), a), (right.node_id(), b))?
+        crate::path_alignment::prepare_alignment(&store, left, right)?
             .publish(&mut store, |store, transaction| {
                 self.session
                     .apply_semantic_transaction_at_root(store, self.root, transaction)

--- a/crates/noon/src/live_session/path_alignment.rs
+++ b/crates/noon/src/live_session/path_alignment.rs
@@ -16,12 +16,14 @@ impl LiveSession<'_> {
         let left = (left.node_id(), self.capture_mobject_state(left)?);
         let right = (right.node_id(), self.capture_mobject_state(right)?);
         let mut store = self.store.borrow_mut();
-        crate::path_alignment::prepare_alignment(&store, left, right)?
-            .publish(&mut store, |store, transaction| {
+        crate::path_alignment::prepare_alignment(&store, left, right)?.publish(
+            &mut store,
+            |store, transaction| {
                 self.session
                     .apply_semantic_transaction_at_root(store, self.root, transaction)
                     .map_err(LiveSessionError::from)
-            })?;
+            },
+        )?;
         Ok(())
     }
 }

--- a/crates/noon/src/path_alignment.rs
+++ b/crates/noon/src/path_alignment.rs
@@ -37,10 +37,10 @@ impl Mobject {
             return Ok(());
         }
         let mut store = self.integration_store().borrow_mut();
-        prepare_alignment(&store, (self.node_id(), left), (other.node_id(), right))?.publish(
-            &mut store,
-            |store, transaction| transaction.apply(store).map_err(AuthoringError::from),
-        )?;
+        prepare_alignment(&store, (self.node_id(), left), (other.node_id(), right))?
+            .publish(&mut store, |store, transaction| {
+                transaction.apply(store).map_err(AuthoringError::from)
+            })?;
         Ok(())
     }
 }

--- a/crates/noon/src/path_alignment.rs
+++ b/crates/noon/src/path_alignment.rs
@@ -39,12 +39,8 @@ impl Mobject {
         let mut store = self.integration_store().borrow_mut();
         prepare_alignment(&store, (self.node_id(), left), (other.node_id(), right))?.publish(
             &mut store,
-            |store, transaction| {
-                transaction
-                    .apply(store)
-                    .map(|_| ())
-                    .map_err(AuthoringError::from)
-            },
-        )
+            |store, transaction| transaction.apply(store).map_err(AuthoringError::from),
+        )?;
+        Ok(())
     }
 }

--- a/crates/noon/tests/path_alignment.rs
+++ b/crates/noon/tests/path_alignment.rs
@@ -1,4 +1,4 @@
-use noon::{ManimGeometryOptions, Scene, Vec2, VectorPath};
+use noon::{AnimationOptions, ManimGeometryOptions, Scene, Vec2, VectorPath};
 
 #[test]
 fn alignment_changes_only_selected_content_and_preserves_identity_style_and_bounds() {
@@ -56,10 +56,23 @@ fn foreign_or_nonvector_operand_cannot_partially_publish() {
     let a = scene.square(1.).unwrap();
     let foreign = Scene::new().circle(1.).unwrap();
     let revision = scene.revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
     let before = a.state().unwrap();
     assert!(a.align_points(&foreign).is_err());
     assert_eq!(a.state().unwrap(), before);
     assert_eq!(scene.revision(), revision);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
 }
 
 #[test]
@@ -79,6 +92,74 @@ fn live_alignment_publishes_both_operands_coherently() {
         live.effective_path_query(&a).unwrap().start().unwrap(),
         (1., 2.)
     );
+}
+
+#[test]
+fn live_self_alignment_is_noop_before_unsupported_current_capture() {
+    let scene = Scene::new();
+    let object = scene.circle(1.).unwrap();
+    let mut session = scene.execution_session().unwrap();
+    scene
+        .live(&mut session)
+        .declare_and_activate_create(&object, AnimationOptions::new())
+        .unwrap();
+    session.take_frame_changes();
+    let revision = scene.revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
+
+    scene
+        .live(&mut session)
+        .align_points(&object, &object)
+        .unwrap();
+
+    assert_eq!(scene.revision(), revision);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
+    assert!(session.take_frame_changes().is_empty());
+}
+
+#[test]
+fn live_foreign_alignment_fails_before_resource_or_frame_publication() {
+    let mut scene = Scene::new();
+    let object = scene.line((0., 0.), (3., 0.)).unwrap();
+    scene.add(&object).unwrap();
+    let foreign = Scene::new().square(2.).unwrap();
+    let mut session = scene.execution_session().unwrap();
+    session.take_frame_changes();
+    let before = object.state().unwrap();
+    let revision = scene.revision();
+    let resources = scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len();
+
+    assert!(scene
+        .live(&mut session)
+        .align_points(&object, &foreign)
+        .is_err());
+
+    assert_eq!(object.state().unwrap(), before);
+    assert_eq!(scene.revision(), revision);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .geometry_resources()
+            .len(),
+        resources
+    );
+    assert!(session.take_frame_changes().is_empty());
 }
 
 #[test]

--- a/crates/noon/tests/path_alignment.rs
+++ b/crates/noon/tests/path_alignment.rs
@@ -1,5 +1,13 @@
 use noon::{AnimationOptions, ManimGeometryOptions, Scene, Vec2, VectorPath};
 
+fn geometry_resource_count(scene: &Scene) -> usize {
+    scene
+        .integration_store()
+        .borrow()
+        .geometry_resources()
+        .len()
+}
+
 #[test]
 fn alignment_changes_only_selected_content_and_preserves_identity_style_and_bounds() {
     let scene = Scene::new();
@@ -32,22 +40,11 @@ fn alignment_changes_only_selected_content_and_preserves_identity_style_and_boun
     assert_eq!(b.state().unwrap(), before[1]);
     assert_eq!(unrelated.state().unwrap(), before[2]);
     let revision = scene.revision();
-    let resources = scene
-        .integration_store()
-        .borrow()
-        .geometry_resources()
-        .len();
+    let resources = geometry_resource_count(&scene);
     a.align_points(&b).unwrap();
     a.align_points(&a).unwrap();
     assert_eq!(scene.revision(), revision);
-    assert_eq!(
-        scene
-            .integration_store()
-            .borrow()
-            .geometry_resources()
-            .len(),
-        resources
-    );
+    assert_eq!(geometry_resource_count(&scene), resources);
 }
 
 #[test]
@@ -56,23 +53,12 @@ fn foreign_or_nonvector_operand_cannot_partially_publish() {
     let a = scene.square(1.).unwrap();
     let foreign = Scene::new().circle(1.).unwrap();
     let revision = scene.revision();
-    let resources = scene
-        .integration_store()
-        .borrow()
-        .geometry_resources()
-        .len();
+    let resources = geometry_resource_count(&scene);
     let before = a.state().unwrap();
     assert!(a.align_points(&foreign).is_err());
     assert_eq!(a.state().unwrap(), before);
     assert_eq!(scene.revision(), revision);
-    assert_eq!(
-        scene
-            .integration_store()
-            .borrow()
-            .geometry_resources()
-            .len(),
-        resources
-    );
+    assert_eq!(geometry_resource_count(&scene), resources);
 }
 
 #[test]
@@ -105,26 +91,12 @@ fn live_self_alignment_is_noop_before_unsupported_current_capture() {
         .unwrap();
     session.take_frame_changes();
     let revision = scene.revision();
-    let resources = scene
-        .integration_store()
-        .borrow()
-        .geometry_resources()
-        .len();
+    let resources = geometry_resource_count(&scene);
 
-    scene
-        .live(&mut session)
-        .align_points(&object, &object)
-        .unwrap();
+    scene.live(&mut session).align_points(&object, &object).unwrap();
 
     assert_eq!(scene.revision(), revision);
-    assert_eq!(
-        scene
-            .integration_store()
-            .borrow()
-            .geometry_resources()
-            .len(),
-        resources
-    );
+    assert_eq!(geometry_resource_count(&scene), resources);
     assert!(session.take_frame_changes().is_empty());
 }
 
@@ -138,27 +110,13 @@ fn live_foreign_alignment_fails_before_resource_or_frame_publication() {
     session.take_frame_changes();
     let before = object.state().unwrap();
     let revision = scene.revision();
-    let resources = scene
-        .integration_store()
-        .borrow()
-        .geometry_resources()
-        .len();
+    let resources = geometry_resource_count(&scene);
 
-    assert!(scene
-        .live(&mut session)
-        .align_points(&object, &foreign)
-        .is_err());
+    assert!(scene.live(&mut session).align_points(&object, &foreign).is_err());
 
     assert_eq!(object.state().unwrap(), before);
     assert_eq!(scene.revision(), revision);
-    assert_eq!(
-        scene
-            .integration_store()
-            .borrow()
-            .geometry_resources()
-            .len(),
-        resources
-    );
+    assert_eq!(geometry_resource_count(&scene), resources);
     assert!(session.take_frame_changes().is_empty());
 }
 

--- a/crates/noon/tests/path_alignment.rs
+++ b/crates/noon/tests/path_alignment.rs
@@ -93,7 +93,10 @@ fn live_self_alignment_is_noop_before_unsupported_current_capture() {
     let revision = scene.revision();
     let resources = geometry_resource_count(&scene);
 
-    scene.live(&mut session).align_points(&object, &object).unwrap();
+    scene
+        .live(&mut session)
+        .align_points(&object, &object)
+        .unwrap();
 
     assert_eq!(scene.revision(), revision);
     assert_eq!(geometry_resource_count(&scene), resources);
@@ -112,7 +115,10 @@ fn live_foreign_alignment_fails_before_resource_or_frame_publication() {
     let revision = scene.revision();
     let resources = geometry_resource_count(&scene);
 
-    assert!(scene.live(&mut session).align_points(&object, &foreign).is_err());
+    assert!(scene
+        .live(&mut session)
+        .align_points(&object, &foreign)
+        .is_err());
 
     assert_eq!(object.state().unwrap(), before);
     assert_eq!(scene.revision(), revision);


### PR DESCRIPTION
## Summary

- keep authored state capture and live effective-state capture explicit in their existing owners
- keep `PreparedPathEdits::publish` as the single existing immutable-resource admission seam
- remove duplicate `map(|_| ())` adaptation from both authored/live publication closures; each closure now returns its native publication receipt and the public `align_points` boundary discards it once
- keep the live `(node_id, effective_state)` pairs explicit before publication so the shared preparation call stays compact without hiding the capture contract
- add focused regression coverage for authored resource atomicity, live self/alias no-op before unsupported current-content capture, and live foreign-store resource/frame atomicity

No path correspondence/subdivision logic, `PreparedPathEdits`, path-query code, execution publication, or public API is changed.

## Complexity delta

Owned production modules only:

- physical LOC: **77 -> 75** (`-2`)
- explicit `if` branches: **5 -> 5**
- type definitions: **0 -> 0**
- production files: **2 -> 2**
- new traits/context/policy types: **0**

The necessary authored-vs-live differences remain visible: authored capture uses authored semantic state; live capture still uses one coherent effective/current context; and each owner still selects its existing commit path.

## Validation

Focused `crates/noon/tests/path_alignment.rs` coverage now includes:

- authored/live successful alignment
- repeated/self alignment no-op and resource stability
- live self alignment while effective content is unsupported for capture
- authored/live foreign-store rejection before resource/frame mutation
- coherent live effective-state capture
- empty/null geometry and closed-contour behavior

PR CI is the execution environment for the repository gates; no automated Codex review is requested.

## #1480 lesson

This pilot does **not** justify another per-operation publication abstraction. `PreparedPathEdits::publish` already owns the resource-admission invariant. The remaining meaningful difference is the context-owned commit closure (semantic-only authored apply vs semantic/execution/runtime live apply). A future single prepared-operation publication seam should reduce that central commit protocol rather than introduce a path-alignment policy/trait layer.

Closes #1483