### PR TITLE
Add Brace tip placement and retained BraceText

### DIFF
--- a/crates/noon/src/geometry_authoring.rs
+++ b/crates/noon/src/geometry_authoring.rs
@@ -456,10 +456,7 @@ mod tests {
         left.shift(-1.0, 0.0).unwrap();
         right.shift(1.0, 0.0).unwrap();
         let family = scene
-            .family(&[
-                MobjectTarget::Object(&left),
-                MobjectTarget::Object(&right),
-            ])
+            .family(&[MobjectTarget::Object(&left), MobjectTarget::Object(&right)])
             .unwrap();
         let left_before = left.state().unwrap();
         let right_before = right.state().unwrap();

--- a/parity/manim-v0.21/core-examples/brace_text.py
+++ b/parity/manim-v0.21/core-examples/brace_text.py
@@ -1,0 +1,20 @@
+"""Pinned ManimCE v0.21 source pair for Noon's BraceText fixture."""
+from manim import *
+
+
+class BraceTextExample(Scene):
+    def construct(self):
+        left = Square().shift(LEFT * 2.0)
+        left_label = BraceText(left, "Label", font_size=36)
+
+        right = Rectangle(width=2.5, height=1.5).shift(RIGHT * 2.0)
+        right_label = BraceText(
+            right,
+            "Side",
+            brace_direction=RIGHT,
+            font_size=36,
+            buff=0.25,
+        )
+
+        self.add(left, left_label, right, right_label)
+        self.wait(0.2)

--- a/web/python/_manim_brace.py
+++ b/web/python/_manim_brace.py
@@ -11,6 +11,10 @@ import _manim_compat as _compat
 import _manim_semantic_handles as _shared
 
 
+_DEFAULT_FONT_SIZE = 48.0
+_BRACE_TIP_ANCHOR_INDEX = 7
+
+
 def _require_geometry_host(name: str) -> None:
     if _shared._create_geometry_handle is None:
         raise RuntimeError(f"{name} requires the shared Rust authoring host")
@@ -65,6 +69,43 @@ def _finish_candidate(
     _shared._attach_geometry_options(owner, candidate, name)
 
 
+def _required_text_constructor(name: str, feature: str):
+    try:
+        constructor = getattr(_base, name)
+    except AttributeError as error:
+        raise NotImplementedError(
+            f"{feature} requires Manim-compatible {name} support from the retained text layer"
+        ) from error
+    if not callable(constructor):
+        raise TypeError(f"{name} must be callable")
+    return constructor
+
+
+def _explicit_label_constructor(label_constructor: object | None):
+    if label_constructor is None:
+        return _required_text_constructor("MathTex", "BraceLabel default label construction")
+    if not callable(label_constructor):
+        raise TypeError("label_constructor must be callable")
+    return label_constructor
+
+
+def _new_label(
+    label_constructor: object,
+    text: object,
+    font_size: float,
+    extra_kwargs: dict[str, Any] | None = None,
+):
+    constructor = label_constructor
+    kwargs = {} if extra_kwargs is None else dict(extra_kwargs)
+    if isinstance(text, (tuple, list)):
+        label = constructor(*text, font_size=font_size, **kwargs)
+    else:
+        label = constructor(str(text), font_size=font_size, **kwargs)
+    if not isinstance(label, _base.Mobject):
+        raise TypeError("label_constructor must return a Mobject")
+    return label
+
+
 class Brace(_compat.VMobject):
     """ManimCE v0.21 Brace whose path/layout policy is owned by shared Rust."""
 
@@ -107,6 +148,57 @@ class Brace(_compat.VMobject):
         self.buff = buff_value
         self.sharpness = sharpness_value
         self.direction = direction_value
+
+    def get_tip(self) -> _base.Vec2:
+        """Return the pinned ManimCE v0.21 brace-tip anchor."""
+        # Cairo's Brace.get_tip() returns points[28] == the eighth anchor in
+        # the canonical cubic path. Noon's anchors come from the Rust-owned
+        # retained VectorPath query, so Python owns only the class-specific index.
+        anchors = self.get_anchors()
+        if len(anchors) <= _BRACE_TIP_ANCHOR_INDEX:
+            raise RuntimeError("Brace path does not contain the canonical tip anchor")
+        return anchors[_BRACE_TIP_ANCHOR_INDEX]
+
+    def get_direction(self) -> _base.Vec2:
+        """Return the normalized direction from brace center to brace tip."""
+        vector = self.get_tip() - self.get_center()
+        return vector.normalized()
+
+    def put_at_tip(
+        self,
+        mob: _base.Mobject,
+        use_next_to: bool = True,
+        **kwargs: Any,
+    ) -> Brace:
+        """Place ``mob`` at the brace tip using ordinary retained layout operations."""
+        if not isinstance(mob, _base.Mobject):
+            raise TypeError("Brace.put_at_tip expects a Mobject")
+        if use_next_to:
+            direction = self.get_direction()
+            rounded = _base.Vec2(round(direction.x), round(direction.y))
+            mob.next_to(self.get_tip(), rounded, **kwargs)
+        else:
+            mob.move_to(self.get_tip())
+            buff = _shared._ir._finite_number(
+                "buff", kwargs.get("buff", _base.DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+            )
+            shift_distance = mob.width / 2.0 + buff
+            mob.shift(self.get_direction() * shift_distance)
+        return self
+
+    def get_text(self, *text: str, **kwargs: Any):
+        """Construct upstream ``Tex`` at the tip once retained Tex is available."""
+        constructor = _required_text_constructor("Tex", "Brace.get_text")
+        label = constructor(*text)
+        self.put_at_tip(label, **kwargs)
+        return label
+
+    def get_tex(self, *tex: str, **kwargs: Any):
+        """Construct upstream ``MathTex`` at the tip once retained MathTex is available."""
+        constructor = _required_text_constructor("MathTex", "Brace.get_tex")
+        label = constructor(*tex)
+        self.put_at_tip(label, **kwargs)
+        return label
 
 
 class BraceBetweenPoints(Brace):
@@ -157,3 +249,113 @@ class BraceBetweenPoints(Brace):
         self.buff = buff_value
         self.sharpness = sharpness_value
         self.direction = direction_value
+
+
+class BraceLabel(_compat.VGroup):
+    """Brace plus label as an ordinary semantic family.
+
+    Noon's retained B4 layer does not yet expose ManimCE ``MathTex``. Therefore
+    the upstream default constructor is fail-closed until that dependency lands;
+    callers may already use an explicit retained label constructor such as ``Text``.
+    """
+
+    def __init__(
+        self,
+        obj: _base.Mobject,
+        text: object,
+        brace_direction: object = _base.DOWN,
+        label_constructor: object | None = None,
+        font_size: float = _DEFAULT_FONT_SIZE,
+        buff: float = 0.2,
+        brace_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        constructor = _explicit_label_constructor(label_constructor)
+        font_size_value = _shared._ir._positive_number("font_size", font_size)
+        group_options = dict(kwargs)
+        z_index = _shared._ir._finite_number("z_index", group_options.pop("z_index", 0.0))
+        if group_options:
+            unsupported = ", ".join(sorted(group_options))
+            raise NotImplementedError(
+                f"unsupported BraceLabel composite option(s): {unsupported}"
+            )
+        if brace_config is None:
+            brace_options: dict[str, Any] = {}
+        elif isinstance(brace_config, dict):
+            brace_options = dict(brace_config)
+        else:
+            raise TypeError("brace_config must be a dict or None")
+
+        self.label_constructor = constructor
+        self.brace_direction = _base._as_vec2(brace_direction)
+        self.brace = Brace(
+            obj,
+            direction=self.brace_direction,
+            buff=buff,
+            **brace_options,
+        )
+        self.label = _new_label(constructor, text, font_size_value)
+        self.brace.put_at_tip(self.label)
+        super().__init__(self.brace, self.label, z_index=z_index)
+
+    def creation_anim(self, label_anim=None, brace_anim=None):
+        if label_anim is None:
+            label_anim = getattr(_base, "FadeIn")
+        if brace_anim is None:
+            brace_anim = getattr(_base, "GrowFromCenter")
+        animation_group = getattr(_base, "AnimationGroup")
+        return animation_group(brace_anim(self.brace), label_anim(self.label))
+
+    def shift_brace(self, obj: _base.Mobject, **kwargs: Any) -> BraceLabel:
+        if isinstance(obj, list):
+            obj = _compat.VGroup(*obj)
+        old_brace = self.brace
+        self.remove(old_brace, self.label)
+        self.brace = Brace(obj, direction=self.brace_direction, **kwargs)
+        self.brace.put_at_tip(self.label)
+        self.add(self.brace, self.label)
+        return self
+
+    def change_label(self, *text: str, **kwargs: Any) -> BraceLabel:
+        old_label = self.label
+        self.remove(old_label)
+        label = self.label_constructor(*text, **kwargs)
+        if not isinstance(label, _base.Mobject):
+            raise TypeError("label_constructor must return a Mobject")
+        self.label = label
+        self.brace.put_at_tip(self.label)
+        self.add(self.label)
+        return self
+
+    def change_brace_label(
+        self,
+        obj: _base.Mobject,
+        *text: str,
+        **kwargs: Any,
+    ) -> BraceLabel:
+        self.shift_brace(obj)
+        self.change_label(*text, **kwargs)
+        return self
+
+
+class BraceText(BraceLabel):
+    """Brace plus retained native ``Text`` as an ordinary semantic family."""
+
+    def __init__(
+        self,
+        obj: _base.Mobject,
+        text: str,
+        label_constructor: object | None = None,
+        **kwargs: Any,
+    ) -> None:
+        constructor = (
+            _required_text_constructor("Text", "BraceText")
+            if label_constructor is None
+            else label_constructor
+        )
+        super().__init__(
+            obj,
+            text,
+            label_constructor=constructor,
+            **kwargs,
+        )

--- a/web/python/examples/ordinary_brace_text.py
+++ b/web/python/examples/ordinary_brace_text.py
@@ -1,0 +1,20 @@
+"""Paired BraceText example over retained Brace geometry and native Text."""
+from noon import *
+
+
+class BraceTextExample(Scene):
+    def construct(self):
+        left = Square().shift(LEFT * 2.0)
+        left_label = BraceText(left, "Label", font_size=36)
+
+        right = Rectangle(width=2.5, height=1.5).shift(RIGHT * 2.0)
+        right_label = BraceText(
+            right,
+            "Side",
+            brace_direction=RIGHT,
+            font_size=36,
+            buff=0.25,
+        )
+
+        self.add(left, left_label, right, right_label)
+        self.wait(0.2)

--- a/web/python/noon.py
+++ b/web/python/noon.py
@@ -778,6 +778,8 @@ _PUBLIC_EXPORTS = {
     "ArcBetweenPoints": "_manim_arc",
     "Brace": "_manim_brace",
     "BraceBetweenPoints": "_manim_brace",
+    "BraceLabel": "_manim_brace",
+    "BraceText": "_manim_brace",
     "Arrow": "_manim_arrow",
     "Vector": "_manim_arrow",
     "DoubleArrow": "_manim_arrow",

--- a/web/python/test_manim_brace.py
+++ b/web/python/test_manim_brace.py
@@ -7,13 +7,28 @@ from pathlib import Path
 
 
 class ManimBraceFacadeTests(unittest.TestCase):
-    def test_brace_facade_stays_thin_over_shared_rust_geometry(self) -> None:
+    def _run_source(self, source: str) -> None:
         python_dir = Path(__file__).resolve().parent
         env = os.environ.copy()
         env["PYTHONPATH"] = os.pathsep.join(
             value for value in (str(python_dir), env.get("PYTHONPATH")) if value
         )
-        source = textwrap.dedent(
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(source)],
+            cwd=python_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_brace_facade_stays_thin_over_shared_rust_geometry(self) -> None:
+        self._run_source(
             r"""
             import json
             import sys
@@ -120,18 +135,130 @@ class ManimBraceFacadeTests(unittest.TestCase):
             assert calls == before
             """
         )
-        completed = subprocess.run(
-            [sys.executable, "-c", source],
-            cwd=python_dir,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(
-            completed.returncode,
-            0,
-            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+
+    def test_brace_tip_placement_and_text_composite_are_thin(self) -> None:
+        self._run_source(
+            r"""
+            import json
+            import sys
+            import types
+
+            fake_js = types.ModuleType("js")
+            import _typed_geometry_test_support as support
+
+            class FakeHandle:
+                def __init__(self, snapshot):
+                    self.snapshot = snapshot
+                def snapshotJson(self):
+                    return json.dumps(self.snapshot)
+                def beginBrace(self, *args):
+                    value = support.FakeGeometryOptions({
+                        "vector_path": {"commands": []}
+                    })
+                    value.setStrokeWidth(0.0)
+                    value.setFillOpacity(1.0)
+                    return value
+
+            support.install_js_bridge(
+                fake_js, lambda value: FakeHandle(json.loads(value))
+            )
+            sys.modules["js"] = fake_js
+
+            import noon
+            import _manim_brace as brace_module
+            from noon import Brace, Square
+
+            brace = Brace(Square(2.0))
+            anchors = [noon.Vec2(float(index), 0.0) for index in range(8)]
+            anchors[7] = noon.Vec2(0.0, -2.0)
+            brace.get_anchors = lambda: anchors
+            brace.get_center = lambda: noon.ORIGIN
+
+            assert brace.get_tip() == noon.Vec2(0.0, -2.0)
+            assert brace.get_direction() == noon.DOWN
+
+            placements = []
+            label = object.__new__(noon.Mobject)
+            label._scene = None
+            label._object = None
+            label.next_to = lambda point, direction, **kwargs: placements.append(
+                (point, direction, kwargs)
+            ) or label
+            assert brace.put_at_tip(label, buff=0.4) is brace
+            assert placements == [
+                (noon.Vec2(0.0, -2.0), noon.DOWN, {"buff": 0.4})
+            ]
+
+            for method in (brace.get_text, brace.get_tex):
+                try:
+                    method("x")
+                except NotImplementedError as error:
+                    assert "retained text layer" in str(error)
+                else:
+                    raise AssertionError("Tex/MathTex dependency unexpectedly succeeded")
+
+            class FakeBrace(noon.Mobject):
+                def __init__(self, obj, direction=noon.DOWN, buff=0.2, **kwargs):
+                    self._scene = None
+                    self._object = None
+                    self.obj = obj
+                    self.direction = noon._as_vec2(direction)
+                    self.buff = float(buff)
+                    self.kwargs = dict(kwargs)
+                    self.placed = []
+                def put_at_tip(self, label, **kwargs):
+                    self.placed.append((label, dict(kwargs)))
+                    return self
+
+            class FakeLabel(noon.Mobject):
+                def __init__(self, text, font_size=48.0, **kwargs):
+                    self._scene = None
+                    self._object = None
+                    self.text = text
+                    self.font_size = float(font_size)
+                    self.kwargs = dict(kwargs)
+
+            family_calls = []
+            brace_module.Brace = FakeBrace
+            brace_module._compat.VGroup.__init__ = (
+                lambda self, *members, z_index=0: family_calls.append(
+                    (self, members, float(z_index))
+                )
+            )
+            noon.Text = FakeLabel
+
+            target = object.__new__(noon.Mobject)
+            target._scene = None
+            target._object = None
+            composite = brace_module.BraceText(
+                target,
+                "Label",
+                font_size=36,
+                buff=0.3,
+                brace_config={"sharpness": 1.5},
+            )
+            assert composite.label.text == "Label"
+            assert composite.label.font_size == 36.0
+            assert composite.brace.direction == noon.DOWN
+            assert composite.brace.buff == 0.3
+            assert composite.brace.kwargs == {"sharpness": 1.5}
+            assert composite.brace.placed == [(composite.label, {})]
+            assert family_calls[-1][1] == (composite.brace, composite.label)
+
+            explicit = brace_module.BraceLabel(
+                target,
+                "Plain",
+                label_constructor=FakeLabel,
+            )
+            assert explicit.label.text == "Plain"
+
+            try:
+                brace_module.BraceLabel(target, "math")
+            except NotImplementedError as error:
+                assert "MathTex" in str(error)
+            else:
+                raise AssertionError("BraceLabel default must wait for MathTex")
+            """
         )
 
 


### PR DESCRIPTION
## Summary

Claims the next bounded label portion of #84 after merged #1476.

- adds source-faithful `Brace.get_tip()`, `get_direction()`, and `put_at_tip()` over the existing Rust-owned retained path/layout queries;
- adds `BraceText` as an ordinary semantic family containing the existing Brace plus retained native `Text`;
- adds `BraceLabel` for explicit currently-supported retained label constructors;
- publicly exports both composites through `noon`;
- keeps `Tex`/`MathTex`-dependent paths fail-closed until B4 supplies those public constructors;
- adds paired Noon / pinned ManimCE v0.21 `BraceText` source fixtures.

## Architecture boundary

No renderer/runtime BraceText primitive and no Python-owned geometry/layout model. The pinned Brace tip is selected from the Rust-owned canonical anchor query; placement uses ordinary retained layout operations; composites use the existing semantic family model.

## Explicit dependency boundary

Pinned ManimCE v0.21 defaults `BraceLabel` to `MathTex`, and `Brace.get_text()`/`get_tex()` require `Tex`/`MathTex`. Noon does not expose those B4 constructors yet, so this PR does not substitute Typst and falsely claim LaTeX compatibility. `BraceText` is fully backed by the retained native `Text` path now.

## Validation

Focused CPython facade coverage is included for tip selection, direction, point placement, explicit dependency failures, semantic-family composition, and explicit label constructors. The paired source fixture also exercises public `from noon import *` export wiring.

Full CI passes on head `2079960effd940559a1a8817846a3ad2201c2247`, including PR Fast Gate, Architecture Ratchets, Layer Dependency Ratchet, Manim raster differential, static SVG Manim raster qualification, cross-browser matrix, Playground Product Gate, Playground authoring recovery, Agent discovery MCP, and Noon agent foundation.

Refs #84
Refs #83
Refs #365