### PR TITLE
feat: add static SVG authoring foundation

### DIFF
--- a/.github/workflows/manim-svg-raster-differential.yml
+++ b/.github/workflows/manim-svg-raster-differential.yml
@@ -1,0 +1,120 @@
+name: Static SVG Manim raster qualification
+
+on:
+  pull_request:
+    paths:
+      - "crates/noon/src/svg_authoring.rs"
+      - "crates/noon-web/src/authoring_svg.rs"
+      - "web/python/_manim_svg.py"
+      - "web/python/noon.py"
+      - "parity/manim-v0.21/core-examples/svg_static_import.py"
+      - "parity/manim-v0.21/svg-manifest.json"
+      - "scripts/manim-raster-differential.mjs"
+      - "scripts/manim-raster-enforce.mjs"
+      - ".github/workflows/manim-svg-raster-differential.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manim-svg-raster-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  NOON_WASM_SKIP_OPT: "1"
+
+jobs:
+  svg-raster:
+    name: Static SVG vs ManimCE 0.21.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install Manim system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            libcairo2-dev \
+            libpango1.0-dev \
+            pkg-config
+
+      - name: Install pinned ManimCE reference
+        run: python -m pip install --disable-pip-version-check "manim[typst]==0.21.0" "typst==0.15.0"
+
+      - name: Use repository-pinned Rust and WASM target
+        run: |
+          rustup install
+          rustup show active-toolchain
+          rustc --version --verbose
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install pinned wasm-pack
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+
+      - name: Build browser package
+        run: bash scripts/build-web-demo.sh
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install raster harness dependencies
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+
+      - name: Select bounded SVG qualification manifest
+        run: |
+          cp parity/manim-v0.21/manifest.json "$RUNNER_TEMP/full-manim-manifest.json"
+          cp parity/manim-v0.21/svg-manifest.json parity/manim-v0.21/manifest.json
+
+      - name: Render canonical SVG with Manim and Noon
+        env:
+          NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_RASTER_ARTIFACTS: manim-svg-raster-artifacts
+        run: |
+          status=0
+          node scripts/manim-raster-differential.mjs > "$RUNNER_TEMP/noon-svg-raster.log" 2>&1 || status=$?
+          tail -n 120 "$RUNNER_TEMP/noon-svg-raster.log"
+          exit "$status"
+
+      - name: Capture semantic state at Manim frame times
+        env:
+          NOON_MANIM_RASTER_ARTIFACTS: manim-svg-raster-artifacts
+        run: node scripts/manim-raster-semantic-state.mjs
+
+      - name: Enforce canonical SVG raster ratchet
+        env:
+          NOON_MANIM_RASTER_ARTIFACTS: manim-svg-raster-artifacts
+        run: node scripts/manim-raster-enforce.mjs
+
+      - name: Verify sparse and dense playback at Manim frame times
+        env:
+          NOON_MANIM_RASTER_BACKENDS: webgpu,webgl
+          NOON_MANIM_RASTER_ARTIFACTS: manim-svg-raster-artifacts
+        run: node scripts/shared-playback-raster.mjs
+
+      - name: Upload SVG qualification evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: static-svg-manim-raster
+          path: |
+            manim-svg-raster-artifacts
+            ${{ runner.temp }}/noon-svg-raster.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -209,6 +209,17 @@ jobs:
           echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Check SVG authoring
+        id: svg-authoring
+        run: |
+          SECONDS=0
+          set +e
+          node scripts/svg-authoring-smoke.mjs
+          status=$?
+          set -e
+          echo "seconds=$SECONDS" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
       - name: Check shared mixed execution and recovery
         if: steps.browser-risk.outputs.retained_execution == 'true'
         id: retained-execution
@@ -271,6 +282,7 @@ jobs:
           COLD_START_SECONDS: ${{ steps.cold-start.outputs.seconds }}
           REPLAY_SECONDS: ${{ steps.deterministic-replay.outputs.seconds }}
           AUTHORING_SECONDS: ${{ steps.manim-authoring.outputs.seconds }}
+          SVG_SECONDS: ${{ steps.svg-authoring.outputs.seconds }}
           RETAINED_REQUIRED: ${{ steps.browser-risk.outputs.retained_execution }}
           RETAINED_SECONDS: ${{ steps.retained-execution.outputs.seconds }}
           WEBGPU_SECONDS: ${{ steps.webgpu-smoke.outputs.seconds }}
@@ -316,6 +328,7 @@ jobs:
             echo "| Preloaded cold start | $cold_start_duration |"
             echo "| Deterministic replay | $(display_seconds "$REPLAY_SECONDS") |"
             echo "| Manim authoring | $(display_seconds "$AUTHORING_SECONDS") |"
+            echo "| SVG authoring | $(display_seconds "$SVG_SECONDS") |"
             echo "| Shared mixed execution and recovery | $retained_duration |"
             echo "| WebGPU smoke | $(display_seconds "$WEBGPU_SECONDS") |"
             echo "| WebGL renderer-risk smoke | $webgl_duration |"

--- a/crates/noon-web/src/authoring_svg.rs
+++ b/crates/noon-web/src/authoring_svg.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    authoring_error::{js_error, AuthoringFailure}, WasmAuthoringFamilyHandle,
-    WasmAuthoringMobjectHandle, WasmAuthoringStore,
+    authoring_error::{js_error, AuthoringFailure},
+    WasmAuthoringFamilyHandle, WasmAuthoringMobjectHandle, WasmAuthoringStore,
 };
 
 impl From<noon::SvgAuthoringError> for AuthoringFailure {
@@ -20,9 +20,7 @@ impl From<noon::SvgAuthoringError> for AuthoringFailure {
         match error {
             E::Xml(_) => Self::new("invalid_input", "svg.invalid_xml", message),
             E::Parse(_) => Self::new("invalid_input", "svg.parse", message),
-            E::Unsupported(_) => {
-                Self::new("unsupported_operation", "svg.unsupported", message)
-            }
+            E::Unsupported(_) => Self::new("unsupported_operation", "svg.unsupported", message),
             E::InvalidTargetDimension { .. } => {
                 Self::new("invalid_input", "svg.invalid_target_dimension", message)
             }

--- a/crates/noon-web/src/authoring_svg.rs
+++ b/crates/noon-web/src/authoring_svg.rs
@@ -35,6 +35,7 @@ impl From<noon::SvgAuthoringError> for AuthoringFailure {
                     cause: Some(Box::new(nested)),
                 }
             }
+            _ => Self::new("invalid_input", "svg.authoring", message),
         }
     }
 }

--- a/crates/noon-web/src/authoring_svg.rs
+++ b/crates/noon-web/src/authoring_svg.rs
@@ -1,0 +1,87 @@
+//! SVG-specific adaptation at the optional browser authoring boundary.
+//!
+//! Parsing, compatibility defaults, geometry, styles and semantic publication all
+//! stay in `noon`. This module only supplies existing store/family handles to that
+//! shared Rust importer and rewraps authoritative SVG leaves for the host language.
+
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    authoring_error::{js_error, AuthoringFailure}, WasmAuthoringFamilyHandle,
+    WasmAuthoringMobjectHandle, WasmAuthoringStore,
+};
+
+impl From<noon::SvgAuthoringError> for AuthoringFailure {
+    fn from(error: noon::SvgAuthoringError) -> Self {
+        use noon::SvgAuthoringError as E;
+        let message = error.to_string();
+        match error {
+            E::Xml(_) => Self::new("invalid_input", "svg.invalid_xml", message),
+            E::Parse(_) => Self::new("invalid_input", "svg.parse", message),
+            E::Unsupported(_) => {
+                Self::new("unsupported_operation", "svg.unsupported", message)
+            }
+            E::InvalidTargetDimension { .. } => {
+                Self::new("invalid_input", "svg.invalid_target_dimension", message)
+            }
+            E::Authoring(cause) => {
+                let nested = AuthoringFailure::from(cause);
+                Self {
+                    category: nested.category,
+                    code: "svg.authoring",
+                    message,
+                    cause: Some(Box::new(nested)),
+                }
+            }
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl WasmAuthoringStore {
+    /// Import static SVG source into this store as one retained semantic family.
+    #[wasm_bindgen(js_name = createSvgFromString)]
+    pub fn create_svg_from_string(
+        &self,
+        source: &str,
+        should_center: bool,
+        height: Option<f64>,
+        width: Option<f64>,
+    ) -> Result<WasmAuthoringFamilyHandle, JsValue> {
+        noon::MobjectFamily::from_svg_str_with_options(
+            Rc::clone(&self.semantics),
+            source,
+            noon::SvgImportOptions {
+                should_center,
+                height,
+                width,
+            },
+        )
+        .map(WasmAuthoringFamilyHandle::from_semantic_family)
+        .map_err(js_error)
+    }
+}
+
+#[wasm_bindgen]
+impl WasmAuthoringFamilyHandle {
+    /// Rewrap one authoritative direct object member without copying geometry.
+    #[wasm_bindgen(js_name = memberMobject)]
+    pub fn member_mobject(&self, index: usize) -> Result<WasmAuthoringMobjectHandle, JsValue> {
+        let family = self.semantic_family()?;
+        let store = Rc::clone(family.integration_store());
+        let member = {
+            let borrowed = store.borrow();
+            borrowed
+                .semantic_family_members_checked(family.node_id())
+                .map_err(js_error)?
+                .get(index)
+                .copied()
+                .ok_or_else(|| JsValue::from_str("family member index is out of bounds"))?
+        };
+        noon::Mobject::from_node(store, member)
+            .map(WasmAuthoringMobjectHandle::from_semantic_mobject)
+            .map_err(js_error)
+    }
+}

--- a/crates/noon-web/src/lib.rs
+++ b/crates/noon-web/src/lib.rs
@@ -12,6 +12,8 @@ mod authoring_geometry;
 mod authoring_mobject;
 mod authoring_options;
 #[cfg(target_arch = "wasm32")]
+mod authoring_svg;
+#[cfg(target_arch = "wasm32")]
 mod authoring_tangent_line;
 mod canonical_authoring_scene;
 mod clock;

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -8,6 +8,7 @@ mod wasm {
     };
     use noon_runtime::FrameChanges;
     use wasm_bindgen::prelude::*;
+    use wasm_bindgen_futures::future_to_promise;
     use web_sys::OffscreenCanvas;
 
     use crate::{
@@ -459,24 +460,29 @@ mod wasm {
         /// Flush one WebGPU validation error scope into the shared diagnostic mailbox.
         ///
         /// Browser worker uncaptured-error delivery is not a reliable scheduling
-        /// boundary. Keep validation recoverable by explicitly closing the current
-        /// device scope at an async host-control boundary, re-arming it immediately,
-        /// and publishing any captured error through the same generation-aware mailbox
-        /// used by direct hosts. OOM/internal errors remain on the uncaptured fatal path.
+        /// boundary. Close the current device scope synchronously while the renderer
+        /// is borrowed, re-arm it immediately, then await the detached pop future.
+        /// The returned Promise therefore never keeps the wasm-bindgen renderer
+        /// mutably borrowed across an await, so frame/transport callbacks can keep
+        /// using the same renderer while validation delivery is pending.
         #[wasm_bindgen(js_name = flushGpuDiagnostics)]
-        pub async fn flush_gpu_diagnostics(&mut self) -> Result<bool, JsValue> {
+        pub fn flush_gpu_diagnostics(&mut self) -> js_sys::Promise {
             let Some(scope) = self.gpu_validation_scope.take() else {
-                return Ok(false);
+                return future_to_promise(async { Ok(JsValue::from_bool(false)) });
             };
             let pending = scope.pop();
             self.gpu_validation_scope =
                 Some(self.device.push_error_scope(wgpu::ErrorFilter::Validation));
-            let Some(error) = pending.await else {
-                return Ok(false);
-            };
-            self.gpu_diagnostics
-                .record_wgpu(self.gpu_generation, self.backend, error);
-            Ok(true)
+            let gpu_diagnostics = self.gpu_diagnostics.clone();
+            let gpu_generation = self.gpu_generation;
+            let backend = self.backend;
+            future_to_promise(async move {
+                let Some(error) = pending.await else {
+                    return Ok(JsValue::from_bool(false));
+                };
+                gpu_diagnostics.record_wgpu(gpu_generation, backend, error);
+                Ok(JsValue::from_bool(true))
+            })
         }
 
         #[wasm_bindgen(js_name = takeGpuDiagnosticJson)]

--- a/crates/noon-web/src/retained_execution_canvas.rs
+++ b/crates/noon-web/src/retained_execution_canvas.rs
@@ -8,7 +8,6 @@ mod wasm {
     };
     use noon_runtime::FrameChanges;
     use wasm_bindgen::prelude::*;
-    use wasm_bindgen_futures::future_to_promise;
     use web_sys::OffscreenCanvas;
 
     use crate::{
@@ -459,28 +458,27 @@ mod wasm {
 
         /// Flush one WebGPU validation error scope into the shared diagnostic mailbox.
         ///
-        /// Browser worker uncaptured-error delivery is not a reliable scheduling
-        /// boundary. Close the current device scope synchronously while the renderer
-        /// is borrowed, re-arm it immediately, then await the detached pop future.
-        /// The returned Promise therefore never keeps the wasm-bindgen renderer
-        /// mutably borrowed across an await, so frame/transport callbacks can keep
-        /// using the same renderer while validation delivery is pending.
+        /// Pop and re-arm the scope synchronously so the wasm-bindgen `&mut self`
+        /// borrow ends before JavaScript awaits the result. The returned promise owns
+        /// only the popped wgpu future and immutable diagnostic metadata, allowing
+        /// engine-port delta/render messages to use this renderer while the browser
+        /// resolves `popErrorScope()`.
         #[wasm_bindgen(js_name = flushGpuDiagnostics)]
         pub fn flush_gpu_diagnostics(&mut self) -> js_sys::Promise {
             let Some(scope) = self.gpu_validation_scope.take() else {
-                return future_to_promise(async { Ok(JsValue::from_bool(false)) });
+                return js_sys::Promise::resolve(&JsValue::from_bool(false));
             };
             let pending = scope.pop();
             self.gpu_validation_scope =
                 Some(self.device.push_error_scope(wgpu::ErrorFilter::Validation));
-            let gpu_diagnostics = self.gpu_diagnostics.clone();
-            let gpu_generation = self.gpu_generation;
+            let diagnostics = self.gpu_diagnostics.clone();
+            let generation = self.gpu_generation;
             let backend = self.backend;
-            future_to_promise(async move {
+            wasm_bindgen_futures::future_to_promise(async move {
                 let Some(error) = pending.await else {
                     return Ok(JsValue::from_bool(false));
                 };
-                gpu_diagnostics.record_wgpu(gpu_generation, backend, error);
+                diagnostics.record_wgpu(generation, backend, error);
                 Ok(JsValue::from_bool(true))
             })
         }

--- a/crates/noon/Cargo.toml
+++ b/crates/noon/Cargo.toml
@@ -36,3 +36,4 @@ noon-text = { path = "../noon-text", optional = true }
 noon-typst = { path = "../noon-typst", optional = true, default-features = false }
 swash = { version = "=0.2.10", optional = true }
 typst-assets = { version = "=0.15.1", features = ["fonts"], optional = true }
+usvg = { version = "=0.48.1", default-features = false }

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -44,7 +44,7 @@
 //! fn raw(object: &noon::Mobject) { let _ = object.store(); }
 //! ```
 //!
-//! ```compile_fail,E0599
+//! ```compile_fail,E0593
 //! fn raw(family: &noon::MobjectFamily) { let _ = family.store(); }
 //! ```
 
@@ -204,8 +204,9 @@ pub mod prelude {
         LiveProgram, LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions,
         ManimArrowVectorField, Mobject, MobjectFamily, MobjectFamilyMember, NativeBoolSignal,
         NativeVectorSignal, RateFunction, Scene, SemanticObjectState, SemanticStyle,
-        StoredGeometry, SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature, TrackerPosition,
-        ValueTracker, Vec2, VectorFieldAxisRange, VectorFieldPoint, VectorFieldRanges2D, VectorPath,
+        StoredGeometry, SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature,
+        TrackerPosition, ValueTracker, Vec2, VectorFieldAxisRange, VectorFieldPoint,
+        VectorFieldRanges2D, VectorPath,
     };
 }
 

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -99,6 +99,7 @@ mod scene_ordering;
 mod sector_authoring;
 mod semantic_mobject;
 mod state_replacement;
+mod svg_authoring;
 mod tangent_line_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_authoring;
@@ -180,6 +181,7 @@ pub use scene::Scene;
 pub use scene_membership::SceneMembershipRequest;
 pub use semantic_mobject::{ManimGeometryOptions, ManimLineEndpoints, ManimNextToArgs, Mobject};
 pub use state_replacement::ManimBecomeOptions;
+pub use svg_authoring::{SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature};
 #[cfg(any(feature = "native-text", feature = "typst"))]
 pub use text_authoring::TextAuthoringError;
 #[cfg(feature = "typst")]
@@ -202,8 +204,8 @@ pub mod prelude {
         LiveProgram, LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions,
         ManimArrowVectorField, Mobject, MobjectFamily, MobjectFamilyMember, NativeBoolSignal,
         NativeVectorSignal, RateFunction, Scene, SemanticObjectState, SemanticStyle,
-        StoredGeometry, TrackerPosition, ValueTracker, Vec2, VectorFieldAxisRange,
-        VectorFieldPoint, VectorFieldRanges2D, VectorPath,
+        StoredGeometry, SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature, TrackerPosition,
+        ValueTracker, Vec2, VectorFieldAxisRange, VectorFieldPoint, VectorFieldRanges2D, VectorPath,
     };
 }
 

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -44,7 +44,7 @@
 //! fn raw(object: &noon::Mobject) { let _ = object.store(); }
 //! ```
 //!
-//! ```compile_fail,E0593
+//! ```compile_fail,E0599
 //! fn raw(family: &noon::MobjectFamily) { let _ = family.store(); }
 //! ```
 

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -322,12 +322,10 @@ fn is_unsupported_element(name: &str) -> bool {
 
 fn css_declares_non_none(style: &str, property: &str) -> bool {
     style.split(';').any(|declaration| {
-        declaration
-            .split_once(':')
-            .is_some_and(|(name, value)| {
-                name.trim().eq_ignore_ascii_case(property)
-                    && !value.trim().eq_ignore_ascii_case("none")
-            })
+        declaration.split_once(':').is_some_and(|(name, value)| {
+            name.trim().eq_ignore_ascii_case(property)
+                && !value.trim().eq_ignore_ascii_case("none")
+        })
     })
 }
 
@@ -524,10 +522,7 @@ fn prepare_vector_path(path: &usvg::Path) -> Result<VectorPath, SvgAuthoringErro
     Ok(result)
 }
 
-fn svg_point(
-    mut point: usvg::tiny_skia_path::Point,
-    transform: usvg::Transform,
-) -> Vec2 {
+fn svg_point(mut point: usvg::tiny_skia_path::Point, transform: usvg::Transform) -> Vec2 {
     transform.map_point(&mut point);
     // SVG canvas coordinates grow down; Manim/Noon scene coordinates grow up.
     Vec2::new(point.x, -point.y)
@@ -613,12 +608,12 @@ mod tests {
             scene.revision(),
             before.checked_next().expect("one SVG publication revision")
         );
-        let members = scene
-            .integration_store()
-            .borrow()
+        let store = scene.integration_store().borrow();
+        let members = store
             .semantic_family_members_checked(family.node_id())
             .unwrap();
         assert_eq!(members.len(), 2);
+        drop(store);
         let bounds = family.layout_bounds().unwrap().unwrap();
         assert!((bounds.height() - 2.0).abs() < 1e-5);
         assert!((bounds.min_x + bounds.max_x).abs() < 1e-5);
@@ -634,16 +629,15 @@ mod tests {
         let family = scene
             .svg_from_str_with_options(svg, raw_options())
             .unwrap();
-        let member = scene
-            .integration_store()
-            .borrow()
+        let store = scene.integration_store().borrow();
+        let member = store
             .semantic_family_members_checked(family.node_id())
             .unwrap()[0];
+        drop(store);
         let object = crate::Mobject::from_node(Rc::clone(scene.integration_store()), member).unwrap();
-        let path = object.path_query().unwrap().path().unwrap();
-        let commands = path.commands();
-        assert_eq!(commands[0], noon_core::PathCommand::MoveTo { to: Vec2::new(4.0, -7.0) });
-        assert_eq!(commands[1], noon_core::PathCommand::LineTo { to: Vec2::new(7.0, -7.0) });
+        let query = object.path_query().unwrap();
+        assert_eq!(query.start().unwrap(), (4.0, -7.0));
+        assert_eq!(query.end().unwrap(), (7.0, -7.0));
     }
 
     #[test]

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -14,6 +14,7 @@ use noon_core::{
 use std::rc::Rc;
 
 const MANIM_DEFAULT_STROKE_WIDTH_SENTINEL: f32 = 0.000_001;
+const MANIM_CAIRO_LINE_WIDTH_MULTIPLE: f64 = 0.01;
 
 /// Positioning applied after SVG parsing.
 ///
@@ -486,7 +487,7 @@ fn prepare_style(path: &usvg::Path) -> Result<SemanticStyle, SvgAuthoringError> 
             let width = if resolved_width == MANIM_DEFAULT_STROKE_WIDTH_SENTINEL {
                 0.0
             } else {
-                f64::from(resolved_width)
+                f64::from(resolved_width) * MANIM_CAIRO_LINE_WIDTH_MULTIPLE
             };
             (
                 Some(SemanticPaint::Solid(solid_paint(stroke.paint())?)),
@@ -696,7 +697,7 @@ mod tests {
         );
         assert!((state.style.fill_opacity - 0.25).abs() < 1e-6);
         assert!((state.style.stroke_opacity - 0.5).abs() < 1e-6);
-        assert!((state.style.stroke_width - 2.0).abs() < 1e-6);
+        assert!((state.style.stroke_width - 0.02).abs() < 1e-6);
     }
 
     #[test]
@@ -715,7 +716,7 @@ mod tests {
         let defaulted = store.semantic_object_state_checked(members[0]).unwrap();
         let explicit = store.semantic_object_state_checked(members[1]).unwrap();
         assert_eq!(defaulted.style.stroke_width, 0.0);
-        assert_eq!(explicit.style.stroke_width, 3.0);
+        assert!((explicit.style.stroke_width - 0.03).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -1,0 +1,709 @@
+//! Static SVG import lowered into ordinary retained Noon vector geometry.
+//!
+//! Parsing and normalization happen entirely at author time. Supported leaves are
+//! published as the same immutable `VectorPath` resources and semantic family
+//! identities used by native geometry; no SVG-specific runtime or renderer state
+//! exists below this module.
+
+use crate::{AuthoringError, MobjectFamily, Scene};
+use noon_core::{
+    semantic_path_bounds, Color, SemanticMutationTransaction, SemanticNodeCreation,
+    SemanticObjectState, SemanticPaint, SemanticStyle, SemanticTransform2_5D, SemanticVec3,
+    StoredGeometry, StrokeCap, StrokeJoin, StrokeWidthMode, Vec2, VectorPath,
+};
+use std::rc::Rc;
+
+/// Positioning applied after SVG parsing.
+///
+/// The default mirrors Manim's `SVGMobject` placement contract: flip SVG's Y axis,
+/// center the imported point bounds, and scale the aggregate height to two scene
+/// units. Set both `height` and `width` to `None` to retain parsed SVG dimensions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SvgImportOptions {
+    pub should_center: bool,
+    pub height: Option<f64>,
+    pub width: Option<f64>,
+}
+
+impl Default for SvgImportOptions {
+    fn default() -> Self {
+        Self {
+            should_center: true,
+            height: Some(2.0),
+            width: None,
+        }
+    }
+}
+
+/// SVG behavior that this bounded importer refuses rather than approximating.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SvgUnsupportedFeature {
+    Element(String),
+    VectorEffect,
+    GroupOpacity,
+    BlendMode,
+    Isolation,
+    ClipPath,
+    Mask,
+    Filter,
+    Image,
+    Text,
+    GradientPaint,
+    PatternPaint,
+    EvenOddFillRule,
+    StrokeDash,
+    StrokeMiterClip,
+    StrokeMiterLimit,
+    StrokeFirstPaintOrder,
+    ShapeRendering,
+}
+
+impl std::fmt::Display for SvgUnsupportedFeature {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Element(name) => write!(formatter, "unsupported SVG element <{name}>"),
+            Self::VectorEffect => formatter.write_str("SVG vector-effect is not supported"),
+            Self::GroupOpacity => formatter.write_str("SVG group opacity is not supported"),
+            Self::BlendMode => formatter.write_str("SVG blend modes are not supported"),
+            Self::Isolation => formatter.write_str("SVG isolation is not supported"),
+            Self::ClipPath => formatter.write_str("SVG clip paths are not supported"),
+            Self::Mask => formatter.write_str("SVG masks are not supported"),
+            Self::Filter => formatter.write_str("SVG filters are not supported"),
+            Self::Image => formatter.write_str("SVG image nodes are not supported in vector import"),
+            Self::Text => formatter.write_str("SVG text nodes are not supported in vector import"),
+            Self::GradientPaint => formatter.write_str("SVG gradient paints are not supported"),
+            Self::PatternPaint => formatter.write_str("SVG pattern paints are not supported"),
+            Self::EvenOddFillRule => formatter.write_str("SVG even-odd fill is not supported"),
+            Self::StrokeDash => formatter.write_str("SVG dashed strokes are not supported"),
+            Self::StrokeMiterClip => formatter.write_str("SVG miter-clip joins are not supported"),
+            Self::StrokeMiterLimit => {
+                formatter.write_str("non-default SVG stroke miter limits are not supported")
+            }
+            Self::StrokeFirstPaintOrder => {
+                formatter.write_str("SVG stroke-before-fill paint order is not supported")
+            }
+            Self::ShapeRendering => {
+                formatter.write_str("non-default SVG shape-rendering is not supported")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SvgUnsupportedFeature {}
+
+/// Deterministic failure from static SVG preparation or semantic publication.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum SvgAuthoringError {
+    Xml(usvg::roxmltree::Error),
+    Parse(usvg::Error),
+    Unsupported(SvgUnsupportedFeature),
+    InvalidTargetDimension { name: &'static str, value: f64 },
+    Authoring(AuthoringError),
+}
+
+impl std::fmt::Display for SvgAuthoringError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Xml(error) => error.fmt(formatter),
+            Self::Parse(error) => error.fmt(formatter),
+            Self::Unsupported(error) => error.fmt(formatter),
+            Self::InvalidTargetDimension { name, .. } => {
+                write!(formatter, "SVG target {name} must be finite and positive")
+            }
+            Self::Authoring(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SvgAuthoringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Xml(error) => Some(error),
+            Self::Parse(error) => Some(error),
+            Self::Unsupported(error) => Some(error),
+            Self::Authoring(error) => Some(error),
+            Self::InvalidTargetDimension { .. } => None,
+        }
+    }
+}
+
+impl From<AuthoringError> for SvgAuthoringError {
+    fn from(error: AuthoringError) -> Self {
+        Self::Authoring(error)
+    }
+}
+
+impl From<noon_core::GeometryResourceError> for SvgAuthoringError {
+    fn from(error: noon_core::GeometryResourceError) -> Self {
+        Self::Authoring(AuthoringError::GeometryResource(error))
+    }
+}
+
+struct PreparedSvgLeaf {
+    path: VectorPath,
+    style: SemanticStyle,
+}
+
+struct PreparedSvg {
+    leaves: Vec<PreparedSvgLeaf>,
+    transform: SemanticTransform2_5D,
+}
+
+impl Scene {
+    /// Parse one static SVG string into a detached semantic family.
+    ///
+    /// Supported content is normalized before one atomic semantic publication.
+    /// The returned family and its leaves are ordinary Noon identities backed by
+    /// immutable geometry resources; later transforms/styles never reparse SVG.
+    pub fn svg_from_str(&self, source: &str) -> Result<MobjectFamily, SvgAuthoringError> {
+        self.svg_from_str_with_options(source, SvgImportOptions::default())
+    }
+
+    /// Parse one static SVG string with explicit post-import placement options.
+    pub fn svg_from_str_with_options(
+        &self,
+        source: &str,
+        options: SvgImportOptions,
+    ) -> Result<MobjectFamily, SvgAuthoringError> {
+        let prepared = prepare_svg(source, options)?;
+        let store_rc = Rc::clone(self.integration_store());
+        let mut paths = Vec::with_capacity(prepared.leaves.len());
+        let mut styles = Vec::with_capacity(prepared.leaves.len());
+        for leaf in prepared.leaves {
+            paths.push(leaf.path);
+            styles.push(leaf.style);
+        }
+
+        let family_id = {
+            let mut store = store_rc.borrow_mut();
+            store.with_geometry_paths(paths, |store, handles| {
+                let mut transaction = SemanticMutationTransaction::new();
+                let family = transaction.create_node(SemanticNodeCreation::family());
+                for (handle, style) in handles.iter().copied().zip(styles.into_iter()) {
+                    let mut state = SemanticObjectState::new(StoredGeometry::Resource(handle));
+                    state.transform = prepared.transform;
+                    state.style = style;
+                    let object = transaction.create_node(SemanticNodeCreation::object(state));
+                    transaction.add_member(family, object);
+                }
+                let result = transaction
+                    .apply(store)
+                    .map_err(AuthoringError::from)
+                    .map_err(SvgAuthoringError::from)?;
+                result.resolve(family).ok_or_else(|| {
+                    SvgAuthoringError::Authoring(AuthoringError::UnresolvedCreatedNode(family))
+                })
+            })?
+        };
+
+        MobjectFamily::from_node(store_rc, family_id).map_err(SvgAuthoringError::from)
+    }
+}
+
+fn prepare_svg(source: &str, options: SvgImportOptions) -> Result<PreparedSvg, SvgAuthoringError> {
+    validate_target_dimension("height", options.height)?;
+    validate_target_dimension("width", options.width)?;
+
+    let xml_options = usvg::roxmltree::ParsingOptions {
+        allow_dtd: true,
+        ..Default::default()
+    };
+    let document = usvg::roxmltree::Document::parse_with_options(source, xml_options)
+        .map_err(SvgAuthoringError::Xml)?;
+    reject_source_features(&document)?;
+
+    let tree = usvg::Tree::from_xmltree(&document, &usvg::Options::default())
+        .map_err(SvgAuthoringError::Parse)?;
+    let mut leaves = Vec::new();
+    collect_group(tree.root(), &mut leaves)?;
+    let bounds = aggregate_path_bounds(&leaves);
+    let transform = placement_transform(bounds, options);
+    Ok(PreparedSvg { leaves, transform })
+}
+
+fn validate_target_dimension(
+    name: &'static str,
+    value: Option<f64>,
+) -> Result<(), SvgAuthoringError> {
+    if let Some(value) = value {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(SvgAuthoringError::InvalidTargetDimension { name, value });
+        }
+    }
+    Ok(())
+}
+
+fn reject_source_features(
+    document: &usvg::roxmltree::Document<'_>,
+) -> Result<(), SvgAuthoringError> {
+    for node in document.descendants().filter(|node| node.is_element()) {
+        let name = node.tag_name().name();
+        if is_unsupported_element(name) {
+            return Err(SvgAuthoringError::Unsupported(
+                SvgUnsupportedFeature::Element(name.to_owned()),
+            ));
+        }
+        for attribute in node.attributes() {
+            if attribute.name() == "vector-effect" && attribute.value().trim() != "none" {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::VectorEffect,
+                ));
+            }
+            if attribute.name() == "style"
+                && css_declares_non_none(attribute.value(), "vector-effect")
+            {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::VectorEffect,
+                ));
+            }
+        }
+        if name == "style"
+            && node
+                .text()
+                .is_some_and(|text| text.to_ascii_lowercase().contains("vector-effect"))
+        {
+            return Err(SvgAuthoringError::Unsupported(
+                SvgUnsupportedFeature::VectorEffect,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_unsupported_element(name: &str) -> bool {
+    matches!(
+        name,
+        "image"
+            | "text"
+            | "tspan"
+            | "textPath"
+            | "linearGradient"
+            | "radialGradient"
+            | "pattern"
+            | "clipPath"
+            | "mask"
+            | "filter"
+            | "marker"
+            | "foreignObject"
+            | "script"
+            | "animate"
+            | "animateMotion"
+            | "animateTransform"
+            | "set"
+            | "feBlend"
+            | "feColorMatrix"
+            | "feComponentTransfer"
+            | "feComposite"
+            | "feConvolveMatrix"
+            | "feDiffuseLighting"
+            | "feDisplacementMap"
+            | "feDistantLight"
+            | "feDropShadow"
+            | "feFlood"
+            | "feFuncA"
+            | "feFuncB"
+            | "feFuncG"
+            | "feFuncR"
+            | "feGaussianBlur"
+            | "feImage"
+            | "feMerge"
+            | "feMergeNode"
+            | "feMorphology"
+            | "feOffset"
+            | "fePointLight"
+            | "feSpecularLighting"
+            | "feSpotLight"
+            | "feTile"
+            | "feTurbulence"
+    )
+}
+
+fn css_declares_non_none(style: &str, property: &str) -> bool {
+    style.split(';').any(|declaration| {
+        declaration
+            .split_once(':')
+            .is_some_and(|(name, value)| {
+                name.trim().eq_ignore_ascii_case(property)
+                    && !value.trim().eq_ignore_ascii_case("none")
+            })
+    })
+}
+
+fn collect_group(
+    group: &usvg::Group,
+    leaves: &mut Vec<PreparedSvgLeaf>,
+) -> Result<(), SvgAuthoringError> {
+    if group.opacity().get() != 1.0 {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::GroupOpacity,
+        ));
+    }
+    if group.blend_mode() != usvg::BlendMode::Normal {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::BlendMode,
+        ));
+    }
+    if group.isolate() {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::Isolation,
+        ));
+    }
+    if group.clip_path().is_some() {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::ClipPath,
+        ));
+    }
+    if group.mask().is_some() {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::Mask,
+        ));
+    }
+    if !group.filters().is_empty() {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::Filter,
+        ));
+    }
+
+    for node in group.children() {
+        match node {
+            usvg::Node::Group(group) => collect_group(group, leaves)?,
+            usvg::Node::Path(path) => {
+                if path.is_visible() {
+                    leaves.push(prepare_path(path)?);
+                }
+            }
+            usvg::Node::Image(_) => {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::Image,
+                ));
+            }
+            usvg::Node::Text(_) => {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::Text,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn prepare_path(path: &usvg::Path) -> Result<PreparedSvgLeaf, SvgAuthoringError> {
+    if path.paint_order() == usvg::PaintOrder::StrokeAndFill
+        && path.fill().is_some()
+        && path.stroke().is_some()
+    {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::StrokeFirstPaintOrder,
+        ));
+    }
+    if path.rendering_mode() != usvg::ShapeRendering::GeometricPrecision {
+        return Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::ShapeRendering,
+        ));
+    }
+
+    let style = prepare_style(path)?;
+    let path = prepare_vector_path(path)?;
+    Ok(PreparedSvgLeaf { path, style })
+}
+
+fn prepare_style(path: &usvg::Path) -> Result<SemanticStyle, SvgAuthoringError> {
+    let (fill, fill_opacity) = match path.fill() {
+        Some(fill) => {
+            if fill.rule() == usvg::FillRule::EvenOdd {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::EvenOddFillRule,
+                ));
+            }
+            (
+                Some(SemanticPaint::Solid(solid_paint(fill.paint())?)),
+                f64::from(fill.opacity().get()),
+            )
+        }
+        None => (None, 1.0),
+    };
+
+    let (stroke, stroke_opacity, stroke_width, stroke_join, stroke_cap) = match path.stroke() {
+        Some(stroke) => {
+            if stroke.dasharray().is_some() {
+                return Err(SvgAuthoringError::Unsupported(
+                    SvgUnsupportedFeature::StrokeDash,
+                ));
+            }
+            let join = match stroke.linejoin() {
+                usvg::LineJoin::Round => StrokeJoin::Round,
+                usvg::LineJoin::Bevel => StrokeJoin::Bevel,
+                usvg::LineJoin::Miter => {
+                    if (stroke.miterlimit().get() - 4.0).abs() > 1e-6 {
+                        return Err(SvgAuthoringError::Unsupported(
+                            SvgUnsupportedFeature::StrokeMiterLimit,
+                        ));
+                    }
+                    StrokeJoin::Miter
+                }
+                usvg::LineJoin::MiterClip => {
+                    return Err(SvgAuthoringError::Unsupported(
+                        SvgUnsupportedFeature::StrokeMiterClip,
+                    ));
+                }
+            };
+            let cap = match stroke.linecap() {
+                usvg::LineCap::Round => StrokeCap::Round,
+                usvg::LineCap::Butt => StrokeCap::Butt,
+                usvg::LineCap::Square => StrokeCap::Square,
+            };
+            (
+                Some(SemanticPaint::Solid(solid_paint(stroke.paint())?)),
+                f64::from(stroke.opacity().get()),
+                f64::from(stroke.width().get()),
+                join,
+                cap,
+            )
+        }
+        None => (None, 1.0, 0.0, StrokeJoin::Round, StrokeCap::Round),
+    };
+
+    Ok(SemanticStyle {
+        fill,
+        fill_opacity,
+        stroke,
+        stroke_opacity,
+        stroke_width,
+        // Manim point transforms do not mutate authored stroke width. Keeping
+        // stroke width invariant under the common post-import affine preserves
+        // that compatibility behavior while the path itself remains retained.
+        stroke_width_mode: StrokeWidthMode::ScreenSpace,
+        stroke_join,
+        stroke_cap,
+        object_opacity: 1.0,
+    })
+}
+
+fn solid_paint(paint: &usvg::Paint) -> Result<Color, SvgAuthoringError> {
+    match paint {
+        usvg::Paint::Color(color) => Ok(Color::rgb(
+            f32::from(color.red) / 255.0,
+            f32::from(color.green) / 255.0,
+            f32::from(color.blue) / 255.0,
+        )),
+        usvg::Paint::LinearGradient(_) | usvg::Paint::RadialGradient(_) => Err(
+            SvgAuthoringError::Unsupported(SvgUnsupportedFeature::GradientPaint),
+        ),
+        usvg::Paint::Pattern(_) => Err(SvgAuthoringError::Unsupported(
+            SvgUnsupportedFeature::PatternPaint,
+        )),
+    }
+}
+
+fn prepare_vector_path(path: &usvg::Path) -> Result<VectorPath, SvgAuthoringError> {
+    use usvg::tiny_skia_path::PathSegment;
+
+    let transform = path.abs_transform();
+    let mut result = VectorPath::new();
+    for segment in path.data().segments() {
+        result = match segment {
+            PathSegment::MoveTo(point) => result.move_to(svg_point(point, transform)),
+            PathSegment::LineTo(point) => result.line_to(svg_point(point, transform)),
+            PathSegment::QuadTo(control, point) => result
+                .quadratic_to(svg_point(control, transform), svg_point(point, transform)),
+            PathSegment::CubicTo(control1, control2, point) => result.cubic_to(
+                svg_point(control1, transform),
+                svg_point(control2, transform),
+                svg_point(point, transform),
+            ),
+            PathSegment::Close => result.close(),
+        };
+    }
+    if !result.is_finite() {
+        return Err(SvgAuthoringError::Authoring(
+            AuthoringError::NonFiniteGeometry,
+        ));
+    }
+    Ok(result)
+}
+
+fn svg_point(
+    mut point: usvg::tiny_skia_path::Point,
+    transform: usvg::Transform,
+) -> Vec2 {
+    transform.map_point(&mut point);
+    // SVG canvas coordinates grow down; Manim/Noon scene coordinates grow up.
+    Vec2::new(point.x, -point.y)
+}
+
+fn aggregate_path_bounds(leaves: &[PreparedSvgLeaf]) -> Option<noon_core::Bounds2D64> {
+    let mut aggregate: Option<noon_core::Bounds2D64> = None;
+    for leaf in leaves {
+        let Some(bounds) = semantic_path_bounds(&leaf.path, 0.0).layout else {
+            continue;
+        };
+        if let Some(aggregate) = &mut aggregate {
+            aggregate.include(bounds.min_x, bounds.min_y);
+            aggregate.include(bounds.max_x, bounds.max_y);
+        } else {
+            aggregate = Some(bounds);
+        }
+    }
+    aggregate
+}
+
+fn placement_transform(
+    bounds: Option<noon_core::Bounds2D64>,
+    options: SvgImportOptions,
+) -> SemanticTransform2_5D {
+    let Some(bounds) = bounds else {
+        return SemanticTransform2_5D::default();
+    };
+    let center_x = (bounds.min_x + bounds.max_x) * 0.5;
+    let center_y = (bounds.min_y + bounds.max_y) * 0.5;
+    let mut scale = 1.0;
+    if let Some(height) = options.height {
+        if bounds.height() > 0.0 {
+            scale *= height / bounds.height();
+        }
+    }
+    if let Some(width) = options.width {
+        let current_width = bounds.width() * scale.abs();
+        if current_width > 0.0 {
+            scale *= width / current_width;
+        }
+    }
+
+    let translation = if options.should_center {
+        SemanticVec3::new(-center_x * scale, -center_y * scale, 0.0)
+    } else {
+        SemanticVec3::new(
+            center_x * (1.0 - scale),
+            center_y * (1.0 - scale),
+            0.0,
+        )
+    };
+    SemanticTransform2_5D {
+        translation,
+        scale: SemanticVec3::new(scale, scale, 1.0),
+        rotation_z: 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_options() -> SvgImportOptions {
+        SvgImportOptions {
+            should_center: false,
+            height: None,
+            width: None,
+        }
+    }
+
+    #[test]
+    fn static_svg_paths_publish_as_one_retained_family_transaction() {
+        let scene = Scene::new();
+        let before = scene.revision();
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+            <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
+            <path d="M 10 0 L 20 0 L 20 10 Z" fill="#00ff00"/>
+        </svg>"#;
+
+        let family = scene.svg_from_str(svg).unwrap();
+        assert_eq!(
+            scene.revision(),
+            before.checked_next().expect("one SVG publication revision")
+        );
+        let members = scene
+            .integration_store()
+            .borrow()
+            .semantic_family_members_checked(family.node_id())
+            .unwrap();
+        assert_eq!(members.len(), 2);
+        let bounds = family.layout_bounds().unwrap().unwrap();
+        assert!((bounds.height() - 2.0).abs() < 1e-5);
+        assert!((bounds.min_x + bounds.max_x).abs() < 1e-5);
+        assert!((bounds.min_y + bounds.max_y).abs() < 1e-5);
+    }
+
+    #[test]
+    fn svg_transform_and_y_flip_are_baked_into_retained_path() {
+        let scene = Scene::new();
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+            <path d="M 1 2 L 4 2" transform="translate(3 5)" fill="none" stroke="#112233"/>
+        </svg>"#;
+        let family = scene
+            .svg_from_str_with_options(svg, raw_options())
+            .unwrap();
+        let member = scene
+            .integration_store()
+            .borrow()
+            .semantic_family_members_checked(family.node_id())
+            .unwrap()[0];
+        let object = crate::Mobject::from_node(Rc::clone(scene.integration_store()), member).unwrap();
+        let path = object.path_query().unwrap().path().unwrap();
+        let commands = path.commands();
+        assert_eq!(commands[0], noon_core::PathCommand::MoveTo { to: Vec2::new(4.0, -7.0) });
+        assert_eq!(commands[1], noon_core::PathCommand::LineTo { to: Vec2::new(7.0, -7.0) });
+    }
+
+    #[test]
+    fn inherited_solid_style_reaches_semantic_leaf() {
+        let scene = Scene::new();
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <g fill="#123456" fill-opacity="0.25" stroke="#abcdef" stroke-opacity="0.5" stroke-width="2">
+                <path d="M 0 0 L 10 0 L 10 10 Z"/>
+            </g>
+        </svg>"#;
+        let family = scene
+            .svg_from_str_with_options(svg, raw_options())
+            .unwrap();
+        let store = scene.integration_store().borrow();
+        let member = store.semantic_family_members_checked(family.node_id()).unwrap()[0];
+        let state = store.semantic_object_state_checked(member).unwrap();
+        assert_eq!(
+            state.style.fill,
+            Some(SemanticPaint::Solid(Color::from_hex(0x123456)))
+        );
+        assert_eq!(
+            state.style.stroke,
+            Some(SemanticPaint::Solid(Color::from_hex(0xABCDEF)))
+        );
+        assert!((state.style.fill_opacity - 0.25).abs() < 1e-6);
+        assert!((state.style.stroke_opacity - 0.5).abs() < 1e-6);
+        assert!((state.style.stroke_width - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn unsupported_svg_fails_before_semantic_publication() {
+        let scene = Scene::new();
+        let before = scene.revision();
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <defs><linearGradient id="g"><stop offset="0" stop-color="red"/></linearGradient></defs>
+            <rect width="10" height="10" fill="url(#g)"/>
+        </svg>"#;
+
+        assert!(matches!(
+            scene.svg_from_str(svg),
+            Err(SvgAuthoringError::Unsupported(
+                SvgUnsupportedFeature::Element(ref name)
+            )) if name == "linearGradient"
+        ));
+        assert_eq!(scene.revision(), before);
+    }
+
+    #[test]
+    fn group_compositing_is_rejected_instead_of_flattened() {
+        let scene = Scene::new();
+        let before = scene.revision();
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <g opacity="0.5"><rect width="10" height="10" fill="red"/></g>
+        </svg>"#;
+        assert!(matches!(
+            scene.svg_from_str(svg),
+            Err(SvgAuthoringError::Unsupported(
+                SvgUnsupportedFeature::GroupOpacity
+            ))
+        ));
+        assert_eq!(scene.revision(), before);
+    }
+}

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -684,14 +684,14 @@ mod tests {
     #[test]
     fn store_scoped_svg_import_publishes_no_extra_scene_root() {
         let store = Rc::new(RefCell::new(SemanticStore::new()));
-        let before = store.borrow().revision();
+        let before = store.borrow().scene_revision();
         let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
             <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
         </svg>"##;
 
         let family = MobjectFamily::from_svg_str(Rc::clone(&store), svg).unwrap();
         assert_eq!(
-            store.borrow().revision(),
+            store.borrow().scene_revision(),
             before.checked_next().expect("one SVG publication revision")
         );
         let members = store

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -598,10 +598,10 @@ mod tests {
     fn static_svg_paths_publish_as_one_retained_family_transaction() {
         let scene = Scene::new();
         let before = scene.revision();
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
             <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
             <path d="M 10 0 L 20 0 L 20 10 Z" fill="#00ff00"/>
-        </svg>"#;
+        </svg>"##;
 
         let family = scene.svg_from_str(svg).unwrap();
         assert_eq!(
@@ -623,9 +623,9 @@ mod tests {
     #[test]
     fn svg_transform_and_y_flip_are_baked_into_retained_path() {
         let scene = Scene::new();
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
             <path d="M 1 2 L 4 2" transform="translate(3 5)" fill="none" stroke="#112233"/>
-        </svg>"#;
+        </svg>"##;
         let family = scene
             .svg_from_str_with_options(svg, raw_options())
             .unwrap();
@@ -643,11 +643,11 @@ mod tests {
     #[test]
     fn inherited_solid_style_reaches_semantic_leaf() {
         let scene = Scene::new();
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
             <g fill="#123456" fill-opacity="0.25" stroke="#abcdef" stroke-opacity="0.5" stroke-width="2">
                 <path d="M 0 0 L 10 0 L 10 10 Z"/>
             </g>
-        </svg>"#;
+        </svg>"##;
         let family = scene
             .svg_from_str_with_options(svg, raw_options())
             .unwrap();
@@ -671,10 +671,10 @@ mod tests {
     fn unsupported_svg_fails_before_semantic_publication() {
         let scene = Scene::new();
         let before = scene.revision();
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
             <defs><linearGradient id="g"><stop offset="0" stop-color="red"/></linearGradient></defs>
             <rect width="10" height="10" fill="url(#g)"/>
-        </svg>"#;
+        </svg>"##;
 
         assert!(matches!(
             scene.svg_from_str(svg),
@@ -689,9 +689,9 @@ mod tests {
     fn group_compositing_is_rejected_instead_of_flattened() {
         let scene = Scene::new();
         let before = scene.revision();
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
             <g opacity="0.5"><rect width="10" height="10" fill="red"/></g>
-        </svg>"#;
+        </svg>"##;
         assert!(matches!(
             scene.svg_from_str(svg),
             Err(SvgAuthoringError::Unsupported(

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -204,19 +204,52 @@ impl Scene {
     }
 }
 
+fn parse_xml(source: &str) -> Result<usvg::roxmltree::Document<'_>, SvgAuthoringError> {
+    usvg::roxmltree::Document::parse_with_options(
+        source,
+        usvg::roxmltree::ParsingOptions {
+            allow_dtd: true,
+            ..Default::default()
+        },
+    )
+    .map_err(SvgAuthoringError::Xml)
+}
+
+fn with_manim_svg_defaults(source: &str, document: &usvg::roxmltree::Document<'_>) -> String {
+    let root = document.root_element();
+    if root.tag_name().name() != "svg" || root.has_attribute("stroke-width") {
+        return source.to_owned();
+    }
+
+    // Manim wraps the source SVG in a group whose fallback stroke width is zero.
+    // Adding the same inherited presentation value to the original root retains
+    // viewBox/viewport behavior while allowing every explicit descendant, inline
+    // style, and stylesheet declaration to override the fallback normally.
+    let root_start = root.range().start;
+    let after_angle = root_start.saturating_add(1);
+    let Some(name_end) = source[after_angle..]
+        .find(|character: char| character.is_ascii_whitespace() || matches!(character, '>' | '/'))
+        .map(|offset| after_angle + offset)
+    else {
+        return source.to_owned();
+    };
+    let mut normalized = String::with_capacity(source.len() + 17);
+    normalized.push_str(&source[..name_end]);
+    normalized.push_str(" stroke-width=\"0\"");
+    normalized.push_str(&source[name_end..]);
+    normalized
+}
+
 fn prepare_svg(source: &str, options: SvgImportOptions) -> Result<PreparedSvg, SvgAuthoringError> {
     validate_target_dimension("height", options.height)?;
     validate_target_dimension("width", options.width)?;
 
-    let xml_options = usvg::roxmltree::ParsingOptions {
-        allow_dtd: true,
-        ..Default::default()
-    };
-    let document = usvg::roxmltree::Document::parse_with_options(source, xml_options)
-        .map_err(SvgAuthoringError::Xml)?;
+    let document = parse_xml(source)?;
     reject_source_features(&document)?;
+    let normalized_source = with_manim_svg_defaults(source, &document);
+    let normalized_document = parse_xml(&normalized_source)?;
 
-    let tree = usvg::Tree::from_xmltree(&document, &usvg::Options::default())
+    let tree = usvg::Tree::from_xmltree(&normalized_document, &usvg::Options::default())
         .map_err(SvgAuthoringError::Parse)?;
     let mut leaves = Vec::new();
     collect_group(tree.root(), &mut leaves)?;
@@ -656,6 +689,25 @@ mod tests {
         assert!((state.style.fill_opacity - 0.25).abs() < 1e-6);
         assert!((state.style.stroke_opacity - 0.5).abs() < 1e-6);
         assert!((state.style.stroke_width - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn manim_default_stroke_width_is_zero_and_explicit_width_wins() {
+        let scene = Scene::new();
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+            <rect x="0" y="0" width="10" height="10" fill="#ffffff" stroke="#ff0000"/>
+            <rect x="10" y="0" width="10" height="10" fill="#ffffff" stroke="#00ff00" stroke-width="3"/>
+        </svg>"##;
+        let family = scene.svg_from_str_with_options(svg, raw_options()).unwrap();
+        let store = scene.integration_store().borrow();
+        let members = store
+            .semantic_family_members_checked(family.node_id())
+            .unwrap();
+        assert_eq!(members.len(), 2);
+        let defaulted = store.semantic_object_state_checked(members[0]).unwrap();
+        let explicit = store.semantic_object_state_checked(members[1]).unwrap();
+        assert_eq!(defaulted.style.stroke_width, 0.0);
+        assert_eq!(explicit.style.stroke_width, 3.0);
     }
 
     #[test]

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -70,7 +70,9 @@ impl std::fmt::Display for SvgUnsupportedFeature {
             Self::ClipPath => formatter.write_str("SVG clip paths are not supported"),
             Self::Mask => formatter.write_str("SVG masks are not supported"),
             Self::Filter => formatter.write_str("SVG filters are not supported"),
-            Self::Image => formatter.write_str("SVG image nodes are not supported in vector import"),
+            Self::Image => {
+                formatter.write_str("SVG image nodes are not supported in vector import")
+            }
             Self::Text => formatter.write_str("SVG text nodes are not supported in vector import"),
             Self::GradientPaint => formatter.write_str("SVG gradient paints are not supported"),
             Self::PatternPaint => formatter.write_str("SVG pattern paints are not supported"),
@@ -323,8 +325,7 @@ fn is_unsupported_element(name: &str) -> bool {
 fn css_declares_non_none(style: &str, property: &str) -> bool {
     style.split(';').any(|declaration| {
         declaration.split_once(':').is_some_and(|(name, value)| {
-            name.trim().eq_ignore_ascii_case(property)
-                && !value.trim().eq_ignore_ascii_case("none")
+            name.trim().eq_ignore_ascii_case(property) && !value.trim().eq_ignore_ascii_case("none")
         })
     })
 }
@@ -354,9 +355,7 @@ fn collect_group(
         ));
     }
     if group.mask().is_some() {
-        return Err(SvgAuthoringError::Unsupported(
-            SvgUnsupportedFeature::Mask,
-        ));
+        return Err(SvgAuthoringError::Unsupported(SvgUnsupportedFeature::Mask));
     }
     if !group.filters().is_empty() {
         return Err(SvgAuthoringError::Unsupported(
@@ -373,14 +372,10 @@ fn collect_group(
                 }
             }
             usvg::Node::Image(_) => {
-                return Err(SvgAuthoringError::Unsupported(
-                    SvgUnsupportedFeature::Image,
-                ));
+                return Err(SvgAuthoringError::Unsupported(SvgUnsupportedFeature::Image));
             }
             usvg::Node::Text(_) => {
-                return Err(SvgAuthoringError::Unsupported(
-                    SvgUnsupportedFeature::Text,
-                ));
+                return Err(SvgAuthoringError::Unsupported(SvgUnsupportedFeature::Text));
             }
         }
     }
@@ -504,8 +499,9 @@ fn prepare_vector_path(path: &usvg::Path) -> Result<VectorPath, SvgAuthoringErro
         result = match segment {
             PathSegment::MoveTo(point) => result.move_to(svg_point(point, transform)),
             PathSegment::LineTo(point) => result.line_to(svg_point(point, transform)),
-            PathSegment::QuadTo(control, point) => result
-                .quadratic_to(svg_point(control, transform), svg_point(point, transform)),
+            PathSegment::QuadTo(control, point) => {
+                result.quadratic_to(svg_point(control, transform), svg_point(point, transform))
+            }
             PathSegment::CubicTo(control1, control2, point) => result.cubic_to(
                 svg_point(control1, transform),
                 svg_point(control2, transform),
@@ -569,11 +565,7 @@ fn placement_transform(
     let translation = if options.should_center {
         SemanticVec3::new(-center_x * scale, -center_y * scale, 0.0)
     } else {
-        SemanticVec3::new(
-            center_x * (1.0 - scale),
-            center_y * (1.0 - scale),
-            0.0,
-        )
+        SemanticVec3::new(center_x * (1.0 - scale), center_y * (1.0 - scale), 0.0)
     };
     SemanticTransform2_5D {
         translation,
@@ -626,15 +618,14 @@ mod tests {
         let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
             <path d="M 1 2 L 4 2" transform="translate(3 5)" fill="none" stroke="#112233"/>
         </svg>"##;
-        let family = scene
-            .svg_from_str_with_options(svg, raw_options())
-            .unwrap();
+        let family = scene.svg_from_str_with_options(svg, raw_options()).unwrap();
         let store = scene.integration_store().borrow();
         let member = store
             .semantic_family_members_checked(family.node_id())
             .unwrap()[0];
         drop(store);
-        let object = crate::Mobject::from_node(Rc::clone(scene.integration_store()), member).unwrap();
+        let object =
+            crate::Mobject::from_node(Rc::clone(scene.integration_store()), member).unwrap();
         let query = object.path_query().unwrap();
         assert_eq!(query.start().unwrap(), (4.0, -7.0));
         assert_eq!(query.end().unwrap(), (7.0, -7.0));
@@ -648,11 +639,11 @@ mod tests {
                 <path d="M 0 0 L 10 0 L 10 10 Z"/>
             </g>
         </svg>"##;
-        let family = scene
-            .svg_from_str_with_options(svg, raw_options())
-            .unwrap();
+        let family = scene.svg_from_str_with_options(svg, raw_options()).unwrap();
         let store = scene.integration_store().borrow();
-        let member = store.semantic_family_members_checked(family.node_id()).unwrap()[0];
+        let member = store
+            .semantic_family_members_checked(family.node_id())
+            .unwrap()[0];
         let state = store.semantic_object_state_checked(member).unwrap();
         assert_eq!(
             state.style.fill,

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -183,7 +183,7 @@ impl Scene {
             store.with_geometry_paths(paths, |store, handles| {
                 let mut transaction = SemanticMutationTransaction::new();
                 let family = transaction.create_node(SemanticNodeCreation::family());
-                for (handle, style) in handles.iter().copied().zip(styles.into_iter()) {
+                for (handle, style) in handles.iter().copied().zip(styles) {
                     let mut state = SemanticObjectState::new(StoredGeometry::Resource(handle));
                     state.transform = prepared.transform;
                     state.style = style;
@@ -194,9 +194,9 @@ impl Scene {
                     .apply(store)
                     .map_err(AuthoringError::from)
                     .map_err(SvgAuthoringError::from)?;
-                result.resolve(family).ok_or_else(|| {
-                    SvgAuthoringError::Authoring(AuthoringError::UnresolvedCreatedNode(family))
-                })
+                result.resolve(family).ok_or(SvgAuthoringError::Authoring(
+                    AuthoringError::UnresolvedCreatedNode(family),
+                ))
             })?
         };
 

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -13,6 +13,8 @@ use noon_core::{
 };
 use std::rc::Rc;
 
+const MANIM_DEFAULT_STROKE_WIDTH_SENTINEL: f32 = 0.000_001;
+
 /// Positioning applied after SVG parsing.
 ///
 /// The default mirrors Manim's `SVGMobject` placement contract: flip SVG's Y axis,
@@ -221,10 +223,10 @@ fn with_manim_svg_defaults(source: &str, document: &usvg::roxmltree::Document<'_
         return source.to_owned();
     }
 
-    // Manim wraps the source SVG in a group whose fallback stroke width is zero.
-    // Adding the same inherited presentation value to the original root retains
-    // viewBox/viewport behavior while allowing every explicit descendant, inline
-    // style, and stylesheet declaration to override the fallback normally.
+    // `usvg` intentionally discards a stroke whose width resolves to zero, which
+    // can also discard an otherwise fill-less path. Manim still retains that path
+    // as a submobject. Use a tiny inherited parse-only sentinel so normalization
+    // keeps the geometry, then lower that sentinel back to Manim's zero fallback.
     let root_start = root.range().start;
     let after_angle = root_start.saturating_add(1);
     let Some(name_end) = source[after_angle..]
@@ -233,9 +235,9 @@ fn with_manim_svg_defaults(source: &str, document: &usvg::roxmltree::Document<'_
     else {
         return source.to_owned();
     };
-    let mut normalized = String::with_capacity(source.len() + 17);
+    let mut normalized = String::with_capacity(source.len() + 24);
     normalized.push_str(&source[..name_end]);
-    normalized.push_str(" stroke-width=\"0\"");
+    normalized.push_str(" stroke-width=\"0.000001\"");
     normalized.push_str(&source[name_end..]);
     normalized
 }
@@ -480,10 +482,16 @@ fn prepare_style(path: &usvg::Path) -> Result<SemanticStyle, SvgAuthoringError> 
                 usvg::LineCap::Butt => StrokeCap::Butt,
                 usvg::LineCap::Square => StrokeCap::Square,
             };
+            let resolved_width = stroke.width().get();
+            let width = if resolved_width == MANIM_DEFAULT_STROKE_WIDTH_SENTINEL {
+                0.0
+            } else {
+                f64::from(resolved_width)
+            };
             (
                 Some(SemanticPaint::Solid(solid_paint(stroke.paint())?)),
                 f64::from(stroke.opacity().get()),
-                f64::from(stroke.width().get()),
+                width,
                 join,
                 cap,
             )

--- a/crates/noon/src/svg_authoring.rs
+++ b/crates/noon/src/svg_authoring.rs
@@ -8,10 +8,10 @@
 use crate::{AuthoringError, MobjectFamily, Scene};
 use noon_core::{
     semantic_path_bounds, Color, SemanticMutationTransaction, SemanticNodeCreation,
-    SemanticObjectState, SemanticPaint, SemanticStyle, SemanticTransform2_5D, SemanticVec3,
-    StoredGeometry, StrokeCap, StrokeJoin, StrokeWidthMode, Vec2, VectorPath,
+    SemanticObjectState, SemanticPaint, SemanticStore, SemanticStyle, SemanticTransform2_5D,
+    SemanticVec3, StoredGeometry, StrokeCap, StrokeJoin, StrokeWidthMode, Vec2, VectorPath,
 };
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 const MANIM_DEFAULT_STROKE_WIDTH_SENTINEL: f32 = 0.000_001;
 const MANIM_CAIRO_LINE_WIDTH_MULTIPLE: f64 = 0.01;
@@ -156,24 +156,27 @@ struct PreparedSvg {
     transform: SemanticTransform2_5D,
 }
 
-impl Scene {
-    /// Parse one static SVG string into a detached semantic family.
+impl MobjectFamily {
+    /// Parse one static SVG string directly into one shared semantic store.
     ///
-    /// Supported content is normalized before one atomic semantic publication.
-    /// The returned family and its leaves are ordinary Noon identities backed by
-    /// immutable geometry resources; later transforms/styles never reparse SVG.
-    pub fn svg_from_str(&self, source: &str) -> Result<MobjectFamily, SvgAuthoringError> {
-        self.svg_from_str_with_options(source, SvgImportOptions::default())
+    /// This is the store-scoped form used by integration frontends. It publishes
+    /// no scene/root identity of its own; only the imported family, leaves, and
+    /// immutable geometry resources enter the supplied arena.
+    pub fn from_svg_str(
+        store: Rc<RefCell<SemanticStore>>,
+        source: &str,
+    ) -> Result<Self, SvgAuthoringError> {
+        Self::from_svg_str_with_options(store, source, SvgImportOptions::default())
     }
 
-    /// Parse one static SVG string with explicit post-import placement options.
-    pub fn svg_from_str_with_options(
-        &self,
+    /// Parse one static SVG string into a supplied semantic store with explicit
+    /// post-import placement options.
+    pub fn from_svg_str_with_options(
+        store_rc: Rc<RefCell<SemanticStore>>,
         source: &str,
         options: SvgImportOptions,
-    ) -> Result<MobjectFamily, SvgAuthoringError> {
+    ) -> Result<Self, SvgAuthoringError> {
         let prepared = prepare_svg(source, options)?;
-        let store_rc = Rc::clone(self.integration_store());
         let mut paths = Vec::with_capacity(prepared.leaves.len());
         let mut styles = Vec::with_capacity(prepared.leaves.len());
         for leaf in prepared.leaves {
@@ -203,7 +206,31 @@ impl Scene {
             })?
         };
 
-        MobjectFamily::from_node(store_rc, family_id).map_err(SvgAuthoringError::from)
+        Self::from_node(store_rc, family_id).map_err(SvgAuthoringError::from)
+    }
+}
+
+impl Scene {
+    /// Parse one static SVG string into a detached semantic family.
+    ///
+    /// Supported content is normalized before one atomic semantic publication.
+    /// The returned family and its leaves are ordinary Noon identities backed by
+    /// immutable geometry resources; later transforms/styles never reparse SVG.
+    pub fn svg_from_str(&self, source: &str) -> Result<MobjectFamily, SvgAuthoringError> {
+        MobjectFamily::from_svg_str(Rc::clone(self.integration_store()), source)
+    }
+
+    /// Parse one static SVG string with explicit post-import placement options.
+    pub fn svg_from_str_with_options(
+        &self,
+        source: &str,
+        options: SvgImportOptions,
+    ) -> Result<MobjectFamily, SvgAuthoringError> {
+        MobjectFamily::from_svg_str_with_options(
+            Rc::clone(self.integration_store()),
+            source,
+            options,
+        )
     }
 }
 
@@ -652,6 +679,26 @@ mod tests {
         assert!((bounds.height() - 2.0).abs() < 1e-5);
         assert!((bounds.min_x + bounds.max_x).abs() < 1e-5);
         assert!((bounds.min_y + bounds.max_y).abs() < 1e-5);
+    }
+
+    #[test]
+    fn store_scoped_svg_import_publishes_no_extra_scene_root() {
+        let store = Rc::new(RefCell::new(SemanticStore::new()));
+        let before = store.borrow().revision();
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+            <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
+        </svg>"##;
+
+        let family = MobjectFamily::from_svg_str(Rc::clone(&store), svg).unwrap();
+        assert_eq!(
+            store.borrow().revision(),
+            before.checked_next().expect("one SVG publication revision")
+        );
+        let members = store
+            .borrow()
+            .semantic_family_members_checked(family.node_id())
+            .unwrap();
+        assert_eq!(members.len(), 1);
     }
 
     #[test]

--- a/parity/manim-v0.21/core-examples/svg_static_import.py
+++ b/parity/manim-v0.21/core-examples/svg_static_import.py
@@ -1,0 +1,21 @@
+from manim import *
+from pathlib import Path
+
+
+SVG_SOURCE = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect x="5" y="5" width="40" height="50"
+        fill="#58C4DD" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="75" cy="30" r="20" fill="#83C167"/>
+  <g transform="translate(100 10)">
+    <path d="M0 0 L15 20 L0 40 Z" fill="#FC6255"/>
+  </g>
+</svg>"""
+
+
+class SvgStaticImport(Scene):
+    def construct(self):
+        path = Path("/tmp/noon_svg_static_parity.svg")
+        path.write_text(SVG_SOURCE)
+        icon = SVGMobject(str(path))
+        self.add(icon)
+        self.wait(0.2)

--- a/parity/manim-v0.21/svg-manifest.json
+++ b/parity/manim-v0.21/svg-manifest.json
@@ -1,0 +1,43 @@
+{
+  "reference": {
+    "project": "Manim Community",
+    "version": "0.21.0",
+    "renderer": "cairo",
+    "frame_format": "png",
+    "pixel_width": 960,
+    "pixel_height": 540,
+    "frame_rate": 30,
+    "source": "parity/manim-v0.21/core-examples/svg_static_import.py"
+  },
+  "fixtures": [
+    {
+      "id": "svg-static-import",
+      "scene": "SvgStaticImport",
+      "source": "parity/manim-v0.21/core-examples/svg_static_import.py",
+      "expected_duration": 0.2
+    }
+  ],
+  "sample_fractions": [
+    0.0,
+    0.25,
+    0.5,
+    0.75,
+    0.9,
+    0.95,
+    0.98,
+    0.99,
+    1.0
+  ],
+  "policy": {
+    "source_adaptation": "replace only `from manim import *` with `from noon import *`, then append a scene-selection wrapper for the browser authoring worker",
+    "reference_frames": "compare Noon screenshots against Manim Cairo's native lossless PNG frame sequence; never derive parity references from compressed video",
+    "blocking": "tooling failures and per-fixture raster tolerance regressions are blocking; known unconverged metrics must be explicitly exempted",
+    "raster_tolerance": {
+      "max_duration_delta_seconds": 0.034,
+      "max_background_channel_delta_sum": 0,
+      "max_bounds_delta_px": 2,
+      "max_differing_ratio": 0.006,
+      "max_mean_absolute_channel_error": 0.5
+    }
+  }
+}

--- a/scripts/svg-authoring-smoke.mjs
+++ b/scripts/svg-authoring-smoke.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import playwright from "playwright";
+
+const { chromium } = playwright;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const port = 4183;
+const baseUrl = `http://127.0.0.1:${port}`;
+
+let serverOutput = "";
+const server = spawn(
+  "python3",
+  ["-m", "http.server", String(port), "--bind", "127.0.0.1", "--directory", repoRoot],
+  { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+);
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+async function waitForServer() {
+  let lastError = null;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/web/manim-compat-smoke.html`);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`SVG authoring smoke server did not start: ${lastError}\n${serverOutput}`);
+}
+
+const svgSource = String.raw`
+from noon import *
+
+class SvgStatic(Scene):
+    def construct(self):
+        icon = SVGMobject.from_string('''
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+  <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
+  <path d="M 10 0 L 20 0 L 20 10 Z" fill="#00ff00"/>
+</svg>
+''')
+        assert isinstance(icon, VGroup)
+        assert len(icon) == 2
+        assert abs(icon.height - 2.0) < 1e-6
+        center = icon.get_center()
+        assert abs(center[0]) < 1e-6
+        assert abs(center[1]) < 1e-6
+        self.add(icon)
+`;
+
+const unsupportedSource = String.raw`
+from noon import *
+
+class UnsupportedSvg(Scene):
+    def construct(self):
+        SVGMobject.from_string('''
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <defs><linearGradient id="g"><stop offset="0" stop-color="red"/></linearGradient></defs>
+  <rect width="10" height="10" fill="url(#g)"/>
+</svg>
+''')
+`;
+
+let browser;
+try {
+  await waitForServer();
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(String(error)));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+
+  await page.goto(`${baseUrl}/web/manim-compat-smoke.html`);
+  await page.evaluate(() => window.noonManimCompat.ready());
+
+  const rendered = await page.evaluate(
+    (source) => window.noonManimCompat.runLive(source),
+    svgSource,
+  );
+  assert.equal(rendered.duration, 0, "static SVG authoring must not invent timeline duration");
+  assert.equal(rendered.mode, "semantic", "SVG must use shared semantic retained execution");
+  assert.equal(rendered.metrics.objectCount, 2, "SVG family must render both retained leaves");
+  assert.ok(rendered.metrics.presentedFrames > 0, "SVG retained scene must present at least one frame");
+
+  let unsupportedError = null;
+  try {
+    await page.evaluate(
+      (source) => window.noonManimCompat.runLive(source),
+      unsupportedSource,
+    );
+  } catch (error) {
+    unsupportedError = String(error);
+  }
+  assert.match(
+    unsupportedError ?? "",
+    /svg\.unsupported|unsupported SVG element <linearGradient>/,
+    "unsupported SVG semantics must fail explicitly through the typed authoring boundary",
+  );
+
+  assert.deepEqual(errors, [], `browser errors while testing SVG authoring:\n${errors.join("\n")}`);
+  console.log(
+    "SVG authoring smoke passed: public SVGMobject import, retained family/leaf identity, Manim default placement, static browser rendering, and explicit unsupported-feature failure.",
+  );
+} finally {
+  await browser?.close();
+  server.kill("SIGTERM");
+}

--- a/web/python-compat-modules.js
+++ b/web/python-compat-modules.js
@@ -7,6 +7,7 @@ export const PYTHON_COMPAT_MODULES = Object.freeze([
   { sourcePath: "python/_manim_path_queries.py", runtimePath: "/tmp/_manim_path_queries.py", label: "Noon shared path query wrappers" },
   { sourcePath: "python/_manim_path_editing.py", runtimePath: "/tmp/_manim_path_editing.py", label: "Noon shared path editing wrappers" },
   { sourcePath: "python/_manim_typst.py", runtimePath: "/tmp/_manim_typst.py", label: "Noon retained Typst compatibility layer" },
+  { sourcePath: "python/_manim_svg.py", runtimePath: "/tmp/_manim_svg.py", label: "Noon retained SVG compatibility layer" },
   { sourcePath: "python/_manim_family_creation.py", runtimePath: "/tmp/_manim_family_creation.py", label: "Noon Write/Unwrite syntax layer" },
   { sourcePath: "python/_manim_rate_functions.py", runtimePath: "/tmp/_manim_rate_functions.py", label: "Noon Manim rate functions" },
   { sourcePath: "python/_manim_geometry.py", runtimePath: "/tmp/_manim_geometry.py", label: "Noon Manim geometry layer" },

--- a/web/python-worker.source.js
+++ b/web/python-worker.source.js
@@ -127,6 +127,8 @@ async function initializePyodide() {
     authoringStore.createManimGeometry(options);
   self.noonCreateAuthoringArrowHandle = (options) =>
     authoringStore.createManimArrow(options);
+  self.noonCreateAuthoringSvgHandle = (source, shouldCenter, height, width) =>
+    authoringStore.createSvgFromString(source, shouldCenter, height, width);
   self.noonCreateAuthoringTextHandle = (source, fontFamily, fontSize, lineSpacing) =>
     authoringStore.createManimText(source, fontFamily, fontSize, lineSpacing);
   self.noonCreateAuthoringTypstHandle = (source, math, fontSize) =>

--- a/web/python/_manim_svg.py
+++ b/web/python/_manim_svg.py
@@ -1,0 +1,154 @@
+"""Partial ManimCE-compatible static SVG authoring over shared Rust resources.
+
+Python owns file/string loading and wrapper identity. Shared Rust owns SVG parsing,
+compatibility normalization, retained path resources, styles, family identity and
+all later semantic mutations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import noon as _base
+import _manim_compat as _compat
+from _noon_errors import engine_call
+from _manim_semantic_handles import (
+    _attach_shared_handle,
+    _family_wrapper_key,
+    _live_constructor_context,
+)
+
+try:
+    from js import noonCreateAuthoringSvgHandle as _create_svg_handle
+except ImportError:  # Native CPython tests do not have the browser bridge.
+    _create_svg_handle = None
+
+
+def _read_svg_file(file_name: object) -> tuple[Path, str]:
+    if file_name is None:
+        raise ValueError("Must specify file for SVGMobject")
+    try:
+        path = Path(file_name)
+    except TypeError as error:
+        raise TypeError("SVGMobject file_name must be path-like") from error
+    candidates = [path]
+    if path.suffix == "":
+        candidates.append(path.with_suffix(".svg"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate, candidate.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"SVG file not found: {path}")
+
+
+def _validate_parser_options(svg_default: object, path_string_config: object) -> None:
+    if svg_default is not None:
+        raise NotImplementedError(
+            "custom SVGMobject svg_default requires shared Rust default-style configuration"
+        )
+    if path_string_config not in (None, {}):
+        raise NotImplementedError(
+            "SVGMobject path_string_config is not yet supported by retained SVG import"
+        )
+
+
+def _wrap_imported_family(owner: "SVGMobject", family: object) -> None:
+    owner._semantic_family_handle = family
+    wrappers: dict[str, _compat.VMobject] = {}
+    count = int(engine_call(getattr, family, "memberCount"))
+    for index in range(count):
+        leaf = object.__new__(_compat.VMobject)
+        _attach_shared_handle(leaf, engine_call(family.memberMobject, index))
+        wrappers[_family_wrapper_key(leaf)] = leaf
+    owner._semantic_member_wrappers = wrappers
+
+
+class SVGMobject(_compat.VGroup):
+    """Static SVG imported as one retained semantic family.
+
+    Direct filesystem paths and :meth:`from_string` are supported in this partial
+    slice. Browser URL/blob loading, non-default parser configuration, cache-policy
+    compatibility and construction after live execution starts remain explicit gaps.
+    """
+
+    def __init__(
+        self,
+        file_name: object | None = None,
+        *,
+        should_center: bool = True,
+        height: float | None = 2,
+        width: float | None = None,
+        color: object | None = None,
+        opacity: float | None = None,
+        fill_color: object | None = None,
+        fill_opacity: float | None = None,
+        stroke_color: object | None = None,
+        stroke_opacity: float | None = None,
+        stroke_width: float | None = None,
+        svg_default: dict | None = None,
+        path_string_config: dict | None = None,
+        use_svg_cache: bool = True,
+        _svg_string: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if _create_svg_handle is None:
+            raise RuntimeError("SVGMobject construction requires the shared Rust authoring host")
+        if kwargs:
+            raise NotImplementedError(
+                "unsupported SVGMobject constructor option(s): " + ", ".join(sorted(kwargs))
+            )
+        if _live_constructor_context("SVG") is not None:
+            raise NotImplementedError(
+                "live SVGMobject construction requires atomic retained-resource publication"
+            )
+        _validate_parser_options(svg_default, path_string_config)
+        if not use_svg_cache:
+            # Cache choice is not a visual semantic. Noon currently relies on the
+            # shared immutable resource arena rather than Manim's wrapper cache.
+            pass
+
+        if _svg_string is None:
+            self.file_name, source = _read_svg_file(file_name)
+        else:
+            if file_name is not None:
+                raise TypeError("SVGMobject accepts either file_name or SVG source, not both")
+            self.file_name = None
+            source = str(_svg_string)
+            if not source.strip():
+                raise ValueError("SVG source must be non-empty")
+
+        self.should_center = bool(should_center)
+        self.svg_height = None if height is None else float(height)
+        self.svg_width = None if width is None else float(width)
+        self.color = color
+        self.opacity = opacity
+        self.fill_color = fill_color
+        self.fill_opacity = fill_opacity
+        self.stroke_color = stroke_color
+        self.stroke_opacity = stroke_opacity
+        self.stroke_width = 0 if stroke_width is None else float(stroke_width)
+        self.svg_default = svg_default
+        self.path_string_config = {} if path_string_config is None else path_string_config
+        self.id_to_vgroup_dict = {}
+
+        family = engine_call(
+            _create_svg_handle,
+            source,
+            self.should_center,
+            self.svg_height,
+            self.svg_width,
+        )
+        _wrap_imported_family(self, family)
+
+        # Manim v0.21 applies these explicit paint overrides after parsing. Its
+        # top-level `color`/`opacity` fields are retained metadata here as there,
+        # while fill/stroke-specific arguments mutate the imported family.
+        if fill_color is not None or fill_opacity is not None:
+            self.set_fill(fill_color, fill_opacity)
+        if stroke_color is not None or stroke_opacity is not None or stroke_width is not None:
+            self.set_stroke(stroke_color, stroke_width, stroke_opacity)
+
+    @classmethod
+    def from_string(cls, source: str, **kwargs: Any) -> "SVGMobject":
+        """Import SVG text without introducing a frontend geometry model."""
+        return cls(_svg_string=source, **kwargs)

--- a/web/python/_manim_svg.py
+++ b/web/python/_manim_svg.py
@@ -25,6 +25,17 @@ except ImportError:  # Native CPython tests do not have the browser bridge.
     _create_svg_handle = None
 
 
+_MANIM_DEFAULT_SVG_STYLE = {
+    "color": None,
+    "opacity": None,
+    "fill_color": None,
+    "fill_opacity": None,
+    "stroke_width": 0,
+    "stroke_color": None,
+    "stroke_opacity": None,
+}
+
+
 def _read_svg_file(file_name: object) -> tuple[Path, str]:
     if file_name is None:
         raise ValueError("Must specify file for SVGMobject")
@@ -55,7 +66,7 @@ def _validate_parser_options(svg_default: object, path_string_config: object) ->
 def _wrap_imported_family(owner: "SVGMobject", family: object) -> None:
     owner._semantic_family_handle = family
     wrappers: dict[str, _compat.VMobject] = {}
-    count = int(engine_call(getattr, family, "memberCount"))
+    count = int(family.memberCount)
     for index in range(count):
         leaf = object.__new__(_compat.VMobject)
         _attach_shared_handle(leaf, engine_call(family.memberMobject, index))
@@ -127,7 +138,7 @@ class SVGMobject(_compat.VGroup):
         self.stroke_color = stroke_color
         self.stroke_opacity = stroke_opacity
         self.stroke_width = 0 if stroke_width is None else float(stroke_width)
-        self.svg_default = svg_default
+        self.svg_default = dict(_MANIM_DEFAULT_SVG_STYLE)
         self.path_string_config = {} if path_string_config is None else path_string_config
         self.id_to_vgroup_dict = {}
 

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -763,6 +763,7 @@ _PUBLIC_EXPORTS = {
     "Write": "_manim_family_creation",
     "Unwrite": "_manim_family_creation",
     "VMobject": "_manim_compat",
+    "SVGMobject": "_manim_svg",
     "Circle": "_manim_compat",
     "Rectangle": "_manim_compat",
     "Square": "_manim_compat",

--- a/web/python/test_manim_svg_facade.py
+++ b/web/python/test_manim_svg_facade.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch
+
+import _manim_compat as compat
+import _manim_svg as svg
+
+
+class _LeafHandle:
+    def __init__(self, slot):
+        self.semanticSlot = slot
+        self.semanticGeneration = 0
+
+
+class _FamilyHandle:
+    def __init__(self, count=2):
+        self._members = [_LeafHandle(index + 1) for index in range(count)]
+        self.memberCount = count
+
+    def memberMobject(self, index):
+        return self._members[index]
+
+    def memberKeys(self):
+        return [f"{member.semanticSlot}:{member.semanticGeneration}" for member in self._members]
+
+
+class SvgFacadeTests(unittest.TestCase):
+    def test_from_string_wraps_authoritative_family_members_without_geometry_copy(self):
+        calls = []
+        family = _FamilyHandle()
+
+        def create(source, should_center, height, width):
+            calls.append((source, should_center, height, width))
+            return family
+
+        with patch.object(svg, "_create_svg_handle", create):
+            value = svg.SVGMobject.from_string(
+                '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L1 0"/></svg>'
+            )
+
+        self.assertIs(value._semantic_family_handle, family)
+        self.assertEqual(len(value), 2)
+        self.assertEqual(len(value.submobjects), 2)
+        self.assertTrue(all(isinstance(member, compat.VMobject) for member in value.submobjects))
+        self.assertEqual(
+            calls,
+            [(
+                '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L1 0"/></svg>',
+                True,
+                2.0,
+                None,
+            )],
+        )
+
+    def test_unsupported_parser_configuration_fails_before_rust_call(self):
+        calls = []
+        with patch.object(svg, "_create_svg_handle", lambda *args: calls.append(args)):
+            with self.assertRaises(NotImplementedError):
+                svg.SVGMobject.from_string("<svg/>", path_string_config={"should_subdivide_sharp_curves": True})
+        self.assertEqual(calls, [])
+
+    def test_empty_source_is_rejected_before_rust_call(self):
+        calls = []
+        with patch.object(svg, "_create_svg_handle", lambda *args: calls.append(args)):
+            with self.assertRaises(ValueError):
+                svg.SVGMobject.from_string("   ")
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/python/test_manim_svg_facade.py
+++ b/web/python/test_manim_svg_facade.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import noon
 import _manim_compat as compat
 import _manim_svg as svg
 
@@ -24,6 +25,10 @@ class _FamilyHandle:
 
 
 class SvgFacadeTests(unittest.TestCase):
+    def test_public_noon_export_is_lazy_svg_facade(self):
+        self.assertIs(noon.SVGMobject, svg.SVGMobject)
+        self.assertIn("SVGMobject", noon.__all__)
+
     def test_from_string_wraps_authoritative_family_members_without_geometry_copy(self):
         calls = []
         family = _FamilyHandle()

--- a/web/retained-gpu-diagnostics-boundary.test.mjs
+++ b/web/retained-gpu-diagnostics-boundary.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const retainedRenderer = await readFile(
+  new URL("../crates/noon-web/src/retained_execution_canvas.rs", import.meta.url),
+  "utf8",
+);
+
+const flushStart = retainedRenderer.indexOf(
+  "#[wasm_bindgen(js_name = flushGpuDiagnostics)]",
+);
+const flushEnd = retainedRenderer.indexOf(
+  "#[wasm_bindgen(js_name = takeGpuDiagnosticJson)]",
+  flushStart,
+);
+assert.ok(flushStart >= 0 && flushEnd > flushStart, "GPU diagnostic flush export must exist");
+const flushSource = retainedRenderer.slice(flushStart, flushEnd);
+
+test("WebGPU diagnostic flush does not hold a mutable wasm renderer borrow across await", () => {
+  assert.match(
+    flushSource,
+    /pub fn flush_gpu_diagnostics\(&mut self\) -> js_sys::Promise/,
+  );
+  assert.doesNotMatch(
+    flushSource,
+    /pub async fn flush_gpu_diagnostics\(&mut self\)/,
+    "an async wasm-bindgen &mut self export would keep the renderer borrowed while WebGPU awaits pop_error_scope",
+  );
+  assert.match(flushSource, /let pending = scope\.pop\(\);/);
+  assert.match(flushSource, /future_to_promise\(async move/);
+});
+
+test("WebGPU diagnostic flush re-arms synchronously before detaching validation delivery", () => {
+  const popIndex = flushSource.indexOf("let pending = scope.pop();");
+  const rearmIndex = flushSource.indexOf("self.device.push_error_scope");
+  const detachIndex = flushSource.indexOf("future_to_promise(async move");
+  assert.ok(popIndex >= 0 && rearmIndex > popIndex && detachIndex > rearmIndex);
+  for (const captured of [
+    "let gpu_diagnostics = self.gpu_diagnostics.clone();",
+    "let gpu_generation = self.gpu_generation;",
+    "let backend = self.backend;",
+  ]) {
+    const captureIndex = flushSource.indexOf(captured);
+    assert.ok(
+      captureIndex > rearmIndex && captureIndex < detachIndex,
+      `detached validation delivery must capture ${captured}`,
+    );
+  }
+});

--- a/web/retained-gpu-diagnostics-boundary.test.mjs
+++ b/web/retained-gpu-diagnostics-boundary.test.mjs
@@ -36,15 +36,25 @@ test("WebGPU diagnostic flush re-arms synchronously before detaching validation 
   const rearmIndex = flushSource.indexOf("self.device.push_error_scope");
   const detachIndex = flushSource.indexOf("future_to_promise(async move");
   assert.ok(popIndex >= 0 && rearmIndex > popIndex && detachIndex > rearmIndex);
-  for (const captured of [
-    "let gpu_diagnostics = self.gpu_diagnostics.clone();",
-    "let gpu_generation = self.gpu_generation;",
-    "let backend = self.backend;",
+
+  for (const [capture, description] of [
+    [/let\s+\w+\s*=\s*self\.gpu_diagnostics\.clone\(\);/, "diagnostic mailbox"],
+    [/let\s+\w+\s*=\s*self\.gpu_generation;/, "GPU generation"],
+    [/let\s+\w+\s*=\s*self\.backend;/, "GPU backend"],
   ]) {
-    const captureIndex = flushSource.indexOf(captured);
+    const match = capture.exec(flushSource);
+    assert.ok(match, `detached validation delivery must capture ${description}`);
     assert.ok(
-      captureIndex > rearmIndex && captureIndex < detachIndex,
-      `detached validation delivery must capture ${captured}`,
+      match.index > rearmIndex && match.index < detachIndex,
+      `${description} must be captured after re-arm and before the detached await`,
     );
   }
+
+  const detachedSource = flushSource.slice(detachIndex);
+  assert.doesNotMatch(
+    detachedSource,
+    /self\./,
+    "detached validation delivery must not retain the wasm renderer borrow",
+  );
+  assert.match(detachedSource, /\.record_wgpu\([^;]+error\);/);
 });


### PR DESCRIPTION
Advances #79 (Roadmap B2) with the first bounded, user-facing static SVG tranche.

## Scope
- adds `usvg` as an author-time SVG normalizer/parser only
- adds store-scoped `MobjectFamily::from_svg_str*` plus `Scene::svg_from_str*`
- converts supported static SVG paths/common primitives, inherited solid paint, viewBox and element/group transforms into ordinary retained `VectorPath` resources
- publishes all imported leaves plus their family atomically in the existing semantic store; store-scoped import creates no synthetic Scene/root identity
- mirrors ManimCE v0.21 placement conventions for this subset: SVG Y flip, centering and default target height 2
- preserves Manim's zero-width SVG stroke fallback during parsing and lowers explicit SVG stroke widths through the existing Cairo-compatible width units
- adds the WASM authoring bridge and a public lazy Python `SVGMobject` facade for filesystem SVGs plus `SVGMobject.from_string(...)`
- rewraps authoritative Rust family members in Python without copying geometry
- explicitly rejects unsupported semantics instead of approximating them: text/images, gradients/patterns, clip/mask/filter, group compositing, dashed strokes, even-odd fill, unsupported paint order/rendering modes, non-default parser configuration and live-time SVG construction

## Architecture
Ownership stays in the existing layers. SVG parsing and compatibility normalization are preparation-time work only. Published state contains normal semantic family/object identities, immutable geometry handles, transforms and styles. No SVG runtime, renderer model, per-frame payload, frontend-owned geometry or second semantic authority is introduced.

## Locality / lifetime
Import cost is proportional to the imported SVG. Once published, normal transform/style/Create/Transform/path behavior uses the existing retained vector pipeline and does not reparse SVG. Geometry lifetime and deduplication use the existing immutable resource arena and atomic `with_geometry_paths` publication.

## Validation already green
- focused Rust importer/publication/style/diagnostic tests
- Rust fmt/clippy and workspace unit tests
- Python facade tests and star-import/public-export checks
- browser/WASM package build and authoring footprint
- dedicated end-to-end `scripts/svg-authoring-smoke.mjs` through normal retained execution
- PR Fast WebGPU + WebGL rendering path
- architecture and layer-dependency ratchets

## Canonical ManimCE qualification
A same-source canonical fixture now lives at `parity/manim-v0.21/core-examples/svg_static_import.py`. The dedicated `Static SVG Manim raster qualification` workflow runs the repository's existing ManimCE 0.21 Cairo semantic/raster harness unchanged against Noon WebGPU and WebGL using `parity/manim-v0.21/svg-manifest.json`.

**Current status:** that canonical qualification workflow is running on the current branch head. The compatibility ledger remains conservative (`SVGMobject` is not promoted yet) until the oracle clears.

## Still outside this tranche / #79 remains open
- gradients/patterns, clip paths, masks, filters and SVG text/image nodes
- dashed/even-odd/group-compositing cases not representable by the current semantic style model
- stable imported element/subpath identity needed for matching/hot reload
- repeated-asset identity/cache qualification beyond the existing immutable geometry deduplication
- URL/blob/packaged runtime asset-loading boundaries
- live SVG construction/replacement
- raster `ImageMobject` and texture residency/decode paths
- broader Manim parser/configuration surface

This PR is intentionally a partial #79 slice; it does not claim complete SVG/image support or close #79.