### PR TITLE
Format brace MobjectTarget test migration

### DIFF
--- a/crates/noon/src/geometry_authoring.rs
+++ b/crates/noon/src/geometry_authoring.rs
@@ -456,10 +456,7 @@ mod tests {
         left.shift(-1.0, 0.0).unwrap();
         right.shift(1.0, 0.0).unwrap();
         let family = scene
-            .family(&[
-                MobjectTarget::Object(&left),
-                MobjectTarget::Object(&right),
-            ])
+            .family(&[MobjectTarget::Object(&left), MobjectTarget::Object(&right)])
             .unwrap();
         let left_before = left.state().unwrap();
         let right_before = right.state().unwrap();


### PR DESCRIPTION
Follow-up to #1513. `cargo fmt --all -- --check` reports only the migrated two-element `MobjectTarget` array in `geometry_authoring.rs`. This applies rustfmt's exact one-line form; no behavior changes.