### PR TITLE
Guard Dynamic Load FPS on physical WebGPU

### DIFF
--- a/.github/workflows/perf-physical-device.yml
+++ b/.github/workflows/perf-physical-device.yml
@@ -13,9 +13,9 @@ on:
         default: webgpu,webgl
         type: string
       suites:
-        description: Comma-separated suites (frame,corpus,authoring)
+        description: Comma-separated suites (frame,corpus,authoring,dynamic-stress)
         required: true
-        default: frame,corpus,authoring
+        default: frame,corpus,authoring,dynamic-stress
         type: string
       width:
         description: Canvas backing width
@@ -36,6 +36,11 @@ on:
         description: Target refresh rate used for frame-budget reporting
         required: true
         default: '60'
+        type: string
+      dynamic_stress_webgpu_min_fps:
+        description: Minimum effective FPS required for Dynamic Load on physical WebGPU
+        required: true
+        default: '55'
         type: string
       notes:
         description: Power/thermal/browser/device notes
@@ -79,6 +84,7 @@ jobs:
           NOON_PERF_HEIGHT: ${{ inputs.height }}
           NOON_PERF_DPR: ${{ inputs.dpr }}
           NOON_PERF_TARGET_HZ: ${{ inputs.target_hz }}
+          NOON_PERF_DYNAMIC_STRESS_WEBGPU_MIN_FPS: ${{ inputs.dynamic_stress_webgpu_min_fps }}
           NOON_PERF_DEVICE_NOTES: ${{ inputs.notes }}
           NOON_PERF_RUN_DIR: perf-artifacts/physical-dispatch
         run: node scripts/perf-device-run.mjs

--- a/scripts/perf-device-run.mjs
+++ b/scripts/perf-device-run.mjs
@@ -16,7 +16,7 @@ for (const backend of backends) {
 const suites = list(process.env.NOON_PERF_SUITES ?? "frame,corpus");
 for (const suite of suites) {
   assert.ok(
-    suite === "frame" || suite === "authoring" || suite === "corpus",
+    suite === "frame" || suite === "authoring" || suite === "corpus" || suite === "dynamic-stress",
     `unknown suite: ${suite}`,
   );
 }
@@ -52,6 +52,19 @@ for (const backend of backends) {
     });
     artifacts.push({ suite: "authoring", backend, path: relative });
   }
+  if (suites.includes("dynamic-stress")) {
+    const relative = path.join(relativeDir, `dynamic-stress-${backend}.json`);
+    const webgpuMinimumFps = process.env.NOON_PERF_DYNAMIC_STRESS_WEBGPU_MIN_FPS?.trim();
+    run("scripts/retained-dynamic-stress-perf.mjs", {
+      NOON_RETAINED_STRESS_BACKEND: backend,
+      NOON_RETAINED_STRESS_ARTIFACT: relative,
+      NOON_RETAINED_STRESS_SAMPLE_HZ: process.env.NOON_PERF_TARGET_HZ ?? "60",
+      ...(backend === "webgpu" && webgpuMinimumFps
+        ? { NOON_RETAINED_STRESS_MIN_EFFECTIVE_FPS: webgpuMinimumFps }
+        : {}),
+    });
+    artifacts.push({ suite: "dynamic-stress", backend, path: relative });
+  }
 }
 
 const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
@@ -69,6 +82,7 @@ const bundle = {
     height: process.env.NOON_PERF_HEIGHT ?? "540",
     devicePixelRatio: process.env.NOON_PERF_DPR ?? "1",
     targetHz: process.env.NOON_PERF_TARGET_HZ ?? "60",
+    dynamicStressWebgpuMinimumFps: process.env.NOON_PERF_DYNAMIC_STRESS_WEBGPU_MIN_FPS ?? null,
   },
   artifacts,
 };

--- a/scripts/retained-dynamic-stress-perf-lib.mjs
+++ b/scripts/retained-dynamic-stress-perf-lib.mjs
@@ -51,7 +51,10 @@ export function summarizeStressPhases(samples) {
   });
 }
 
-export function validateStressReport(report, { transportMode, rendererBackend, sampleHz }) {
+export function validateStressReport(
+  report,
+  { transportMode, rendererBackend, sampleHz, minimumEffectiveFps = null },
+) {
   assert.equal(report.schemaVersion, 2);
   assert.equal(report.execution.mode, "semantic");
   assert.equal(report.execution.transportMode, transportMode);
@@ -68,6 +71,21 @@ export function validateStressReport(report, { transportMode, rendererBackend, s
   // must cover the unchanged source on the requested grid through its endpoint.
   assert.equal(report.samples.length, times.length, "complete sample grid is required");
   assert.equal(report.cadence.frames, times.length);
+  if (minimumEffectiveFps !== null) {
+    assert.ok(
+      Number.isFinite(minimumEffectiveFps) && minimumEffectiveFps > 0,
+      "minimum effective FPS must be positive and finite",
+    );
+    const effectiveFps = report.cadence.effective?.effectiveFps;
+    assert.ok(
+      Number.isFinite(effectiveFps),
+      "effective FPS must be available when a minimum is requested",
+    );
+    assert.ok(
+      effectiveFps >= minimumEffectiveFps,
+      `effective FPS ${effectiveFps.toFixed(2)} is below required ${minimumEffectiveFps.toFixed(2)}`,
+    );
+  }
   assert.equal(report.execution.firstMeasuredTime, times[0]);
   report.samples.forEach((sample, index) => {
     assert.ok(Math.abs(sample.sceneTime - times[index]) < 1e-9, `wrong sample time at ${index}`);

--- a/scripts/retained-dynamic-stress-perf-lib.test.mjs
+++ b/scripts/retained-dynamic-stress-perf-lib.test.mjs
@@ -7,7 +7,7 @@ function complete() {
     environment: { rendererBackend: "WebGPU", targetHz: 60 },
     execution: { mode: "semantic", transportMode: "shared", sourceContinuation: true,
       sourceCompleted: true, authoredDuration: 5, firstMeasuredTime: 1 / 60, lastMeasuredTime: 5 },
-    cadence: { frames: 300 },
+    cadence: { frames: 300, effective: { effectiveFps: 59.8 } },
     samples: fixedStressSampleTimes().slice(1).map(sceneTime => ({ sceneTime, advanceRoundTripMs: 3 })) };
 }
 test("complete fixed samples preserve all ten authored phases and measured timings", () => {
@@ -18,6 +18,15 @@ test("complete fixed samples preserve all ten authored phases and measured timin
   assert.equal(classifyStressPhase(0.35), "create-grid");
   assert.equal(classifyStressPhase(5), "final-wave");
   assert.equal(classifyStressPhase(5.01), null);
+});
+test("optional physical cadence floor rejects an FPS regression", () => {
+  validateStressReport(complete(), { ...options, minimumEffectiveFps: 55 });
+  const report = complete();
+  report.cadence.effective.effectiveFps = 54.9;
+  assert.throws(
+    () => validateStressReport(report, { ...options, minimumEffectiveFps: 55 }),
+    /below required 55\.00/,
+  );
 });
 test("reject truncated, misrouted, incomplete, malformed and cheaper workloads", () => {
   const mutations = [

--- a/scripts/retained-dynamic-stress-perf.mjs
+++ b/scripts/retained-dynamic-stress-perf.mjs
@@ -18,6 +18,7 @@ const backend = process.env.NOON_RETAINED_STRESS_BACKEND ?? "webgpu";
 assert.ok(["webgpu", "webgl"].includes(backend), "unsupported backend");
 const sampleHz = integer("SAMPLE_HZ", STRESS_SAMPLE_HZ);
 const loops = integer("WORKER_LOOPS", 2);
+const minimumEffectiveFps = optionalPositiveNumber("MIN_EFFECTIVE_FPS");
 const transports = (process.env.NOON_RETAINED_STRESS_TRANSPORTS ?? "transferable,shared").split(",");
 assert.ok(transports.length > 0 && new Set(transports).size === transports.length
   && transports.every(mode => ["transferable", "shared"].includes(mode)), "invalid transports");
@@ -29,6 +30,7 @@ const report = {
   commit: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
   generatedAt: new Date().toISOString(), sourcePath, sourceSha256, backend, sampleHz,
   loopsPerTransport: loops,
+  minimumEffectiveFps,
   measurement: "Fresh source per loop; sample round trip includes source continuation, worker, runtime and rendering",
   performanceBudgets: { status: "unavailable", reason: "Isolated CPU/GPU, morph activation and warm replay metrics are not measured by shared source execution" },
   runs: [],
@@ -55,10 +57,14 @@ try {
         assert.equal(result.state, "complete", result.status);
         assert.deepEqual(errors, [], "browser errors");
         const phases = validateStressReport(result.profile, {
-          transportMode, rendererBackend: backend === "webgpu" ? "WebGPU" : "WebGL2", sampleHz,
+          transportMode,
+          rendererBackend: backend === "webgpu" ? "WebGPU" : "WebGL2",
+          sampleHz,
+          minimumEffectiveFps,
         });
         report.runs.push({ transportMode, loop, phases, profile: result.profile });
-        console.log(`PASS ${backend} ${transportMode} fresh source ${loop + 1}/${loops}: ${sampleHz} Hz, ${phases.length} phases`);
+        const effectiveFps = result.profile.cadence.effective?.effectiveFps;
+        console.log(`PASS ${backend} ${transportMode} fresh source ${loop + 1}/${loops}: ${format(effectiveFps)} FPS, ${phases.length} phases`);
       } finally { await page.close(); }
     }
   }
@@ -71,4 +77,16 @@ function integer(name, fallback) {
   const value = Number(process.env[`NOON_RETAINED_STRESS_${name}`] ?? fallback);
   assert.ok(Number.isSafeInteger(value) && value > 0, `${name} must be a positive integer`);
   return value;
+}
+
+function optionalPositiveNumber(name) {
+  const raw = process.env[`NOON_RETAINED_STRESS_${name}`];
+  if (raw === undefined || raw.trim() === "") return null;
+  const value = Number(raw);
+  assert.ok(Number.isFinite(value) && value > 0, `${name} must be positive and finite`);
+  return value;
+}
+
+function format(value) {
+  return Number.isFinite(value) ? Number(value).toFixed(2) : "—";
 }


### PR DESCRIPTION
## Summary

Restore explicit physical-device cadence qualification for the retained Dynamic Load stress workload.

- Add `dynamic-stress` to the named physical-device performance suites.
- Reuse the existing unchanged five-second source-continuation benchmark and its measured `cadence.effective.effectiveFps`.
- Add an optional benchmark FPS floor without changing ordinary SwiftShader/coverage behavior.
- Default the physical WebGPU floor to 55 FPS, against the established ~59.7-59.8 FPS retained Dynamic Load baseline.
- Keep WebGL Dynamic Load collection informational so the WebGPU floor does not create a backend-independent policy accidentally.
- Record the configured floor and Dynamic Load artifacts in the named-device bundle.

## Why

The current physical-device workflow runs frame/corpus/authoring suites but not the dedicated Dynamic Load source-continuation benchmark. The retained-stress harness already computes effective FPS, but previously only validated source coverage and fixed authored sample timing. That leaves a gap where an app-visible Dynamic Load cadence regression can merge without failing performance qualification.

This guard is intentionally measurement-only; it does not change renderer/runtime behavior while the current regression is isolated. Two recent changes are worth A/B testing once the physical runner executes this suite: #1410's retained morph correspondence/tessellation changes and #1477's persistent worker WebGPU validation error scope. The latter is currently the stronger sustained-frame suspect because the validation scope remains active across normal WebGPU submissions.

## Validation

The added unit coverage verifies that the optional FPS floor accepts a 59.8 FPS report and rejects a 54.9 FPS report at a 55 FPS floor. The physical qualification itself requires the repository's self-hosted physical runner and remains `workflow_dispatch` by design.