### PR TITLE
Diagnostic: qualify Shared text on current master

### DIFF
--- a/.github/workflows/retained-typst-authoring.yml
+++ b/.github/workflows/retained-typst-authoring.yml
@@ -85,3 +85,5 @@ jobs:
           npx playwright install chromium
       - name: Test retained Typst Python authoring
         run: node scripts/manim-typst-authoring-smoke.mjs
+
+# Diagnostic-only no-op: trigger this workflow against the current master integration baseline.


### PR DESCRIPTION
Temporary integration-isolation PR for #1410. The only change is a no-op comment in the Shared text workflow so the exact current master baseline (`ba7ae17733b2e14155bba57b873cfeb5e3bec946`) runs the same retained-Typst browser qualification that is failing on the refreshed #1410 head. Do not merge. Close after the result is captured.