### PR TITLE
Make Scene own LiveProgram execution

### DIFF
--- a/crates/noon/src/live_program.rs
+++ b/crates/noon/src/live_program.rs
@@ -1,7 +1,7 @@
 //! Target-neutral ownership for realtime Rust authoring continuations.
 //!
-//! A [`LiveProgram`] keeps the consumed semantic [`Scene`] paired with the one
-//! [`ExecutionSession`] lowered from it. It owns only the control-plane state
+//! A [`LiveProgram`] drives the one execution component owned by its consumed
+//! semantic [`Scene`]. It owns only the continuation control-plane state
 //! needed to await one existing [`ExecutionSegment`]. Timeline evaluation,
 //! callback ordering, semantic publication, and renderer-facing invalidation
 //! remain in their existing owners.
@@ -136,7 +136,6 @@ impl<E: Error + 'static> Error for LiveProgramError<E> {
 /// one existing segment and never creates another timeline or cursor.
 pub struct LiveProgram<C> {
     scene: Scene,
-    session: ExecutionSession,
     continuation: C,
     phase: LiveProgramPhase,
 }
@@ -147,13 +146,13 @@ impl Scene {
     /// Lowering happens once before the continuation starts. All later semantic
     /// work is available only through the program's temporary [`LiveSession`].
     pub fn into_live_program<C: LiveContinuation>(
-        self,
+        mut self,
         continuation: C,
     ) -> Result<LiveProgram<C>, noon_compile::SemanticExecutionLoweringError> {
-        let session = self.execution_session()?;
+        let execution = self.execution_session()?;
+        self.install_execution(execution);
         Ok(LiveProgram {
             scene: self,
-            session,
             continuation,
             phase: LiveProgramPhase::ReadyToResume,
         })
@@ -163,7 +162,7 @@ impl Scene {
 impl<C: LiveContinuation> LiveProgram<C> {
     /// Borrow the authoritative runtime for frame, wake, camera, and query observations.
     pub const fn session(&self) -> &ExecutionSession {
-        &self.session
+        self.scene.owned_execution()
     }
 
     /// Derive host cadence from the runtime and this program's one continuation barrier.
@@ -172,7 +171,7 @@ impl<C: LiveContinuation> LiveProgram<C> {
     /// callbacks and shared completion cannot be skipped merely because the
     /// underlying tokenless wait already reports a complete interval.
     pub fn wake_state(&self) -> noon_runtime::RuntimeWakeState {
-        let wake = self.session.wake_state();
+        let wake = self.session().wake_state();
         let LiveProgramPhase::Awaiting(segment) = self.phase else {
             // Only an awaited segment authorizes authored-time advancement.
             // Endpoint presentation, authoring resumption, and a finished source
@@ -180,17 +179,17 @@ impl<C: LiveContinuation> LiveProgram<C> {
             // callback registrations beyond the source's logical interval.
             return wake.without_timeline_wake();
         };
-        let timeline = if self.session.frame().time >= segment.end_time() {
-            noon_runtime::TimelineWakeState::Deadline(self.session.frame().time)
+        let timeline = if self.session().frame().time >= segment.end_time() {
+            noon_runtime::TimelineWakeState::Deadline(self.session().frame().time)
         } else {
-            self.session.segment_state(segment).timeline()
+            self.session().segment_state(segment).timeline()
         };
         wake.with_additional_timeline(timeline)
     }
 
     /// Query candidate frame rows through the session-owned derived spatial index.
     pub fn query_viewport(&mut self, bounds: Rect) -> ExecutionViewportQuery {
-        self.session.query_viewport(bounds)
+        self.scene.owned_execution_mut().query_viewport(bounds)
     }
 
     /// Deliver one normalized sampled native value without exposing mutable session authority.
@@ -200,11 +199,12 @@ impl<C: LiveContinuation> LiveProgram<C> {
         value: NativeInputValue,
     ) -> Result<&FrameState, LiveProgramError<C::Error>> {
         self.ensure_host_input_available("deliver native state input")?;
-        self.session
+        self.scene
+            .owned_execution_mut()
             .set_native_state_input(source, value)
             .map_err(LiveProgramError::Input)?;
         self.refresh_pending_publication();
-        Ok(self.session.frame())
+        Ok(self.session().frame())
     }
 
     /// Deliver one ordered native event without exposing mutable session authority.
@@ -213,23 +213,24 @@ impl<C: LiveContinuation> LiveProgram<C> {
         occurrence: NativeEventOccurrence,
     ) -> Result<&FrameState, LiveProgramError<C::Error>> {
         self.ensure_host_input_available("deliver a native event")?;
-        self.session
+        self.scene
+            .owned_execution_mut()
             .emit_native_event(occurrence)
             .map_err(LiveProgramError::Input)?;
         self.refresh_pending_publication();
-        Ok(self.session.frame())
+        Ok(self.session().frame())
     }
 
     /// Consume the runtime's current renderer-facing invalidation without copying state.
     pub fn take_renderer_publication(&mut self) -> RendererPublication<'_> {
-        self.session.take_renderer_publication()
+        self.scene.owned_execution_mut().take_renderer_publication()
     }
 
     pub fn status(&self) -> LiveProgramStatus {
         match self.phase {
             LiveProgramPhase::ReadyToResume => LiveProgramStatus::ReadyToResume,
             LiveProgramPhase::Awaiting(segment) => {
-                LiveProgramStatus::Awaiting(self.session.segment_state(segment))
+                LiveProgramStatus::Awaiting(self.session().segment_state(segment))
             }
             LiveProgramPhase::PublicationPending(publication) => {
                 LiveProgramStatus::PublicationPending(publication)
@@ -248,12 +249,13 @@ impl<C: LiveContinuation> LiveProgram<C> {
             return Err(self.invalid_state("resume authoring"));
         }
         let result = {
-            let mut live = self.scene.live(&mut self.session);
-            self.continuation.resume(&mut live)
+            let continuation = &mut self.continuation;
+            let mut live = self.scene.owned_live();
+            continuation.resume(&mut live)
         };
         match result {
             Ok(ContinuationStep::Await(segment)) => {
-                match self.session.validate_segment_for_advance(segment) {
+                match self.session().validate_segment_for_advance(segment) {
                     Ok(false) => {}
                     Ok(true) => {
                         self.phase = LiveProgramPhase::Terminal;
@@ -292,27 +294,28 @@ impl<C: LiveContinuation> LiveProgram<C> {
         let LiveProgramPhase::Awaiting(segment) = self.phase else {
             return Err(self.invalid_state("drive a segment"));
         };
-        if let Err(error) = callbacks.advance_segment_to(&mut self.session, segment, requested_time)
+        if let Err(error) =
+            callbacks.advance_segment_to(self.scene.owned_execution_mut(), segment, requested_time)
         {
             self.phase = LiveProgramPhase::Terminal;
             return Err(LiveProgramError::Callback(error));
         }
-        if self.session.frame().time < segment.end_time() {
+        if self.session().frame().time < segment.end_time() {
             return Ok(self.status());
         }
 
         let completion = {
-            let mut live = self.scene.live(&mut self.session);
+            let mut live = self.scene.owned_live();
             live.complete_segment(segment)
         };
         if let Err(error) = completion {
             self.phase = LiveProgramPhase::Terminal;
             return Err(LiveProgramError::Completion(error));
         }
-        debug_assert!(self.session.segment_state(segment).is_complete());
+        debug_assert!(self.session().segment_state(segment).is_complete());
 
-        self.phase = if self.session.wake_state().frame_pending() {
-            LiveProgramPhase::PublicationPending(self.session.publication_context())
+        self.phase = if self.session().wake_state().frame_pending() {
+            LiveProgramPhase::PublicationPending(self.session().publication_context())
         } else {
             LiveProgramPhase::ReadyToResume
         };
@@ -337,7 +340,7 @@ impl<C: LiveContinuation> LiveProgram<C> {
                 actual: publication,
             });
         }
-        if self.session.wake_state().frame_pending() {
+        if self.session().wake_state().frame_pending() {
             return Err(LiveProgramError::PublicationStillPending { expected });
         }
         self.phase = LiveProgramPhase::ReadyToResume;
@@ -363,7 +366,8 @@ impl<C: LiveContinuation> LiveProgram<C> {
 
     fn refresh_pending_publication(&mut self) {
         if matches!(self.phase, LiveProgramPhase::PublicationPending(_)) {
-            self.phase = LiveProgramPhase::PublicationPending(self.session.publication_context());
+            let publication = self.session().publication_context();
+            self.phase = LiveProgramPhase::PublicationPending(publication);
         }
     }
 }
@@ -567,7 +571,7 @@ mod tests {
         ));
         assert_eq!(foreign_program.status(), LiveProgramStatus::Terminal);
 
-        let (scene, session, pending) = scene_with_pending_segment();
+        let (mut scene, session, pending) = scene_with_pending_segment();
         let pending_token = pending.token().unwrap();
         let stale_sequence = crate::execution_segment::ExecutionSegmentSequence::new(
             pending_token.sequence().get().checked_add(1).unwrap(),
@@ -578,9 +582,9 @@ mod tests {
                 session.runtime_identity(),
                 stale_sequence,
             ));
+        scene.install_execution(session);
         let mut stale_program = LiveProgram {
             scene,
-            session,
             continuation: ReturnSegment(stale),
             phase: LiveProgramPhase::ReadyToResume,
         };

--- a/crates/noon/src/scene.rs
+++ b/crates/noon/src/scene.rs
@@ -10,14 +10,16 @@ use noon_core::{
 };
 use std::{cell::RefCell, rc::Rc};
 
-/// A scene owns only its shared semantic store, root identity, and authoring cursor.
-/// Direct membership edits prepare a subsequent execution session. Use
-/// [`LiveSession`] to publish supported membership changes into an existing session.
+/// A scene owns its shared semantic store/root and, after bootstrap, the one
+/// execution component lowered from them. The optional execution slot is control
+/// ownership only; Runtime state remains owned by the contained [`ExecutionSession`].
+/// Direct integration callers may still create standalone sessions during migration.
 #[derive(Debug)]
 pub struct Scene {
     store: Rc<RefCell<SemanticStore>>,
     root: SemanticNodeId,
     cursor: f64,
+    execution: Option<ExecutionSession>,
 }
 impl Default for Scene {
     fn default() -> Self {
@@ -45,6 +47,7 @@ impl Scene {
             store,
             root: *root,
             cursor: 0.0,
+            execution: None,
         }
     }
     /// Raw shared arena access for explicit integration, not live mutation.
@@ -257,6 +260,42 @@ impl Scene {
             origin,
         )
         .map_err(|error| error.to_string())
+    }
+
+    /// Install the execution component lowered from this exact Scene.
+    ///
+    /// This is private migration plumbing for the Scene-owned live path. External
+    /// integration entry points may still construct standalone sessions until the
+    /// broader control-surface migration removes that compatibility shape.
+    pub(crate) fn install_execution(&mut self, execution: ExecutionSession) {
+        assert!(
+            self.execution.is_none(),
+            "scene execution component may only be installed once"
+        );
+        self.execution = Some(execution);
+    }
+
+    pub(crate) const fn owned_execution(&self) -> &ExecutionSession {
+        match &self.execution {
+            Some(execution) => execution,
+            None => panic!("scene execution component is not initialized"),
+        }
+    }
+
+    pub(crate) fn owned_execution_mut(&mut self) -> &mut ExecutionSession {
+        self.execution
+            .as_mut()
+            .expect("scene execution component is not initialized")
+    }
+
+    pub(crate) fn owned_live(&mut self) -> LiveSession<'_> {
+        let root = self.root;
+        let store = &self.store;
+        let execution = self
+            .execution
+            .as_mut()
+            .expect("scene execution component is not initialized");
+        LiveSession::new(store, root, execution)
     }
 
     /// Borrow the already-published execution session for supported live membership,


### PR DESCRIPTION
## Summary

Implements the bounded first Wave-1 ownership slice from #1496 / #1484.

- adds one private optional execution slot to `Scene`;
- lowers first, then installs the matching `ExecutionSession` into the consumed `Scene`;
- removes the separate `ExecutionSession` field from `LiveProgram<C>`;
- routes existing LiveProgram session observation, input, viewport, renderer-publication, continuation, callback-drive, and completion paths through the Scene-owned execution component;
- preserves the existing public `LiveProgram`, `LiveContinuation`, `LiveSession`, `ExecutionSegment`, and host APIs in this slice.

## Boundary

Only `crates/noon/src/scene.rs` and `crates/noon/src/live_program.rs` are changed. No publication, animation IR, runtime, host, export, or architecture-doc changes are included.

The bootstrap remains failure-atomic: lowering completes before the Scene execution slot is installed.

## Complexity delta

`LiveProgram<C>` drops its separate execution-owner field (4 fields -> 3). The execution component now has one ownership location in `Scene`; the temporary public `session()` accessor is unchanged and delegates to that owned component. This slice intentionally adds private Scene accessors so later control-surface work can delete the facade without recreating the Scene/session pair.

## Validation

Exact head `72d839039de4f0bfba2fe561b253936cd9aeb72c`:
- PR Fast Gate — passed, including Rust format/lint, workspace library tests, web static/unit checks, browser fast checks, and primary WebGPU rendering;
- Architecture Ratchets — passed;
- Layer Dependency Ratchet — passed;
- Native Host Smoke — passed;
- Provider feature isolation — passed;
- all seven focused `live_program::tests` pass through the workspace all-feature library run.

The broader Playground cross-browser/product workflows are repository qualification and may still be running; no known failure is attributable to this bounded two-file ownership change.

Refs #1480
Refs #1484
Closes #1496