### PR TITLE
Render transient VectorPath presentation with retained semantics

### DIFF
--- a/.github/workflows/1499-manifest-append.yml
+++ b/.github/workflows/1499-manifest-append.yml
@@ -1,0 +1,56 @@
+name: Append transient path raster fixture
+
+on:
+  push:
+    branches:
+      - codex/1499-transient-path-presentation
+
+permissions:
+  contents: write
+
+jobs:
+  append:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: codex/1499-transient-path-presentation
+      - name: Append manifest entry
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('parity/manim-v0.21/manifest.json')
+          text = path.read_text()
+          marker = '''    {
+            "id": "unequal-family-transform-contraction",
+            "scene": "UnequalFamilyTransformContraction",
+            "source": "parity/manim-v0.21/core-examples/unequal_family_transform.py",
+            "expected_duration": 1.0
+          }
+          '''
+          replacement = marker.rstrip() + ''',
+              {
+                "id": "unequal-family-path-transform-expansion",
+                "scene": "UnequalFamilyPathTransformExpansion",
+                "source": "parity/manim-v0.21/core-examples/unequal_family_transform.py",
+                "expected_duration": 1.0
+              }
+          '''
+          if text.count(marker) != 1:
+              raise SystemExit(f'expected one contraction manifest marker, found {text.count(marker)}')
+          text = text.replace(marker, replacement, 1)
+          path.write_text(text)
+          PY
+          python3 -m json.tool parity/manim-v0.21/manifest.json >/dev/null
+          git diff --check
+      - name: Commit manifest only
+        shell: bash
+        run: |
+          rm .github/workflows/1499-manifest-append.yml
+          git config user.name "Yongkyun Shin"
+          git config user.email "yongkyuns@gmail.com"
+          git add parity/manim-v0.21/manifest.json .github/workflows/1499-manifest-append.yml
+          git commit -m "Register unequal-family path raster fixture"
+          git push origin HEAD:codex/1499-transient-path-presentation

--- a/crates/noon-native/src/lib.rs
+++ b/crates/noon-native/src/lib.rs
@@ -23,8 +23,8 @@ use noon_core::{
 };
 use noon_render_wgpu::text::TextDeviceMetrics;
 use noon_render_wgpu::{
-    prepare_derived_display_visible, Camera2D, GpuRenderer, RetainedFramePreparer,
-    RetainedTextGpuState,
+    Camera2D, GpuRenderer, RetainedFramePreparer, RetainedTextGpuState,
+    TransientPresentationPreparer,
 };
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
@@ -533,7 +533,9 @@ impl NativeApp {
             .as_mut()
             .expect("drawable native host must own GPU state");
         let metrics = gpu.text_metrics(camera)?;
-        let derived = prepare_derived_display_visible(&publication, visibility.object_indices())
+        let derived = gpu
+            .transient_preparer
+            .prepare_visible(&publication, visibility.object_indices())
             .map_err(|error| NativeHostError::Gpu(error.to_string()))?;
         let prepared = gpu
             .preparer
@@ -791,6 +793,7 @@ struct NativeGpu {
     config: wgpu::SurfaceConfiguration,
     drawable: bool,
     preparer: RetainedFramePreparer,
+    transient_preparer: TransientPresentationPreparer,
     text_state: RetainedTextGpuState,
     renderer: GpuRenderer,
 }
@@ -842,6 +845,7 @@ impl NativeGpu {
             config,
             drawable: size.width > 0 && size.height > 0,
             preparer: RetainedFramePreparer::new(),
+            transient_preparer: TransientPresentationPreparer::new(),
             text_state,
             renderer,
         })

--- a/crates/noon-render-wgpu/src/gpu/derived_display.rs
+++ b/crates/noon-render-wgpu/src/gpu/derived_display.rs
@@ -5,16 +5,25 @@ use crate::{
     PreparedGeometryObjectOutcome, RenderPrimitive,
 };
 
-use super::{empty_instance_buffer, ensure_capacity, DrawStats, GpuRenderer, UploadStats};
+use super::{
+    empty_buffer, empty_instance_buffer, ensure_capacity, ensure_capacity_with_usage, DrawStats,
+    GpuRenderer, UploadStats,
+};
 
 #[derive(Debug)]
 pub(super) struct DerivedDisplayGpu {
     circle_buffer: wgpu::Buffer,
     rectangle_buffer: wgpu::Buffer,
     line_buffer: wgpu::Buffer,
+    path_vertex_buffer: wgpu::Buffer,
+    path_index_buffer: wgpu::Buffer,
+    path_instance_buffer: wgpu::Buffer,
     circle_capacity_bytes: usize,
     rectangle_capacity_bytes: usize,
     line_capacity_bytes: usize,
+    path_vertex_capacity_bytes: usize,
+    path_index_capacity_bytes: usize,
+    path_instance_capacity_bytes: usize,
 }
 
 impl DerivedDisplayGpu {
@@ -23,9 +32,23 @@ impl DerivedDisplayGpu {
             circle_buffer: empty_instance_buffer(device, "Noon derived circle instances"),
             rectangle_buffer: empty_instance_buffer(device, "Noon derived rectangle instances"),
             line_buffer: empty_instance_buffer(device, "Noon derived line instances"),
+            path_vertex_buffer: empty_buffer(
+                device,
+                "Noon transient path vertices",
+                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            ),
+            path_index_buffer: empty_buffer(
+                device,
+                "Noon transient path indices",
+                wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+            ),
+            path_instance_buffer: empty_instance_buffer(device, "Noon transient path instances"),
             circle_capacity_bytes: 0,
             rectangle_capacity_bytes: 0,
             line_capacity_bytes: 0,
+            path_vertex_capacity_bytes: 0,
+            path_index_capacity_bytes: 0,
+            path_instance_capacity_bytes: 0,
         }
     }
 
@@ -38,6 +61,9 @@ impl DerivedDisplayGpu {
         let circle_bytes = std::mem::size_of_val(prepared.circles.as_slice());
         let rectangle_bytes = std::mem::size_of_val(prepared.rectangles.as_slice());
         let line_bytes = std::mem::size_of_val(prepared.lines.as_slice());
+        let path_vertex_bytes = std::mem::size_of_val(prepared.path_vertices.as_slice());
+        let path_index_bytes = std::mem::size_of_val(prepared.path_indices.as_slice());
+        let path_instance_bytes = std::mem::size_of_val(prepared.paths.as_slice());
         let mut buffer_reallocations = 0;
 
         buffer_reallocations += usize::from(ensure_capacity(
@@ -61,11 +87,37 @@ impl DerivedDisplayGpu {
             line_bytes,
             "Noon derived line instances",
         ));
+        buffer_reallocations += usize::from(ensure_capacity_with_usage(
+            device,
+            &mut self.path_vertex_buffer,
+            &mut self.path_vertex_capacity_bytes,
+            path_vertex_bytes,
+            "Noon transient path vertices",
+            wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        ));
+        buffer_reallocations += usize::from(ensure_capacity_with_usage(
+            device,
+            &mut self.path_index_buffer,
+            &mut self.path_index_capacity_bytes,
+            path_index_bytes,
+            "Noon transient path indices",
+            wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+        ));
+        buffer_reallocations += usize::from(ensure_capacity(
+            device,
+            &mut self.path_instance_buffer,
+            &mut self.path_instance_capacity_bytes,
+            path_instance_bytes,
+            "Noon transient path instances",
+        ));
 
         let mut bytes_uploaded = 0;
         bytes_uploaded += upload_all(queue, &self.circle_buffer, &prepared.circles);
         bytes_uploaded += upload_all(queue, &self.rectangle_buffer, &prepared.rectangles);
         bytes_uploaded += upload_all(queue, &self.line_buffer, &prepared.lines);
+        bytes_uploaded += upload_all(queue, &self.path_vertex_buffer, &prepared.path_vertices);
+        bytes_uploaded += upload_all(queue, &self.path_index_buffer, &prepared.path_indices);
+        bytes_uploaded += upload_all(queue, &self.path_instance_buffer, &prepared.paths);
         UploadStats {
             bytes_uploaded,
             buffer_reallocations,
@@ -332,6 +384,44 @@ impl GpuRenderer {
                     &self.derived_display.line_buffer,
                     instance_index,
                 ),
+                MixedDrawItem::Derived {
+                    primitive: DerivedDisplayPrimitive::Path { batch, reveal_head },
+                    instance_index,
+                } => {
+                    let path = &derived.path_batches[batch];
+                    if !path.index_range.is_empty() {
+                        pass.set_pipeline(&self.path_pipeline);
+                        pass.set_vertex_buffer(
+                            0,
+                            self.derived_display.path_vertex_buffer.slice(..),
+                        );
+                        pass.set_vertex_buffer(
+                            1,
+                            self.derived_display.path_instance_buffer.slice(..),
+                        );
+                        pass.set_index_buffer(
+                            self.derived_display.path_index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        let start = u32::try_from(instance_index)
+                            .expect("transient path instance count exceeds wgpu limits");
+                        pass.draw_indexed(path.index_range.clone(), 0, start..start + 1);
+                        stats.draw_calls += 1;
+                        stats.instances_drawn += 1;
+                    }
+                    if let Some(head_index) = reveal_head {
+                        draw_analytic(
+                            pass,
+                            line_pipeline,
+                            &self.quad_buffer,
+                            &self.derived_display.line_buffer,
+                            head_index,
+                        );
+                        stats.draw_calls += 1;
+                        stats.instances_drawn += 1;
+                    }
+                    continue;
+                }
             }
             stats.draw_calls += 1;
             stats.instances_drawn += 1;

--- a/crates/noon-render-wgpu/src/gpu/mod.rs
+++ b/crates/noon-render-wgpu/src/gpu/mod.rs
@@ -937,7 +937,16 @@ impl GpuRenderer {
         query_set: Option<&wgpu::QuerySet>,
     ) -> DrawStats {
         let scene_view = self.presentation.scene_view(view);
-        let sample_count = ordered_render_sample_count(prepared.path_batches);
+        let sample_count = if derived.is_some_and(|presentation| {
+            presentation
+                .path_batches
+                .iter()
+                .any(|batch| !batch.index_range.is_empty())
+        }) {
+            PATH_SAMPLE_COUNT
+        } else {
+            ordered_render_sample_count(prepared.path_batches)
+        };
         let stats = if sample_count == 1 {
             // Analytic SDF primitives already use derivative-based edge coverage. When
             // no visible vector path participates in painter order, avoid 4x sample

--- a/crates/noon-render-wgpu/src/lib.rs
+++ b/crates/noon-render-wgpu/src/lib.rs
@@ -486,6 +486,125 @@ struct CachedPathMesh {
     last_used: u64,
 }
 
+impl CachedPathMesh {
+    fn matches(&self, path: &VectorPath, style: Style, transform: Transform2D) -> bool {
+        self.path == *path
+            && self.stroke_transform == path_stroke_transform_key(style, transform)
+            && self.stroke_width_bits == style.stroke_width.to_bits()
+            && self.stroke_join == style.stroke_join
+            && self.stroke_cap == style.stroke_cap
+            && self.fill_enabled == style.fill.is_some()
+    }
+}
+
+/// Renderer-local preparation reuse for identity-free transient paths.
+///
+/// Entries use the exact same key and tessellation function as stable retained
+/// paths, but their lifetime is independent so transient retirement never moves
+/// or invalidates stable renderer residency.
+#[derive(Debug, Default)]
+pub(crate) struct TransientPathMeshCache {
+    entries: Vec<CachedPathMesh>,
+    lookup: HashMap<PathMeshKey, Vec<usize>>,
+    clock: u64,
+    hits: u64,
+    misses: u64,
+}
+
+impl TransientPathMeshCache {
+    pub(crate) fn mesh(
+        &mut self,
+        path: &VectorPath,
+        style: Style,
+        transform: Transform2D,
+    ) -> Result<&TessellatedPath, noon_geometry::GeometryError> {
+        let stroke_transform = path_stroke_transform_key(style, transform);
+        let key = path_mesh_key(
+            path,
+            stroke_transform,
+            style.stroke_width.to_bits(),
+            style.stroke_join,
+            style.stroke_cap,
+            style.fill.is_some(),
+        );
+        let existing = self.lookup.get(&key).and_then(|candidates| {
+            candidates
+                .iter()
+                .copied()
+                .find(|&index| self.entries[index].matches(path, style, transform))
+        });
+        if let Some(index) = existing {
+            let last_used = self.next_use();
+            self.entries[index].last_used = last_used;
+            self.hits = self.hits.saturating_add(1);
+            return Ok(&self.entries[index].mesh);
+        }
+
+        if self.entries.len() >= DEFAULT_PATH_MESH_CACHE_LIMIT {
+            self.evict_oldest();
+        }
+        let mesh = tessellate_path_mesh(path, style, transform)?;
+        let last_used = self.next_use();
+        let index = self.entries.len();
+        self.entries.push(CachedPathMesh {
+            path: path.clone(),
+            stroke_transform,
+            stroke_width_bits: style.stroke_width.to_bits(),
+            stroke_join: style.stroke_join,
+            stroke_cap: style.stroke_cap,
+            fill_enabled: style.fill.is_some(),
+            mesh,
+            resident: None,
+            last_used,
+        });
+        self.lookup.entry(key).or_default().push(index);
+        self.misses = self.misses.saturating_add(1);
+        Ok(&self.entries[index].mesh)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn hits(&self) -> u64 {
+        self.hits
+    }
+
+    pub(crate) fn misses(&self) -> u64 {
+        self.misses
+    }
+
+    fn next_use(&mut self) -> u64 {
+        self.clock = self.clock.saturating_add(1);
+        self.clock
+    }
+
+    fn evict_oldest(&mut self) {
+        let Some(index) = self
+            .entries
+            .iter()
+            .enumerate()
+            .min_by_key(|(index, entry)| (entry.last_used, *index))
+            .map(|(index, _)| index)
+        else {
+            return;
+        };
+        self.entries.remove(index);
+        self.lookup.clear();
+        for (index, entry) in self.entries.iter().enumerate() {
+            let key = path_mesh_key(
+                &entry.path,
+                entry.stroke_transform,
+                entry.stroke_width_bits,
+                entry.stroke_join,
+                entry.stroke_cap,
+                entry.fill_enabled,
+            );
+            self.lookup.entry(key).or_default().push(index);
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct PathReplacementStats {
     cache_miss: bool,
@@ -1808,32 +1927,7 @@ impl FramePreparer {
             return Ok((index, false));
         }
 
-        let transformed_path;
-        let tessellation_path = if style.stroke_width_mode == StrokeWidthMode::ScreenSpace {
-            transformed_path = transform_path_without_translation(path, transform);
-            &transformed_path
-        } else {
-            path
-        };
-        // Correspondence is established by shared transform preparation. Stroke
-        // scaling affects tessellation coordinates, never semantic point pairing.
-        let mesh = if tessellation_path.morph_target().is_some() {
-            noon_geometry::tessellate_styled_with_fill_preserving_morph_order(
-                tessellation_path,
-                style.stroke_width,
-                style.stroke_join,
-                style.stroke_cap,
-                fill_enabled,
-            )?
-        } else {
-            noon_geometry::tessellate_styled_with_fill(
-                tessellation_path,
-                style.stroke_width,
-                style.stroke_join,
-                style.stroke_cap,
-                fill_enabled,
-            )?
-        };
+        let mesh = tessellate_path_mesh(path, style, transform)?;
         let index = self.path_mesh_cache.len();
         let last_used = self.next_path_mesh_use();
         self.path_mesh_cache.push(CachedPathMesh {
@@ -2077,6 +2171,41 @@ fn transform_path_without_translation(path: &VectorPath, transform: Transform2D)
     })
 }
 
+/// Canonical path tessellation used by both stable retained paths and
+/// identity-free transient path presentation.
+pub(crate) fn tessellate_path_mesh(
+    path: &VectorPath,
+    style: Style,
+    transform: Transform2D,
+) -> Result<TessellatedPath, noon_geometry::GeometryError> {
+    let transformed_path;
+    let tessellation_path = if style.stroke_width_mode == StrokeWidthMode::ScreenSpace {
+        transformed_path = transform_path_without_translation(path, transform);
+        &transformed_path
+    } else {
+        path
+    };
+    // Correspondence is established by shared transform preparation. Stroke
+    // scaling affects tessellation coordinates, never semantic point pairing.
+    if tessellation_path.morph_target().is_some() {
+        noon_geometry::tessellate_styled_with_fill_preserving_morph_order(
+            tessellation_path,
+            style.stroke_width,
+            style.stroke_join,
+            style.stroke_cap,
+            style.fill.is_some(),
+        )
+    } else {
+        noon_geometry::tessellate_styled_with_fill(
+            tessellation_path,
+            style.stroke_width,
+            style.stroke_join,
+            style.stroke_cap,
+            style.fill.is_some(),
+        )
+    }
+}
+
 fn packed_path_transform(style: Style, transform: Transform2D) -> PackedTransform {
     if style.stroke_width_mode == StrokeWidthMode::ScreenSpace {
         PackedTransform {
@@ -2154,10 +2283,14 @@ fn hash_vec2(value: noon_core::Vec2, hasher: &mut impl Hasher) {
     value.y.to_bits().hash(hasher);
 }
 
+fn pack_style_values(style: Style, appearance: f32) -> PackedStyle {
+    let mut packed: PackedStyle = style.into();
+    packed.opacity *= appearance.clamp(0.0, 1.0);
+    packed
+}
+
 fn pack_style(object: &FrameObjectState) -> PackedStyle {
-    let mut style: PackedStyle = object.style.into();
-    style.opacity *= object.appearance.clamp(0.0, 1.0);
-    style
+    pack_style_values(object.style, object.appearance)
 }
 
 fn pack_circle(object: &FrameObjectState, reveal: f32) -> CircleInstance {
@@ -2208,10 +2341,14 @@ fn pack_line(object: &FrameObjectState, reveal: f32) -> LineInstance {
 }
 
 fn should_create_path_reveal_head(object: &FrameObjectState, reveal: f32) -> bool {
+    should_create_path_reveal_head_for_style(object.style, reveal)
+}
+
+fn should_create_path_reveal_head_for_style(style: Style, reveal: f32) -> bool {
     reveal < 1.0
-        && object.style.stroke_cap == StrokeCap::Round
-        && object.style.stroke_width > 0.0
-        && (object.style.stroke.is_some() || object.style.fill.is_some())
+        && style.stroke_cap == StrokeCap::Round
+        && style.stroke_width > 0.0
+        && (style.stroke.is_some() || style.fill.is_some())
 }
 
 fn pack_path_reveal_head(
@@ -2220,14 +2357,41 @@ fn pack_path_reveal_head(
     mesh: &TessellatedPath,
     reveal: f32,
 ) -> LineInstance {
+    pack_path_reveal_head_values(
+        object.style,
+        object.appearance,
+        render_transform,
+        mesh,
+        reveal,
+    )
+}
+
+pub(crate) fn pack_transient_path_reveal_head(
+    style: Style,
+    appearance: f32,
+    render_transform: Transform2D,
+    mesh: &TessellatedPath,
+    reveal: f32,
+) -> Option<LineInstance> {
+    should_create_path_reveal_head_for_style(style, reveal)
+        .then(|| pack_path_reveal_head_values(style, appearance, render_transform, mesh, reveal))
+}
+
+fn pack_path_reveal_head_values(
+    source_style: Style,
+    appearance: f32,
+    render_transform: Transform2D,
+    mesh: &TessellatedPath,
+    reveal: f32,
+) -> LineInstance {
     let reveal = reveal.clamp(0.0, 1.0);
     let point = mesh.reveal_head_position(reveal).unwrap_or(Vec2::ZERO);
-    let mut transform = packed_path_transform(object.style, render_transform);
+    let mut transform = packed_path_transform(source_style, render_transform);
     transform.padding = 1.0;
-    let mut style = pack_style(object);
+    let mut style = pack_style_values(source_style, appearance);
     style.fill = [0.0; 4];
     style.fill_enabled = 0;
-    if let Some(color) = object.style.stroke.or(object.style.fill) {
+    if let Some(color) = source_style.stroke.or(source_style.fill) {
         style.stroke = [color.red, color.green, color.blue, color.alpha];
         style.stroke_enabled = (style.stroke_enabled & 2) | 1;
     } else {
@@ -2236,7 +2400,7 @@ fn pack_path_reveal_head(
     }
     let active = reveal > 0.0 && reveal < 1.0;
     style.opacity *= f32::from(active);
-    if object.style.stroke.is_none() {
+    if source_style.stroke.is_none() {
         style.opacity *= 1.0 - smoothstep(0.75, 1.0, reveal);
     }
     LineInstance {
@@ -2261,14 +2425,30 @@ fn pack_path(
     reveal: f32,
     morph: f32,
 ) -> PathInstance {
+    pack_transient_path_instance(
+        object.style,
+        object.appearance,
+        render_transform,
+        reveal,
+        morph,
+    )
+}
+
+pub(crate) fn pack_transient_path_instance(
+    style: Style,
+    appearance: f32,
+    render_transform: Transform2D,
+    reveal: f32,
+    morph: f32,
+) -> PathInstance {
     PathInstance {
-        transform: packed_path_transform(object.style, render_transform),
-        style: pack_style(object),
+        transform: packed_path_transform(style, render_transform),
+        style: pack_style_values(style, appearance),
         path_params: [reveal.clamp(0.0, 1.0), morph.clamp(0.0, 1.0)],
     }
 }
 
-fn pack_path_surface(surface: PathSurface, progress: f32) -> u32 {
+pub(crate) fn pack_path_surface(surface: PathSurface, progress: f32) -> u32 {
     let progress = (progress.clamp(0.0, 1.0) * PATH_PROGRESS_MAX as f32).round() as u32;
     (progress << 1)
         | match surface {

--- a/crates/noon-render-wgpu/src/render_order.rs
+++ b/crates/noon-render-wgpu/src/render_order.rs
@@ -810,6 +810,10 @@ pub enum DerivedDisplayPrimitive {
     Circle,
     Rectangle,
     Line,
+    Path {
+        batch: usize,
+        reveal_head: Option<usize>,
+    },
 }
 
 /// One lookup row into the transient derived-instance buffers.
@@ -839,6 +843,10 @@ pub struct PreparedDerivedDisplay {
     pub circles: Vec<crate::CircleInstance>,
     pub rectangles: Vec<crate::RectangleInstance>,
     pub lines: Vec<crate::LineInstance>,
+    pub paths: Vec<crate::PathInstance>,
+    pub path_vertices: Vec<crate::PathVertex>,
+    pub path_indices: Vec<u32>,
+    pub path_batches: Vec<crate::PathBatch>,
     pub slots: Vec<PreparedDerivedDisplaySlot>,
     pub painter_items: Vec<DisplayPainterItem>,
 }
@@ -859,6 +867,7 @@ pub enum DerivedDisplayRenderError {
     DerivedObjectNotPresent(u32),
     UnsupportedContent(u32),
     UnsupportedGeometry(u32),
+    PathPreparation(u32),
 }
 
 impl std::fmt::Display for DerivedDisplayRenderError {
@@ -882,7 +891,11 @@ impl std::fmt::Display for DerivedDisplayRenderError {
             ),
             Self::UnsupportedGeometry(occurrence) => write!(
                 formatter,
-                "derived display occurrence {occurrence} requires transient path/external geometry packing"
+                "derived display occurrence {occurrence} requires unsupported external geometry packing"
+            ),
+            Self::PathPreparation(occurrence) => write!(
+                formatter,
+                "derived display occurrence {occurrence} failed transient path preparation"
             ),
         }
     }
@@ -890,35 +903,72 @@ impl std::fmt::Display for DerivedDisplayRenderError {
 
 impl std::error::Error for DerivedDisplayRenderError {}
 
-/// Pack analytic derived display rows and merge their occurrence order immediately
-/// after each stable source anchor without modifying the stable frame preparer.
+/// Persistent renderer preparation for identity-free transient presentation.
 ///
-/// Vector paths, external geometry and text intentionally fail closed in this first
-/// renderer slice. Those need the renderer's retained resource/tessellation lanes;
-/// assigning a fake `ObjectId` merely to reuse stable slot packing is forbidden.
+/// Analytic instances are publication-local. Vector paths additionally reuse a
+/// renderer-local mesh cache whose key and tessellation semantics are identical to
+/// stable retained paths; no stable object identity or slot is created.
+#[derive(Debug, Default)]
+pub struct TransientPresentationPreparer {
+    path_cache: crate::TransientPathMeshCache,
+}
+
+impl TransientPresentationPreparer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn prepare(
+        &mut self,
+        publication: &noon_runtime::RendererPublication<'_>,
+    ) -> Result<PreparedDerivedDisplay, DerivedDisplayRenderError> {
+        prepare_derived_display_inner(publication, None, &mut self.path_cache)
+    }
+
+    pub fn prepare_visible(
+        &mut self,
+        publication: &noon_runtime::RendererPublication<'_>,
+        visible_object_indices: &[usize],
+    ) -> Result<PreparedDerivedDisplay, DerivedDisplayRenderError> {
+        let visible = visible_object_indices
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        prepare_derived_display_inner(publication, Some(&visible), &mut self.path_cache)
+    }
+
+    pub fn cached_path_mesh_count(&self) -> usize {
+        self.path_cache.len()
+    }
+
+    pub fn path_cache_hits(&self) -> u64 {
+        self.path_cache.hits()
+    }
+
+    pub fn path_cache_misses(&self) -> u64 {
+        self.path_cache.misses()
+    }
+}
+
+/// Compatibility convenience for callers that do not need cross-frame path reuse.
 pub fn prepare_derived_display(
     publication: &noon_runtime::RendererPublication<'_>,
 ) -> Result<PreparedDerivedDisplay, DerivedDisplayRenderError> {
-    prepare_derived_display_inner(publication, None)
+    TransientPresentationPreparer::new().prepare(publication)
 }
 
-/// Prepare only derived occurrences whose real source anchor participates in this
-/// viewport projection. Stable and derived painter ordering still comes from the
-/// authoritative publication order rather than candidate order.
+/// Compatibility convenience for candidate-filtered one-shot preparation.
 pub fn prepare_derived_display_visible(
     publication: &noon_runtime::RendererPublication<'_>,
     visible_object_indices: &[usize],
 ) -> Result<PreparedDerivedDisplay, DerivedDisplayRenderError> {
-    let visible = visible_object_indices
-        .iter()
-        .copied()
-        .collect::<std::collections::HashSet<_>>();
-    prepare_derived_display_inner(publication, Some(&visible))
+    TransientPresentationPreparer::new().prepare_visible(publication, visible_object_indices)
 }
 
 fn prepare_derived_display_inner(
     publication: &noon_runtime::RendererPublication<'_>,
     visible: Option<&std::collections::HashSet<usize>>,
+    path_cache: &mut crate::TransientPathMeshCache,
 ) -> Result<PreparedDerivedDisplay, DerivedDisplayRenderError> {
     let mut by_anchor =
         std::collections::BTreeMap::<u32, Vec<&noon_runtime::DerivedDisplayObject>>::new();
@@ -955,7 +1005,7 @@ fn prepare_derived_display_inner(
         };
         seen_anchors.insert(object_index);
         for &object in objects {
-            pack_derived_display_object(object, &mut prepared)?;
+            pack_derived_display_object(object, &mut prepared, path_cache)?;
             prepared.painter_items.push(DisplayPainterItem::Derived {
                 occurrence_index: object.occurrence_index(),
             });
@@ -975,6 +1025,7 @@ fn prepare_derived_display_inner(
 fn pack_derived_display_object(
     object: &noon_runtime::DerivedDisplayObject,
     prepared: &mut PreparedDerivedDisplay,
+    path_cache: &mut crate::TransientPathMeshCache,
 ) -> Result<(), DerivedDisplayRenderError> {
     let state = object.state();
     let occurrence = object.occurrence_index();
@@ -1027,7 +1078,68 @@ fn pack_derived_display_object(
             });
             (DerivedDisplayPrimitive::Line, index)
         }
-        noon_core::GeometryRef::VectorPath(_) | noon_core::GeometryRef::External(_) => {
+        noon_core::GeometryRef::VectorPath(path) => {
+            let render_transform = state.effective_render_transform();
+            let mesh = path_cache
+                .mesh(path, state.style, render_transform)
+                .map_err(|_| DerivedDisplayRenderError::PathPreparation(occurrence))?;
+            let vertex_start = u32::try_from(prepared.path_vertices.len())
+                .expect("transient path vertex count exceeds u32 limits");
+            let index_start = u32::try_from(prepared.path_indices.len())
+                .expect("transient path index count exceeds u32 limits");
+            prepared
+                .path_vertices
+                .extend(mesh.vertices.iter().map(|vertex| crate::PathVertex {
+                    position: [vertex.position.x, vertex.position.y],
+                    target_position: [vertex.target_position.x, vertex.target_position.y],
+                    surface: crate::pack_path_surface(vertex.surface, vertex.path_progress),
+                }));
+            prepared
+                .path_indices
+                .extend(mesh.indices.iter().map(|index| {
+                    index
+                        .checked_add(vertex_start)
+                        .expect("transient path index exceeds u32 limits")
+                }));
+            let vertex_end = u32::try_from(prepared.path_vertices.len())
+                .expect("transient path vertex count exceeds u32 limits");
+            let index_end = u32::try_from(prepared.path_indices.len())
+                .expect("transient path index count exceeds u32 limits");
+            debug_assert!(vertex_end >= vertex_start);
+
+            let instance_index = prepared.paths.len();
+            prepared.paths.push(crate::pack_transient_path_instance(
+                state.style,
+                state.appearance,
+                render_transform,
+                state.reveal,
+                state.morph,
+            ));
+            let batch = prepared.path_batches.len();
+            let instance_start = u32::try_from(instance_index)
+                .expect("transient path instance count exceeds u32 limits");
+            prepared.path_batches.push(crate::PathBatch {
+                index_range: index_start..index_end,
+                instance_range: instance_start..instance_start + 1,
+            });
+            let reveal_head = crate::pack_transient_path_reveal_head(
+                state.style,
+                state.appearance,
+                render_transform,
+                mesh,
+                state.reveal,
+            )
+            .map(|head| {
+                let index = prepared.lines.len();
+                prepared.lines.push(head);
+                index
+            });
+            (
+                DerivedDisplayPrimitive::Path { batch, reveal_head },
+                instance_index,
+            )
+        }
+        noon_core::GeometryRef::External(_) => {
             return Err(DerivedDisplayRenderError::UnsupportedGeometry(occurrence));
         }
     };
@@ -1153,25 +1265,52 @@ mod derived_display_tests {
     }
 
     #[test]
-    fn transient_renderer_fails_closed_for_path_without_synthetic_id() {
+    fn transient_path_uses_shared_morph_preparation_without_synthetic_id() {
         let mut runtime = runtime(vec![GeometryRef::circle(1.0)]);
+        let target = noon_core::VectorPath::new()
+            .move_to(Vec2::new(-0.5, -0.5))
+            .line_to(Vec2::new(0.5, -0.5))
+            .line_to(Vec2::new(0.0, 0.75))
+            .close();
         let path = noon_core::VectorPath::new()
-            .move_to(Vec2::ZERO)
-            .line_to(Vec2::ONE);
-        let derived = [DerivedDisplayObject::new(
-            0,
-            3,
-            state(GeometryRef::path(path)),
-        )];
+            .move_to(Vec2::new(-0.75, 0.0))
+            .line_to(Vec2::new(0.75, 0.0))
+            .line_to(Vec2::new(0.0, 0.5))
+            .close()
+            .with_morph_target(target);
+        let mut transient = state(GeometryRef::path(path));
+        transient.morph = 0.4;
+        let derived = [DerivedDisplayObject::new(0, 3, transient)];
         let publication = runtime
             .take_renderer_publication()
             .with_derived_display_objects(&derived)
             .unwrap();
+        let mut preparer = TransientPresentationPreparer::new();
 
-        assert_eq!(
-            prepare_derived_display(&publication).unwrap_err(),
-            DerivedDisplayRenderError::UnsupportedGeometry(3)
-        );
+        let first = preparer.prepare(&publication).unwrap();
+        assert_eq!(first.paths.len(), 1);
+        assert!(!first.path_vertices.is_empty());
+        assert!(!first.path_indices.is_empty());
+        assert_eq!(first.paths[0].path_params, [1.0, 0.4]);
+        assert!(first
+            .path_vertices
+            .iter()
+            .any(|vertex| vertex.position != vertex.target_position));
+        assert_eq!(preparer.cached_path_mesh_count(), 1);
+        assert_eq!(preparer.path_cache_misses(), 1);
+        assert_eq!(preparer.path_cache_hits(), 0);
+
+        let second = preparer.prepare(&publication).unwrap();
+        assert_eq!(second.path_vertices, first.path_vertices);
+        assert_eq!(second.path_indices, first.path_indices);
+        assert_eq!(preparer.cached_path_mesh_count(), 1);
+        assert_eq!(preparer.path_cache_misses(), 1);
+        assert_eq!(preparer.path_cache_hits(), 1);
+        assert_eq!(second.slots.len(), 1);
+        assert!(matches!(
+            second.slots[0].primitive,
+            DerivedDisplayPrimitive::Path { batch: 0, .. }
+        ));
     }
 
     #[test]

--- a/crates/noon-render-wgpu/tests/transient_path_presentation.rs
+++ b/crates/noon-render-wgpu/tests/transient_path_presentation.rs
@@ -1,0 +1,163 @@
+use noon_compile::{CompiledObject, CompiledScene};
+use noon_core::{
+    GeometryRef, ObjectContentRef, ObjectId, Style, Transform2D, Vec2, VectorPath,
+};
+use noon_render_wgpu::{
+    DerivedDisplayPrimitive, DisplayPainterItem, FramePreparer, TransientPresentationPreparer,
+};
+use noon_runtime::{
+    FrameChanges, SceneInstance, TransientPresentationOccurrence, TransientPresentationState,
+};
+
+fn triangle(height: f32) -> VectorPath {
+    VectorPath::new()
+        .move_to(Vec2::new(-0.6, -0.5))
+        .line_to(Vec2::new(0.6, -0.5))
+        .line_to(Vec2::new(0.0, height))
+        .close()
+}
+
+fn transient_state(path: VectorPath) -> TransientPresentationState {
+    TransientPresentationState {
+        z_index: 0.0,
+        content: ObjectContentRef::Geometry(GeometryRef::path(path)),
+        text_bounds: None,
+        transform: Transform2D::IDENTITY,
+        style: Style::default(),
+        appearance: 1.0,
+        presence: true,
+        reveal: 1.0,
+        morph: 0.0,
+        render_geometry: None,
+        render_transform: None,
+    }
+}
+
+fn runtime_with_stable_paths() -> SceneInstance {
+    let objects = vec![
+        CompiledObject::new(
+            ObjectId::new(1),
+            GeometryRef::path(triangle(0.8)),
+            Transform2D::IDENTITY,
+            Style::default(),
+        ),
+        CompiledObject::new(
+            ObjectId::new(2),
+            GeometryRef::path(triangle(1.2)),
+            Transform2D {
+                translation: Vec2::new(2.0, 0.0),
+                ..Transform2D::IDENTITY
+            },
+            Style::default(),
+        ),
+    ];
+    SceneInstance::new(CompiledScene::compile_objects(objects, &[]).unwrap())
+}
+
+#[test]
+fn transient_path_reuses_preparation_without_touching_stable_path_residency() {
+    let mut runtime = runtime_with_stable_paths();
+    let mut stable_preparer = FramePreparer::new();
+    let initial = stable_preparer.prepare(runtime.frame());
+    let stable_vertices = initial.path_vertices.to_vec();
+    let stable_indices = initial.path_indices.to_vec();
+    drop(initial);
+    let stable_cache_count = stable_preparer.cached_path_mesh_count();
+    assert_eq!(stable_cache_count, 2);
+
+    let target = triangle(1.4);
+    let morph = triangle(0.7).with_morph_target(target);
+    let mut state = transient_state(morph);
+    state.morph = 0.4;
+    let presentations = [TransientPresentationOccurrence::new(0, 9, state)];
+    let publication = runtime
+        .take_renderer_publication()
+        .with_transient_presentations(&presentations)
+        .unwrap();
+
+    let mut transient_preparer = TransientPresentationPreparer::new();
+    let first = transient_preparer.prepare(&publication).unwrap();
+    assert_eq!(first.paths.len(), 1);
+    assert!(!first.path_vertices.is_empty());
+    assert!(!first.path_indices.is_empty());
+    assert_eq!(transient_preparer.cached_path_mesh_count(), 1);
+    assert_eq!(transient_preparer.path_cache_misses(), 1);
+    assert_eq!(transient_preparer.path_cache_hits(), 0);
+    let transient_vertices = first.path_vertices.clone();
+    let transient_indices = first.path_indices.clone();
+
+    let second = transient_preparer.prepare(&publication).unwrap();
+    assert_eq!(second.path_vertices, transient_vertices);
+    assert_eq!(second.path_indices, transient_indices);
+    assert_eq!(transient_preparer.cached_path_mesh_count(), 1);
+    assert_eq!(transient_preparer.path_cache_misses(), 1);
+    assert_eq!(transient_preparer.path_cache_hits(), 1);
+
+    let stable_after_transient =
+        stable_preparer.prepare_incremental(publication.frame(), &FrameChanges::default());
+    assert_eq!(stable_after_transient.stats.full_rebuilds, 0);
+    assert_eq!(stable_after_transient.stats.geometry_cache_misses, 0);
+    assert_eq!(stable_after_transient.stats.path_vertices_repacked, 0);
+    assert_eq!(stable_after_transient.stats.path_indices_repacked, 0);
+    assert_eq!(stable_after_transient.path_vertices, stable_vertices.as_slice());
+    assert_eq!(stable_after_transient.path_indices, stable_indices.as_slice());
+    drop(stable_after_transient);
+    assert_eq!(stable_preparer.cached_path_mesh_count(), stable_cache_count);
+
+    let retirement = runtime.take_renderer_publication();
+    let retired = transient_preparer.prepare(&retirement).unwrap();
+    assert!(retired.slots.is_empty());
+    assert!(retired.paths.is_empty());
+    assert!(retired.path_vertices.is_empty());
+    assert!(retired.path_indices.is_empty());
+
+    let stable_after_retirement =
+        stable_preparer.prepare_incremental(retirement.frame(), &FrameChanges::default());
+    assert_eq!(stable_after_retirement.stats.full_rebuilds, 0);
+    assert_eq!(stable_after_retirement.stats.geometry_cache_misses, 0);
+    assert_eq!(stable_after_retirement.stats.path_vertices_repacked, 0);
+    assert_eq!(stable_after_retirement.stats.path_indices_repacked, 0);
+    assert_eq!(stable_preparer.cached_path_mesh_count(), stable_cache_count);
+}
+
+#[test]
+fn transient_path_viewport_projection_keeps_anchor_order_and_identity_local() {
+    let mut runtime = runtime_with_stable_paths();
+    let presentations = [TransientPresentationOccurrence::new(
+        1,
+        17,
+        transient_state(triangle(0.9)),
+    )];
+    let publication = runtime
+        .take_renderer_publication()
+        .with_transient_presentations(&presentations)
+        .unwrap();
+    let mut preparer = TransientPresentationPreparer::new();
+
+    let first_only = preparer.prepare_visible(&publication, &[0]).unwrap();
+    assert!(first_only.slots.is_empty());
+    assert!(first_only.paths.is_empty());
+    assert_eq!(
+        first_only.painter_items,
+        vec![DisplayPainterItem::Stable { object_index: 0 }]
+    );
+
+    let second_only = preparer.prepare_visible(&publication, &[1]).unwrap();
+    assert_eq!(second_only.paths.len(), 1);
+    assert_eq!(second_only.slots.len(), 1);
+    assert_eq!(second_only.slots[0].anchor_object_index, 1);
+    assert_eq!(second_only.slots[0].occurrence_index, 17);
+    assert!(matches!(
+        second_only.slots[0].primitive,
+        DerivedDisplayPrimitive::Path { batch: 0, .. }
+    ));
+    assert_eq!(
+        second_only.painter_items,
+        vec![
+            DisplayPainterItem::Stable { object_index: 1 },
+            DisplayPainterItem::Derived {
+                occurrence_index: 17,
+            },
+        ]
+    );
+}

--- a/crates/noon-web/src/execution_canvas.rs
+++ b/crates/noon-web/src/execution_canvas.rs
@@ -23,8 +23,8 @@ mod wasm {
     };
     use noon_render_wgpu::text::TextDeviceMetrics;
     use noon_render_wgpu::{
-        prepare_derived_display_visible, Camera2D, GpuRenderer, RetainedFramePreparer,
-        RetainedTextGpuState,
+        Camera2D, GpuRenderer, RetainedFramePreparer, RetainedTextGpuState,
+        TransientPresentationPreparer,
     };
     use serde::Serialize;
     use wasm_bindgen::{prelude::*, JsCast};
@@ -371,6 +371,7 @@ mod wasm {
         source: DirectExecutionSource,
         direct_wake_clock: BrowserExecutionWakeClock,
         direct_preparer: RetainedFramePreparer,
+        direct_transient_preparer: TransientPresentationPreparer,
         renderer: GpuRenderer,
         direct_text_gpu: RetainedTextGpuState,
         timestamp_query_supported: bool,
@@ -439,6 +440,7 @@ mod wasm {
             self.renderer = renderer;
             self.direct_text_gpu = direct_text_gpu;
             self.direct_preparer = RetainedFramePreparer::new();
+            self.direct_transient_preparer = TransientPresentationPreparer::new();
             self.timestamp_profiler =
                 profiling_enabled.then(|| GpuTimestampProfiler::new(&self.device, &self.queue));
             self.gpu_generation = next_generation;
@@ -1076,6 +1078,7 @@ mod wasm {
                 source,
                 direct_wake_clock: BrowserExecutionWakeClock::default(),
                 direct_preparer: RetainedFramePreparer::new(),
+                direct_transient_preparer: TransientPresentationPreparer::new(),
                 renderer,
                 direct_text_gpu,
                 timestamp_query_supported,
@@ -1124,9 +1127,10 @@ mod wasm {
                 ));
                 let publication = direct.take_renderer_publication();
                 publication_context = publication.context();
-                let derived =
-                    prepare_derived_display_visible(&publication, visibility.object_indices())
-                        .map_err(js_error)?;
+                let derived = self
+                    .direct_transient_preparer
+                    .prepare_visible(&publication, visibility.object_indices())
+                    .map_err(js_error)?;
                 let prepared = self
                     .direct_preparer
                     .prepare_planned_publication_visible(

--- a/crates/noon/src/execution_session/family_transform_tests.rs
+++ b/crates/noon/src/execution_session/family_transform_tests.rs
@@ -1,12 +1,24 @@
 use noon_core::{
-    AnimationOptions, RateFunction, SemanticObjectState, SemanticStore, SemanticVec3,
-    StoredGeometry,
+    AnimationOptions, GeometryRef, RateFunction, SemanticObjectState, SemanticStore, SemanticVec3,
+    StoredGeometry, Vec2, VectorPath,
 };
 
 use super::*;
 
 fn object(store: &mut SemanticStore, x: f64) -> SemanticNodeId {
     let mut state = SemanticObjectState::new(StoredGeometry::Circle { radius: 1.0 });
+    state.transform.translation = SemanticVec3::new(x, 0.0, 0.0);
+    store.insert_semantic_object(state)
+}
+
+fn path_object(store: &mut SemanticStore, x: f64, height: f32) -> SemanticNodeId {
+    let path = VectorPath::new()
+        .move_to(Vec2::new(-0.6, -0.5))
+        .line_to(Vec2::new(0.6, -0.5))
+        .line_to(Vec2::new(0.0, height))
+        .close();
+    let handle = store.insert_geometry_path(path).unwrap();
+    let mut state = SemanticObjectState::new(StoredGeometry::Resource(handle));
     state.transform.translation = SemanticVec3::new(x, 0.0, 0.0);
     store.insert_semantic_object(state)
 }
@@ -27,6 +39,30 @@ fn expansion_session() -> (ExecutionSession, ExecutionSegment) {
     let t0 = object(&mut store, 10.0);
     let t1 = object(&mut store, 12.0);
     let t2 = object(&mut store, 14.0);
+    let target = family(&mut store, &[t0, t1, t2]);
+
+    let mut session = ExecutionSession::from_semantic_root(&store, source).unwrap();
+    let request = SemanticCompositionRequest::FamilyTransformTo {
+        source,
+        target_state: target,
+        options: AnimationOptions::new()
+            .run_time(1.0)
+            .rate_func(RateFunction::Linear),
+    };
+    let segment = session
+        .declare_and_activate_composition(&mut store, source, &request, AnimationOptions::new())
+        .unwrap();
+    (session, segment)
+}
+
+fn path_expansion_session() -> (ExecutionSession, ExecutionSegment) {
+    let mut store = SemanticStore::new();
+    let s0 = path_object(&mut store, 0.0, 0.7);
+    let s1 = path_object(&mut store, 2.0, 0.9);
+    let source = family(&mut store, &[s0, s1]);
+    let t0 = path_object(&mut store, 10.0, 1.1);
+    let t1 = path_object(&mut store, 12.0, 0.6);
+    let t2 = path_object(&mut store, 14.0, 1.3);
     let target = family(&mut store, &[t0, t1, t2]);
 
     let mut session = ExecutionSession::from_semantic_root(&store, source).unwrap();
@@ -153,6 +189,45 @@ fn unequal_family_transform_direct_seek_matches_forward_playback() {
     assert!(
         forward_derived[0].state().appearance > 0.0 && forward_derived[0].state().appearance < 1.0
     );
+}
+
+#[test]
+fn unequal_path_family_transform_direct_seek_matches_forward_playback() {
+    let (mut forward, forward_segment) = path_expansion_session();
+    forward.advance_segment_to(forward_segment, 0.25).unwrap();
+    assert_eq!(
+        forward
+            .take_renderer_publication()
+            .transient_presentations()
+            .len(),
+        1
+    );
+    forward.advance_segment_to(forward_segment, 0.5).unwrap();
+    let forward_frame = forward.frame().clone();
+    let forward_presentations = forward
+        .take_renderer_publication()
+        .transient_presentations()
+        .to_vec();
+
+    let (mut direct, _direct_segment) = path_expansion_session();
+    direct.seek(0.5).unwrap();
+    let direct_frame = direct.frame().clone();
+    let direct_presentations = direct
+        .take_renderer_publication()
+        .transient_presentations()
+        .to_vec();
+
+    assert_eq!(forward_frame, direct_frame);
+    assert_eq!(forward_presentations, direct_presentations);
+    assert_eq!(forward_presentations.len(), 1);
+    let copy = &forward_presentations[0];
+    assert_eq!(copy.anchor_object_index(), 0);
+    assert!(copy.state().appearance > 0.0 && copy.state().appearance < 1.0);
+    assert!(copy.state().morph > 0.0 && copy.state().morph < 1.0);
+    assert!(copy
+        .state()
+        .effective_render_geometry()
+        .is_some_and(|geometry| matches!(geometry, GeometryRef::VectorPath(_))));
 }
 
 #[test]

--- a/parity/manim-v0.21/core-examples/unequal_family_transform.py
+++ b/parity/manim-v0.21/core-examples/unequal_family_transform.py
@@ -79,3 +79,38 @@ class UnequalFamilyTransformContraction(Scene):
         )
         self.add(source)
         self.play(Transform(source, target), run_time=1.0, rate_func=linear)
+
+
+class UnequalFamilyPathTransformExpansion(Scene):
+    def construct(self):
+        source = VGroup(
+            Triangle(
+                fill_color=PURPLE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).scale(0.8).move_to(2.5 * LEFT),
+            Triangle(
+                fill_color=PURPLE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).scale(0.8).move_to(2.5 * RIGHT),
+        )
+        target = VGroup(
+            Triangle(
+                fill_color=PURPLE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).scale(0.8).move_to(3.0 * LEFT),
+            Triangle(
+                fill_color=PURPLE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).scale(0.8),
+            Triangle(
+                fill_color=PURPLE,
+                fill_opacity=1.0,
+                stroke_opacity=0.0,
+            ).scale(0.8).move_to(3.0 * RIGHT),
+        )
+        self.add(source)
+        self.play(Transform(source, target), run_time=1.0, rate_func=linear)


### PR DESCRIPTION
## Summary

Advances #1499 on top of #1494.

- extends the generic identity-free transient-presentation lane to `VectorPath` without allocating `SemanticNodeId`, stable `ObjectId`, `TrackId`, or stable renderer slots;
- reuses the canonical retained path tessellation rules for screen-space/object-scaled strokes and morph-preserving ordered geometry;
- keeps a renderer-local transient path preparation cache across publications so unchanged transient geometry is not retessellated;
- packs transient path reveal/morph instance parameters and reveal heads through the same path semantics as stable retained geometry;
- adds separate transient path GPU vertex/index/instance buffers and submits them through the existing path pipeline and authoritative stable+transient painter projection;
- keeps external geometry fail-closed;
- switches native and direct-WASM hosts to a persistent `TransientPresentationPreparer`, resetting it with the GPU stack on browser device/context recovery.

## Architecture boundary

Transient occurrences remain presentation-only derived state. Stable retained path residency is not moved or invalidated when a transient path appears or retires. Native/WebGPU/WebGL use the same renderer contract; there is no family-Transform-specific renderer branch and no synthetic frame/object identity.

This draft does not yet claim the full #1499 acceptance gate. Next qualification adds path-family direct-seek/forward equivalence, locality/retirement assertions, and source-equivalent WebGPU/WebGL coverage before review-ready status.

## Focused validation

The exact production tree passed:

- `cargo fmt --all`;
- `cargo test -p noon-render-wgpu derived_display --lib`;
- `cargo check -p noon-native`;
- `cargo check -p noon-web --all-targets --all-features`;
- `cargo check -p noon-web --target wasm32-unknown-unknown --features renderer-smoke`;
- `git diff --check`.

Current head: `73ed16591de4db0924e960c3eab21e42e884a6c8`, one production commit directly on #1494 head `f07e4920079e81b38e367aa1829a648bdfcd9c7e`.

Refs #1499
Refs #82
Refs #1466
Refs #1494