### PR TITLE
A/B: disable persistent WebGPU validation scope for Dynamic Load

### DIFF
--- a/.github/workflows/codex-dynamic-load-ab-hosted.yml
+++ b/.github/workflows/codex-dynamic-load-ab-hosted.yml
@@ -1,0 +1,95 @@
+name: Dynamic Load hosted A/B - validation scope
+
+on:
+  push:
+    branches:
+      - codex/dynamic-load-ab-no-validation-scope
+    paths:
+      - .github/workflows/codex-dynamic-load-ab-hosted.yml
+
+permissions:
+  contents: read
+
+jobs:
+  ab-hosted:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+      - name: Install pinned browser tooling
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+      - name: Measure exact master
+        run: |
+          git checkout --detach fe3a654eade65be4cd9a338520cb9808fbf7761f
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=1 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/hosted-ab/master.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Measure master without persistent validation scope
+        run: |
+          git reset --hard fe3a654eade65be4cd9a338520cb9808fbf7761f
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('crates/noon-web/src/retained_execution_canvas.rs')
+          source = path.read_text()
+          old = '''            let gpu_validation_scope = (backend == wgpu::Backend::BrowserWebGpu)\n                .then(|| device.push_error_scope(wgpu::ErrorFilter::Validation));\n'''
+          new = '''            // Hosted A/B only: preserve recovery and the diagnostic mailbox,\n            // but do not keep normal WebGPU submissions inside a validation scope.\n            let gpu_validation_scope: Option<wgpu::ErrorScopeGuard> = None;\n'''
+          if old not in source:
+              raise SystemExit('persistent WebGPU validation scope shape changed')
+          path.write_text(source.replace(old, new, 1))
+          PY
+          git diff --check
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=1 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/hosted-ab/no-validation-scope.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Summarize A/B
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('perf-artifacts/hosted-ab')
+          reports = {
+              'master': json.loads((root / 'master.json').read_text()),
+              'no_validation_scope': json.loads((root / 'no-validation-scope.json').read_text()),
+          }
+          def summarize(report):
+              rows = []
+              for run in report['runs']:
+                  fps = run['profile']['cadence']['effective']['effectiveFps']
+                  rows.append({'transport': run['transportMode'], 'fps': fps})
+              values = [row['fps'] for row in rows]
+              return {'runs': rows, 'mean_fps': sum(values) / len(values), 'min_fps': min(values), 'max_fps': max(values)}
+          summary = {name: summarize(report) for name, report in reports.items()}
+          summary['delta_mean_fps'] = summary['no_validation_scope']['mean_fps'] - summary['master']['mean_fps']
+          summary['delta_percent'] = 100.0 * summary['delta_mean_fps'] / summary['master']['mean_fps']
+          (root / 'comparison.json').write_text(json.dumps(summary, indent=2) + '\n')
+          print(json.dumps(summary, indent=2))
+          PY
+      - name: Upload hosted A/B evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-dynamic-load-validation-scope-hosted-${{ github.run_id }}
+          path: perf-artifacts/hosted-ab
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/codex-dynamic-load-ab-physical.yml
+++ b/.github/workflows/codex-dynamic-load-ab-physical.yml
@@ -1,0 +1,118 @@
+name: Dynamic Load physical A/B - validation scope
+
+on:
+  push:
+    branches:
+      - codex/dynamic-load-ab-no-validation-scope
+    paths:
+      - .github/workflows/codex-dynamic-load-ab-physical.yml
+
+permissions:
+  contents: read
+
+jobs:
+  ab:
+    runs-on: self-hosted
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+      - name: Install pinned browser tooling
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+      - name: Measure exact master
+        run: |
+          git checkout --detach fe3a654eade65be4cd9a338520cb9808fbf7761f
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=2 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/physical-ab/master.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Measure master without persistent validation scope
+        run: |
+          git reset --hard fe3a654eade65be4cd9a338520cb9808fbf7761f
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('crates/noon-web/src/retained_execution_canvas.rs')
+          source = path.read_text()
+          old = '''            let gpu_validation_scope = (backend == wgpu::Backend::BrowserWebGpu)\n                .then(|| device.push_error_scope(wgpu::ErrorFilter::Validation));\n'''
+          new = '''            // Physical A/B only: preserve recovery and the diagnostic mailbox,\n            // but do not keep normal WebGPU submissions inside a validation scope.\n            let gpu_validation_scope: Option<wgpu::ErrorScopeGuard> = None;\n'''
+          if old not in source:
+              raise SystemExit('persistent WebGPU validation scope shape changed')
+          path.write_text(source.replace(old, new, 1))
+          PY
+          git diff --check
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=2 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/physical-ab/no-validation-scope.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Summarize A/B
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('perf-artifacts/physical-ab')
+          reports = {
+              'master': json.loads((root / 'master.json').read_text()),
+              'no_validation_scope': json.loads((root / 'no-validation-scope.json').read_text()),
+          }
+          def summarize(report):
+              rows = []
+              for run in report['runs']:
+                  fps = run['profile']['cadence']['effective']['effectiveFps']
+                  rows.append({'transport': run['transportMode'], 'loop': run['loop'], 'fps': fps})
+              values = [row['fps'] for row in rows]
+              by_transport = {}
+              for transport in sorted({row['transport'] for row in rows}):
+                  sample = [row['fps'] for row in rows if row['transport'] == transport]
+                  by_transport[transport] = {
+                      'mean_fps': sum(sample) / len(sample),
+                      'min_fps': min(sample),
+                      'max_fps': max(sample),
+                  }
+              return {
+                  'runs': rows,
+                  'mean_fps': sum(values) / len(values),
+                  'min_fps': min(values),
+                  'max_fps': max(values),
+                  'by_transport': by_transport,
+              }
+          summary = {name: summarize(report) for name, report in reports.items()}
+          summary['delta_mean_fps'] = (
+              summary['no_validation_scope']['mean_fps'] - summary['master']['mean_fps']
+          )
+          summary['delta_percent'] = (
+              100.0 * summary['delta_mean_fps'] / summary['master']['mean_fps']
+          )
+          (root / 'comparison.json').write_text(json.dumps(summary, indent=2) + '\n')
+          print(json.dumps(summary, indent=2))
+          with open(Path(__import__('os').environ['GITHUB_STEP_SUMMARY']), 'a') as out:
+              out.write('## Dynamic Load physical A/B\n\n')
+              out.write(f"- master mean: {summary['master']['mean_fps']:.2f} FPS\n")
+              out.write(f"- no validation scope mean: {summary['no_validation_scope']['mean_fps']:.2f} FPS\n")
+              out.write(f"- delta: {summary['delta_mean_fps']:+.2f} FPS ({summary['delta_percent']:+.1f}%)\n")
+          PY
+      - name: Upload A/B evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-dynamic-load-validation-scope-ab-${{ github.run_id }}
+          path: perf-artifacts/physical-ab
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/codex-dynamic-load-realtime-hosted.yml
+++ b/.github/workflows/codex-dynamic-load-realtime-hosted.yml
@@ -1,0 +1,168 @@
+name: Dynamic Load hosted realtime gallery A/B
+
+on:
+  push:
+    branches:
+      - codex/dynamic-load-ab-no-validation-scope
+    paths:
+      - .github/workflows/codex-dynamic-load-realtime-hosted.yml
+
+permissions:
+  contents: read
+
+jobs:
+  realtime-ab:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+      - name: Install pinned browser tooling
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+      - name: Write realtime gallery probe
+        run: |
+          cat > /tmp/noon-realtime-gallery-probe.mjs <<'NODE'
+          import { writeFile } from 'node:fs/promises';
+          import path from 'node:path';
+          import { pathToFileURL } from 'node:url';
+          const root = process.cwd();
+          const { default: playwright } = await import('playwright');
+          const { serveRepository } = await import(pathToFileURL(path.join(root, 'scripts/browser-test-server.mjs')));
+          const { browserArgs } = await import(pathToFileURL(path.join(root, 'scripts/manim-raster-support.mjs')));
+          const artifact = path.resolve(process.env.NOON_REALTIME_ARTIFACT);
+          const server = await serveRepository(root, Number(process.env.NOON_REALTIME_PORT ?? 4204), { crossOriginIsolated: true });
+          let browser;
+          try {
+            browser = await playwright.chromium.launch({ channel: 'chromium', headless: true, args: browserArgs('webgpu') });
+            const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+            const errors = [];
+            page.on('pageerror', error => errors.push(String(error)));
+            page.on('console', message => { if (message.type() === 'error') errors.push(message.text()); });
+            await page.goto(`${server.baseUrl}/web/index.html?example=manim-parity-stress-grid`);
+            await page.waitForFunction(() => {
+              const button = document.querySelector('#replace-scene');
+              return button && !button.disabled;
+            }, null, { timeout: 180000 });
+            await page.click('#replace-scene');
+            await page.waitForFunction(() => {
+              const status = document.querySelector('#status');
+              return status?.dataset.state === 'running'
+                && status.dataset.rendererBackend === 'WebGPU'
+                && Number(status.dataset.presentedFrames ?? 0) >= 4;
+            }, null, { timeout: 180000 });
+            const observation = await page.evaluate(() => new Promise((resolve) => {
+              const status = document.querySelector('#status');
+              const samples = [];
+              const capture = () => {
+                const frames = Number(status.dataset.presentedFrames ?? NaN);
+                if (!Number.isFinite(frames)) return;
+                const last = samples.at(-1);
+                if (!last || last.frames !== frames) {
+                  samples.push({
+                    wallMs: performance.now(),
+                    frames,
+                    missedDeadlines: Number(status.dataset.hostMissedDeadlines ?? 0),
+                    droppedLateResults: Number(status.dataset.hostDroppedLateResults ?? 0),
+                  });
+                }
+              };
+              capture();
+              const observer = new MutationObserver(capture);
+              observer.observe(status, { attributes: true, attributeFilter: ['data-presented-frames'] });
+              const deadline = performance.now() + 3400;
+              const poll = setInterval(() => {
+                capture();
+                if (samples.length >= 7 || performance.now() >= deadline) {
+                  clearInterval(poll);
+                  observer.disconnect();
+                  resolve({
+                    samples,
+                    rendererBackend: status.dataset.rendererBackend,
+                    executionMode: status.dataset.executionMode,
+                    state: status.dataset.state,
+                    objects: document.querySelector('#metric-objects')?.value,
+                  });
+                }
+              }, 50);
+            }));
+            if (errors.length) throw new Error(`browser errors: ${errors.join(' | ')}`);
+            if (observation.samples.length < 4) throw new Error(`insufficient realtime samples: ${JSON.stringify(observation)}`);
+            const first = observation.samples[0];
+            const last = observation.samples.at(-1);
+            const frameDelta = last.frames - first.frames;
+            const wallMs = last.wallMs - first.wallMs;
+            const effectiveFps = frameDelta * 1000 / wallMs;
+            const result = { ...observation, frameDelta, wallMs, effectiveFps };
+            await writeFile(artifact, JSON.stringify(result, null, 2));
+            console.log('NOON_REALTIME_GALLERY', JSON.stringify(result, null, 2));
+            await page.close();
+          } finally {
+            await browser?.close();
+            await server.close();
+          }
+          NODE
+      - name: Measure exact master realtime gallery
+        run: |
+          git checkout --detach fe3a654eade65be4cd9a338520cb9808fbf7761f
+          bash scripts/build-web-demo.sh
+          mkdir -p perf-artifacts/realtime-gallery-ab
+          NOON_REALTIME_PORT=4204 \
+          NOON_REALTIME_ARTIFACT=perf-artifacts/realtime-gallery-ab/master.json \
+          node /tmp/noon-realtime-gallery-probe.mjs
+      - name: Measure no-validation-scope realtime gallery
+        run: |
+          git reset --hard fe3a654eade65be4cd9a338520cb9808fbf7761f
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('crates/noon-web/src/retained_execution_canvas.rs')
+          source = path.read_text()
+          old = '''            let gpu_validation_scope = (backend == wgpu::Backend::BrowserWebGpu)\n                .then(|| device.push_error_scope(wgpu::ErrorFilter::Validation));\n'''
+          new = '''            let gpu_validation_scope: Option<wgpu::ErrorScopeGuard> = None;\n'''
+          if old not in source:
+              raise SystemExit('persistent WebGPU validation scope shape changed')
+          path.write_text(source.replace(old, new, 1))
+          PY
+          git diff --check
+          bash scripts/build-web-demo.sh
+          NOON_REALTIME_PORT=4205 \
+          NOON_REALTIME_ARTIFACT=perf-artifacts/realtime-gallery-ab/no-validation-scope.json \
+          node /tmp/noon-realtime-gallery-probe.mjs
+      - name: Summarize realtime A/B
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('perf-artifacts/realtime-gallery-ab')
+          master = json.loads((root / 'master.json').read_text())
+          variant = json.loads((root / 'no-validation-scope.json').read_text())
+          summary = {
+              'master_fps': master['effectiveFps'],
+              'no_validation_scope_fps': variant['effectiveFps'],
+              'delta_fps': variant['effectiveFps'] - master['effectiveFps'],
+              'delta_percent': 100 * (variant['effectiveFps'] - master['effectiveFps']) / master['effectiveFps'],
+              'master_missed_deadlines': master['samples'][-1]['missedDeadlines'] - master['samples'][0]['missedDeadlines'],
+              'variant_missed_deadlines': variant['samples'][-1]['missedDeadlines'] - variant['samples'][0]['missedDeadlines'],
+          }
+          (root / 'comparison.json').write_text(json.dumps(summary, indent=2) + '\n')
+          print(json.dumps(summary, indent=2))
+          PY
+      - name: Upload realtime A/B evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-dynamic-load-realtime-gallery-${{ github.run_id }}
+          path: perf-artifacts/realtime-gallery-ab
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/perf-physical-device.yml
+++ b/.github/workflows/perf-physical-device.yml
@@ -73,6 +73,21 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
+      - name: A/B disable persistent worker WebGPU validation scope
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('crates/noon-web/src/retained_execution_canvas.rs')
+          source = path.read_text()
+          old = '''            let gpu_validation_scope = (backend == wgpu::Backend::BrowserWebGpu)\n                .then(|| device.push_error_scope(wgpu::ErrorFilter::Validation));\n'''
+          new = '''            // Dynamic Load A/B only: preserve #1477 recovery/mailbox behavior but\n            // do not keep every normal WebGPU submission inside a validation scope.\n            let gpu_validation_scope: Option<wgpu::ErrorScopeGuard> = None;\n'''
+          if old not in source:
+              raise SystemExit('persistent WebGPU validation scope shape changed')
+          path.write_text(source.replace(old, new, 1))
+          PY
+          git diff --check
+          git diff -- crates/noon-web/src/retained_execution_canvas.rs
       - name: Build optimized production WASM
         run: bash scripts/build-web-demo.sh
       - name: Record named physical-device bundle


### PR DESCRIPTION
## Purpose

Single-variable performance experiment for the Dynamic Load FPS regression.

The physical-device workflow on this branch patches only one runtime behavior before building: it leaves #1477's recovery, diagnostic mailbox, uncaptured-error handler and flush API intact, but does not arm the persistent `wgpu::ErrorScopeGuard` around ordinary WebGPU submissions.

This PR is **experimental and not intended to merge as-is**. Its purpose is to run the same physical WebGPU `dynamic-stress` suite added by #1518 against:

1. `master` — persistent validation scope enabled.
2. this branch — persistent validation scope disabled.

Use identical device/backend/suite/settings for both runs. A material FPS recovery here would isolate #1477's persistent validation scope as the regression source; no recovery would rule it down and move the bisect to retained runtime/render changes after the last known-good 60 Hz baseline.

## Run

Workflow: `Physical device performance baseline`

- backend: `webgpu`
- suite: `dynamic-stress`
- target Hz: `60`
- Dynamic Load floor: `55`

The workflow fails if the patch target no longer matches, so the experiment cannot silently become a different comparison.