### PR TITLE
A/B: restore pre-1410 morph tessellator selection for Dynamic Load

### DIFF
--- a/.github/workflows/codex-dynamic-load-morph-ab-hosted.yml
+++ b/.github/workflows/codex-dynamic-load-morph-ab-hosted.yml
@@ -1,0 +1,95 @@
+name: Dynamic Load hosted A/B - morph selection
+
+on:
+  push:
+    branches:
+      - codex/dynamic-load-ab-pre1410-morph
+    paths:
+      - .github/workflows/codex-dynamic-load-morph-ab-hosted.yml
+
+permissions:
+  contents: read
+
+jobs:
+  ab-hosted:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b
+        with:
+          tool: wasm-pack@0.15.0
+          fallback: none
+      - name: Install pinned browser tooling
+        run: |
+          npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
+          npx playwright install chromium
+      - name: Measure exact master
+        run: |
+          git checkout --detach fe3a654eade65be4cd9a338520cb9808fbf7761f
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=1 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/hosted-morph-ab/master.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Measure master with pre-1410 morph selection
+        run: |
+          git reset --hard fe3a654eade65be4cd9a338520cb9808fbf7761f
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('crates/noon-render-wgpu/src/lib.rs')
+          source = path.read_text()
+          current = '''        let mesh = if tessellation_path.morph_target().is_some() {\n            noon_geometry::tessellate_styled_with_fill_preserving_morph_order(\n'''
+          prior = '''        let mesh = if style.stroke_width_mode == StrokeWidthMode::ScreenSpace\n            && tessellation_path.morph_target().is_some()\n        {\n            noon_geometry::tessellate_styled_with_fill_preserving_morph_order(\n'''
+          if current not in source:
+              raise SystemExit('post-1410 morph tessellator shape changed')
+          path.write_text(source.replace(current, prior, 1))
+          PY
+          git diff --check
+          bash scripts/build-web-demo.sh
+          NOON_RETAINED_STRESS_BACKEND=webgpu \
+          NOON_RETAINED_STRESS_SAMPLE_HZ=60 \
+          NOON_RETAINED_STRESS_WORKER_LOOPS=1 \
+          NOON_RETAINED_STRESS_TRANSPORTS=transferable,shared \
+          NOON_RETAINED_STRESS_ARTIFACT=perf-artifacts/hosted-morph-ab/pre1410.json \
+          node scripts/retained-dynamic-stress-perf.mjs
+      - name: Summarize A/B
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('perf-artifacts/hosted-morph-ab')
+          reports = {
+              'master': json.loads((root / 'master.json').read_text()),
+              'pre1410': json.loads((root / 'pre1410.json').read_text()),
+          }
+          def summarize(report):
+              rows = []
+              for run in report['runs']:
+                  fps = run['profile']['cadence']['effective']['effectiveFps']
+                  rows.append({'transport': run['transportMode'], 'fps': fps})
+              values = [row['fps'] for row in rows]
+              return {'runs': rows, 'mean_fps': sum(values) / len(values), 'min_fps': min(values), 'max_fps': max(values)}
+          summary = {name: summarize(report) for name, report in reports.items()}
+          summary['delta_mean_fps'] = summary['pre1410']['mean_fps'] - summary['master']['mean_fps']
+          summary['delta_percent'] = 100.0 * summary['delta_mean_fps'] / summary['master']['mean_fps']
+          (root / 'comparison.json').write_text(json.dumps(summary, indent=2) + '\n')
+          print(json.dumps(summary, indent=2))
+          PY
+      - name: Upload hosted A/B evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: noon-dynamic-load-morph-selection-hosted-${{ github.run_id }}
+          path: perf-artifacts/hosted-morph-ab
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/perf-physical-device.yml
+++ b/.github/workflows/perf-physical-device.yml
@@ -73,6 +73,21 @@ jobs:
         run: |
           npm install --no-save --ignore-scripts playwright@1.62.1 pngjs@7.0.0
           npx playwright install chromium
+      - name: A/B restore pre-1410 morph tessellator selection
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('crates/noon-render-wgpu/src/lib.rs')
+          source = path.read_text()
+          current = '''        let mesh = if tessellation_path.morph_target().is_some() {\n            noon_geometry::tessellate_styled_with_fill_preserving_morph_order(\n'''
+          prior = '''        let mesh = if style.stroke_width_mode == StrokeWidthMode::ScreenSpace\n            && tessellation_path.morph_target().is_some()\n        {\n            noon_geometry::tessellate_styled_with_fill_preserving_morph_order(\n'''
+          if current not in source:
+              raise SystemExit('post-1410 morph tessellator shape changed')
+          path.write_text(source.replace(current, prior, 1))
+          PY
+          git diff --check
+          git diff -- crates/noon-render-wgpu/src/lib.rs
       - name: Build optimized production WASM
         run: bash scripts/build-web-demo.sh
       - name: Record named physical-device bundle


### PR DESCRIPTION
## Purpose

Second single-variable performance experiment for the Dynamic Load FPS regression.

The physical-device workflow on this branch patches only the morph mesh-selection condition before building. It restores the pre-#1410 behavior where preserving-order morph tessellation is selected only for `ScreenSpace` strokes. Dynamic Load uses the default `ScaleWithObject` stroke-width mode, so this makes its square↔circle morphs use the pre-#1410 tessellator while leaving current source/runtime/transport code unchanged.

This PR is **experimental and not intended to merge as-is**. Run it only if the #1519 no-validation-scope experiment does not recover cadence, or run all three variants on the same physical machine for a direct comparison:

1. `master` — current renderer behavior.
2. #1519 — current morph path, persistent WebGPU validation scope disabled.
3. this branch — current validation behavior, pre-#1410 morph tessellator selection.

## Run

Workflow: `Physical device performance baseline`

- backend: `webgpu`
- suite: `dynamic-stress`
- target Hz: `60`
- Dynamic Load floor: `55`

The workflow aborts if the post-#1410 source shape changes, preventing the experiment from silently testing a different code path.