### PR TITLE
B2: publish live Arrow scaling atomically

### DIFF
--- a/crates/noon-web/src/authoring_arrow.rs
+++ b/crates/noon-web/src/authoring_arrow.rs
@@ -433,7 +433,7 @@ pub struct WasmAuthoringArrowHandle {
 }
 
 impl WasmAuthoringArrowHandle {
-    fn arrow(&self) -> Result<&noon::ManimArrow, JsValue> {
+    pub(crate) fn arrow(&self) -> Result<&noon::ManimArrow, JsValue> {
         match &self.published {
             PublishedArrowRequest::Arrow(arrow) => Ok(arrow),
             PublishedArrowRequest::VectorField(_) => Err(invalid_input(

--- a/crates/noon-web/src/canonical_authoring_scene.rs
+++ b/crates/noon-web/src/canonical_authoring_scene.rs
@@ -2376,6 +2376,18 @@ impl CanonicalAuthoringScene {
     }
 
     #[cfg(any(target_arch = "wasm32", test))]
+    fn live_scale_arrow(
+        &mut self,
+        arrow: &noon::ManimArrow,
+        factor: f64,
+        scale_tips: bool,
+    ) -> Result<(), AuthoringFailure> {
+        self.active_live_player()
+            .map_err(AuthoringFailure::from)?
+            .live_scale_arrow(arrow, factor, scale_tips)
+    }
+
+    #[cfg(any(target_arch = "wasm32", test))]
     fn live_replace_content(
         &mut self,
         target: &noon::Mobject,
@@ -6842,6 +6854,19 @@ mod wasm {
                 .map_err(typed_js_error)
         }
 
+        #[wasm_bindgen(js_name = liveScaleArrow)]
+        pub fn live_scale_arrow(
+            &mut self,
+            handle: &crate::WasmAuthoringArrowHandle,
+            factor: f64,
+            scale_tips: bool,
+        ) -> Result<(), JsValue> {
+            let arrow = handle.arrow()?;
+            self.inner
+                .live_scale_arrow(arrow, factor, scale_tips)
+                .map_err(typed_js_error)
+        }
+
         #[wasm_bindgen(js_name = liveScaleFamily)]
         pub fn live_scale_family(
             &mut self,
@@ -8075,6 +8100,32 @@ mod tests {
         );
         context.return_execution_player(resumed).unwrap();
         assert_eq!(context.live_execution_ownership(), "returned");
+    }
+
+    #[test]
+    fn arrow_scale_rejects_a_transferred_player_without_authored_fallback() {
+        let mut context = CanonicalAuthoringScene::default();
+        let mut options = noon::ManimArrowOptions::arrow(-1.0, 0.0, 1.0, 0.0).unwrap();
+        options.set_buff(0.0).unwrap();
+        let arrow = context.scene.manim_arrow(options).unwrap();
+        context.scene.add_many(&[arrow.family().into()]).unwrap();
+        context.live_player(1.0).unwrap();
+        let player = context.take_execution_player(1.0, 17).unwrap();
+        let revision = context.scene.integration_store().borrow().scene_revision();
+        let before_shaft = arrow.shaft().state().unwrap();
+        let before_tip = arrow.end_tip().state().unwrap();
+
+        assert!(context.live_scale_arrow(&arrow, 0.5, false).is_err());
+        assert_eq!(
+            context.scene.integration_store().borrow().scene_revision(),
+            revision
+        );
+        assert_eq!(arrow.shaft().state().unwrap(), before_shaft);
+        assert_eq!(arrow.end_tip().state().unwrap(), before_tip);
+
+        context.return_execution_player(player).unwrap();
+        context.live_scale_arrow(&arrow, 0.5, false).unwrap();
+        assert!((arrow.manim_length().unwrap() - 1.0).abs() < 1e-5);
     }
 
     #[test]

--- a/crates/noon-web/src/semantic_execution_player.rs
+++ b/crates/noon-web/src/semantic_execution_player.rs
@@ -1047,6 +1047,16 @@ impl SemanticExecutionPlayer {
         })
     }
 
+    #[cfg(any(target_arch = "wasm32", test))]
+    pub(crate) fn live_scale_arrow(
+        &mut self,
+        arrow: &noon::ManimArrow,
+        factor: f64,
+        scale_tips: bool,
+    ) -> Result<(), AuthoringFailure> {
+        self.with_live_session(|session| session.scale_arrow(arrow, factor, scale_tips))
+    }
+
     #[cfg(target_arch = "wasm32")]
     pub(crate) fn live_scale_family(
         &mut self,

--- a/crates/noon/src/arrow_scale.rs
+++ b/crates/noon/src/arrow_scale.rs
@@ -84,6 +84,26 @@ impl ManimArrow {
     /// by the authoritative semantic shaft role. All changed leaves publish in one
     /// semantic transaction and unrelated scene state is untouched.
     pub fn scale(&self, factor: f64, scale_tips: bool) -> Result<(), ArrowScaleError> {
+        let Some(transaction) = self.prepare_scale_transaction(factor, scale_tips)? else {
+            return Ok(());
+        };
+        let store = self.family().integration_store();
+        transaction
+            .apply(&mut store.borrow_mut())
+            .map(|_| ())
+            .map_err(AuthoringError::from)?;
+        Ok(())
+    }
+
+    /// Prepare the complete dependent Arrow edit without publishing it.
+    ///
+    /// Detached authoring and live execution share this exact transaction;
+    /// only the owning publication path differs.
+    fn prepare_scale_transaction(
+        &self,
+        factor: f64,
+        scale_tips: bool,
+    ) -> Result<Option<SemanticMutationTransaction>, ArrowScaleError> {
         let factor = crate::integration::authoring_render_f64("arrow scale factor", factor)?;
         let policy = self.validate_scale_components()?;
         let endpoints = self.manim_endpoints()?;
@@ -93,7 +113,7 @@ impl ManimArrow {
 
         // Pinned ManimCE returns immediately for a zero-length Arrow.
         if old_length == 0.0 {
-            return Ok(());
+            return Ok(None);
         }
 
         let previous_shaft = self.shaft().state()?;
@@ -145,11 +165,7 @@ impl ManimArrow {
                 next,
             );
         }
-        transaction
-            .apply(&mut store.borrow_mut())
-            .map(|_| ())
-            .map_err(AuthoringError::from)?;
-        Ok(())
+        Ok(Some(transaction))
     }
 
     fn validate_scale_components(&self) -> Result<SemanticArrowShaftRole, ArrowScaleError> {
@@ -342,6 +358,43 @@ impl ManimArrow {
             .min(snapshot.policy.max_stroke_width_to_length_ratio() * new_length);
 
         Ok((next_shaft, next_end_tip, next_start_tip))
+    }
+}
+
+impl crate::LiveSession<'_> {
+    /// Scale one retained Arrow dependency closure through the owning live session.
+    ///
+    /// Component identity and immutable tip resources are retained. The authored
+    /// store is never changed separately from the active execution publication.
+    pub fn scale_arrow(
+        &mut self,
+        arrow: &ManimArrow,
+        factor: f64,
+        scale_tips: bool,
+    ) -> Result<(), crate::LiveSessionError> {
+        // Validate ownership before deriving any dependent edit. The aggregate Arrow
+        // is constructed from one store, so checking its retained leaves also checks
+        // the family capability without inventing frontend ownership state.
+        self.authored(arrow.shaft())?;
+        self.authored(arrow.end_tip())?;
+        if let Some(start_tip) = arrow.start_tip() {
+            self.authored(start_tip)?;
+        }
+
+        let Some(transaction) = arrow
+            .prepare_scale_transaction(factor, scale_tips)
+            .map_err(live_arrow_scale_error)?
+        else {
+            return Ok(());
+        };
+        self.apply(transaction).map(|_| ())
+    }
+}
+
+fn live_arrow_scale_error(error: ArrowScaleError) -> crate::LiveSessionError {
+    match error {
+        ArrowScaleError::Authoring(error) => crate::LiveSessionError::Authoring(error),
+        other => crate::LiveSessionError::Mobject(other.to_string()),
     }
 }
 
@@ -589,6 +642,67 @@ mod tests {
             start_resource
         );
         assert!((arrow.manim_length().unwrap() - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn live_scale_publishes_the_arrow_dependency_closure_once() {
+        let mut scene = Scene::new();
+        let mut options = ManimArrowOptions::arrow(-1.0, 0.0, 1.0, 0.0).unwrap();
+        options.set_buff(0.0).unwrap();
+        let arrow = ManimArrow::create(Rc::clone(scene.integration_store()), options).unwrap();
+        scene.add_many(&[arrow.family().into()]).unwrap();
+        let tip_resource = resource_handle(&arrow.end_tip().state().unwrap());
+        let before_revision = scene.integration_store().borrow().scene_revision();
+        let mut session = scene.execution_session().unwrap();
+
+        scene
+            .live(&mut session)
+            .scale_arrow(&arrow, 0.5, false)
+            .unwrap();
+
+        assert!((arrow.manim_length().unwrap() - 1.0).abs() < 1e-5);
+        assert_eq!(
+            resource_handle(&arrow.end_tip().state().unwrap()),
+            tip_resource
+        );
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            before_revision.checked_next().unwrap()
+        );
+    }
+
+    #[test]
+    fn live_scale_rejects_a_stale_session_without_partial_arrow_mutation() {
+        let mut scene = Scene::new();
+        let mut options = ManimArrowOptions::arrow(-1.0, 0.0, 1.0, 0.0).unwrap();
+        options.set_buff(0.0).unwrap();
+        let arrow = ManimArrow::create(Rc::clone(scene.integration_store()), options).unwrap();
+        scene.add_many(&[arrow.family().into()]).unwrap();
+        let mut session = scene.execution_session().unwrap();
+
+        // A direct authored mutation after lowering deliberately stales this runtime.
+        arrow.scale(0.8, false).unwrap();
+        let stale_revision = scene.integration_store().borrow().scene_revision();
+        let before_shaft = arrow.shaft().state().unwrap();
+        let before_tip = arrow.end_tip().state().unwrap();
+
+        let error = scene
+            .live(&mut session)
+            .scale_arrow(&arrow, 0.5, false)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::LiveSessionError::Publication(
+                crate::ExecutionSessionPublicationError::StaleSceneRevision { .. }
+            )
+        ));
+        assert_eq!(
+            scene.integration_store().borrow().scene_revision(),
+            stale_revision
+        );
+        assert_eq!(arrow.shaft().state().unwrap(), before_shaft);
+        assert_eq!(arrow.end_tip().state().unwrap(), before_tip);
     }
 
     #[test]

--- a/web/python/_manim_arrow.py
+++ b/web/python/_manim_arrow.py
@@ -313,17 +313,29 @@ class Arrow(_compat.Group):
             raise NotImplementedError(
                 f"Arrow.scale pivot option(s) are not yet shared Rust semantics: {unknown}"
             )
-        if _shared._group_live_layout_context(self) is not None:
-            raise NotImplementedError(
-                "live Arrow.scale requires shared dependent publication support"
-            )
+        live_context = _shared._group_live_layout_context(self)
         handle = getattr(self, "_semantic_arrow_handle", None)
-        operation = getattr(handle, "scale", None) if handle is not None else None
+        if handle is None:
+            raise RuntimeError("Arrow.scale requires the shared Rust authoring host")
+        factor = _ir._finite_number("factor", factor)
+        if live_context is not None:
+            operation = getattr(live_context, "liveScaleArrow", None)
+            if operation is None:
+                raise RuntimeError("live Arrow.scale requires the shared Rust live host")
+            engine_call(
+                operation,
+                handle,
+                factor,
+                bool(scale_tips),
+                operation="Arrow.scale",
+            )
+            return self
+        operation = getattr(handle, "scale", None)
         if operation is None:
             raise RuntimeError("Arrow.scale requires the shared Rust authoring host")
         engine_call(
             operation,
-            _ir._finite_number("factor", factor),
+            factor,
             bool(scale_tips),
             operation="Arrow.scale",
         )


### PR DESCRIPTION
Advances #77; does not close it.

## What changed
- split Arrow scaling into shared transaction preparation + publication
- add `LiveSession::scale_arrow` so shaft + start/end tips publish through one owning live transaction
- preserve retained tip resource identity and the existing `scale_tips` semantics
- reject stale live sessions before any partial Arrow mutation
- route Python live `Arrow.scale()` through the typed Rust live host, including transferred-player ownership rejection
- keep detached/pre-bootstrap `Arrow.scale()` behavior unchanged

## Validation
- `cargo test -p noon arrow_scale --all-features`
- `cargo check -p noon-web --all-targets --all-features`
- `python3 -m py_compile web/python/_manim_arrow.py`

#77 remains open. Generic `DashedVMobject`, broader Arrow/tip surface, remaining Line breadth, B3 consumption, and final reconciliation are still separate follow-up slices.