### PR TITLE
Prepare ordinary value publication before semantic commit

### DIFF
--- a/crates/noon-compile/src/execution_patch.rs
+++ b/crates/noon-compile/src/execution_patch.rs
@@ -2,7 +2,7 @@ use noon_core::{
     ObjectContentRef, ObjectId, Property, Rect, Style, TrackDefinition, TrackId, Transform2D,
 };
 
-use crate::{CompiledFamilyAnimation, CompiledObject};
+use crate::{CompiledFamilyAnimation, CompiledObject, CompiledScene};
 
 /// Renderer-independent mutations over the compiler-owned execution plan.
 ///
@@ -76,5 +76,24 @@ impl ExecutionMutationTransaction {
 
     pub fn is_empty(&self) -> bool {
         self.mutations.is_empty()
+    }
+}
+
+impl CompiledScene {
+    /// Commit one transform value whose object slot and numeric payload were already
+    /// validated by the caller's prepared publication proof.
+    ///
+    /// This is deliberately narrower than `apply_execution_patch`: it performs no
+    /// lookup or validation and cannot publish structural/timeline/resource edits.
+    #[doc(hidden)]
+    pub fn commit_prepared_transform_value(&mut self, object_index: u32, transform: Transform2D) {
+        self.objects[object_index as usize].base_transform = transform;
+    }
+
+    /// Commit one style value whose object slot and payload were already validated
+    /// by the caller's prepared publication proof.
+    #[doc(hidden)]
+    pub fn commit_prepared_style_value(&mut self, object_index: u32, style: Style) {
+        self.objects[object_index as usize].base_style = style;
     }
 }

--- a/crates/noon-runtime/src/execution_slots/mod.rs
+++ b/crates/noon-runtime/src/execution_slots/mod.rs
@@ -1,7 +1,9 @@
+mod prepared_value_publication;
 mod runtime_transaction;
 mod semantic_membership;
 mod table;
 
+pub use prepared_value_publication::PreparedAuthoredValuePublication;
 pub use runtime_transaction::{
     AuthoredPublicationError, PreparedAuthoredPlanChange, PreparedAuthoredReactivePlanChange,
 };

--- a/crates/noon-runtime/src/execution_slots/prepared_value_publication.rs
+++ b/crates/noon-runtime/src/execution_slots/prepared_value_publication.rs
@@ -1,0 +1,227 @@
+use noon_compile::{ExecutionMutationTransaction, ExecutionPatch};
+use noon_core::{
+    ExecutionRevision, FrameEpoch, Property, PublicationContext, SceneRevision, Style, Transform2D,
+};
+
+use super::runtime_transaction::{final_value_writes, AuthoredPublicationError};
+use crate::{FrameRowState, FrameState, RuntimeIdentity, SceneInstance};
+
+#[derive(Clone, Copy, Debug)]
+enum PreparedAuthoredValueWrite {
+    Transform {
+        object_index: usize,
+        transform: Transform2D,
+        changes_execution: bool,
+    },
+    Style {
+        object_index: usize,
+        style: Style,
+        changes_execution: bool,
+    },
+}
+
+impl PreparedAuthoredValueWrite {
+    const fn object_index(self) -> usize {
+        match self {
+            Self::Transform { object_index, .. } | Self::Style { object_index, .. } => object_index,
+        }
+    }
+
+    const fn changes_execution(self) -> bool {
+        match self {
+            Self::Transform {
+                changes_execution, ..
+            }
+            | Self::Style {
+                changes_execution, ..
+            } => changes_execution,
+        }
+    }
+}
+
+/// Runtime proof for one already-semantic-prepared batch containing only ordinary
+/// local transform/style writes.
+///
+/// Construction validates the exact Runtime identity/context, complete compiled
+/// transaction, object slots, and revision capacity. The execution-session owner
+/// then holds this proof under exclusive control until semantic commit, so commit
+/// itself contains no validation or fallible Runtime operation.
+#[derive(Clone, Debug)]
+pub struct PreparedAuthoredValuePublication {
+    runtime: RuntimeIdentity,
+    expected: PublicationContext,
+    scene_revision: SceneRevision,
+    execution_revision: ExecutionRevision,
+    frame_epoch: FrameEpoch,
+    writes: Vec<PreparedAuthoredValueWrite>,
+}
+
+impl SceneInstance {
+    /// Prepare the narrow P1 authored-value publication contract.
+    ///
+    /// `Ok(None)` means the transaction contains something other than transform/style
+    /// base writes and must stay on the existing general publication path.
+    pub fn prepare_authored_value_publication(
+        &self,
+        transaction: &ExecutionMutationTransaction,
+        expected: PublicationContext,
+        scene_revision: SceneRevision,
+    ) -> Result<Option<PreparedAuthoredValuePublication>, AuthoredPublicationError> {
+        if transaction.mutations().iter().any(|patch| {
+            !matches!(
+                patch,
+                ExecutionPatch::SetTransform { .. } | ExecutionPatch::SetStyle { .. }
+            )
+        }) {
+            return Ok(None);
+        }
+
+        let current = self.publication_context();
+        if expected != current {
+            return Err(AuthoredPublicationError::StalePublication {
+                expected,
+                actual: current,
+            });
+        }
+        let scene_changed = scene_revision != current.scene_revision();
+        if scene_changed && current.scene_revision().checked_next() != Some(scene_revision) {
+            return Err(AuthoredPublicationError::InvalidSceneRevision {
+                current: current.scene_revision(),
+                proposed: scene_revision,
+            });
+        }
+
+        // Validate every submitted write, including one superseded by a later value,
+        // before retaining only the final value in each object/property lane.
+        self.compiled.preflight_execution_transaction(transaction)?;
+        let mut writes = Vec::new();
+        let mut execution_changed = false;
+        for patch in final_value_writes(transaction) {
+            let (object, prepared) = match patch {
+                ExecutionPatch::SetTransform { object, .. } => (*object, 0_u8),
+                ExecutionPatch::SetStyle { object, .. } => (*object, 1_u8),
+                _ => return Ok(None),
+            };
+            let object_index = self
+                .compiled
+                .object_index(object)
+                .ok_or(noon_compile::CompilePatchError::UnknownObject(object))?
+                as usize;
+            let changes_execution = self.compiled.patch_changes_execution(patch);
+            execution_changed |= changes_execution;
+            writes.push(match (prepared, patch) {
+                (0, ExecutionPatch::SetTransform { transform, .. }) => {
+                    PreparedAuthoredValueWrite::Transform {
+                        object_index,
+                        transform: *transform,
+                        changes_execution,
+                    }
+                }
+                (1, ExecutionPatch::SetStyle { style, .. }) => PreparedAuthoredValueWrite::Style {
+                    object_index,
+                    style: *style,
+                    changes_execution,
+                },
+                _ => unreachable!("ordinary value publication classified above"),
+            });
+        }
+
+        let execution_revision = if execution_changed {
+            current.execution_revision().checked_next().ok_or(
+                AuthoredPublicationError::ExecutionRevisionExhausted(current.execution_revision()),
+            )?
+        } else {
+            current.execution_revision()
+        };
+        let frame_epoch = if scene_changed || execution_changed {
+            current.frame_epoch().checked_next().ok_or(
+                AuthoredPublicationError::FrameEpochExhausted(current.frame_epoch()),
+            )?
+        } else {
+            current.frame_epoch()
+        };
+
+        Ok(Some(PreparedAuthoredValuePublication {
+            runtime: self.runtime_identity(),
+            expected,
+            scene_revision,
+            execution_revision,
+            frame_epoch,
+            writes,
+        }))
+    }
+
+    /// Commit an authored local-value publication after its matching Semantic Scene
+    /// transaction has crossed the point of no return.
+    ///
+    /// The execution-session `PreparedPublication` owns exclusive access between
+    /// preparation and this call. No check, lookup, allocation, or fallible compile
+    /// operation remains here.
+    pub fn commit_prepared_authored_value_publication(
+        &mut self,
+        prepared: PreparedAuthoredValuePublication,
+    ) -> &FrameState {
+        debug_assert_eq!(prepared.runtime, self.runtime_identity());
+        debug_assert_eq!(prepared.expected, self.publication_context());
+        self.last_patch_stats = crate::RuntimePatchStats::default();
+
+        for write in prepared.writes {
+            if !write.changes_execution() {
+                continue;
+            }
+            let object_index = write.object_index();
+            let before = FrameRowState::from_frame(&self.frame, object_index);
+            match write {
+                PreparedAuthoredValueWrite::Transform {
+                    transform,
+                    object_index,
+                    ..
+                } => {
+                    self.compiled
+                        .commit_prepared_transform_value(object_index as u32, transform);
+                    self.frame.release_render_transform(object_index);
+                    self.frame.objects[object_index].transform = transform;
+                    self.reapply_properties(
+                        object_index,
+                        &[
+                            Property::Transform,
+                            Property::Position,
+                            Property::Rotation,
+                            Property::Scale,
+                        ],
+                    );
+                }
+                PreparedAuthoredValueWrite::Style {
+                    style,
+                    object_index,
+                    ..
+                } => {
+                    self.compiled
+                        .commit_prepared_style_value(object_index as u32, style);
+                    self.frame.objects[object_index].style = style;
+                    self.reapply_properties(
+                        object_index,
+                        &[
+                            Property::Transform,
+                            Property::Fill,
+                            Property::Stroke,
+                            Property::StrokeWidth,
+                            Property::Opacity,
+                        ],
+                    );
+                }
+            }
+            self.reapply_reactive_for_object(object_index);
+            if before.differs_from_frame(&self.frame, object_index) {
+                self.mark_changed(object_index);
+            }
+        }
+
+        self.publication = PublicationContext::new(
+            prepared.scene_revision,
+            prepared.execution_revision,
+            prepared.frame_epoch,
+        );
+        &self.frame
+    }
+}

--- a/crates/noon/src/execution_session/publication.rs
+++ b/crates/noon/src/execution_session/publication.rs
@@ -18,6 +18,9 @@ use noon_runtime::{
 
 use super::ExecutionSession;
 
+mod prepared_value;
+use prepared_value::PreparedPublication;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SemanticPublicationPurpose {
     AuthoredMutation,
@@ -329,6 +332,15 @@ impl ExecutionSession {
         scalar: Option<PreparedScalarPublicationContract>,
         order_root: Option<SemanticNodeId>,
     ) -> Result<SemanticMutationTransactionResult, ExecutionSessionPublicationError> {
+        if purpose == SemanticPublicationPurpose::AuthoredMutation
+            && execution_prefix.is_empty()
+            && effective.is_none()
+            && scalar.is_none()
+            && PreparedPublication::supports(&prepared)
+        {
+            return Ok(PreparedPublication::prepare(self, prepared, order_root)?.publish());
+        }
+
         self.require_publication_ready(purpose)?;
         self.require_published_store(prepared.store())?;
         if order_root.is_none() {

--- a/crates/noon/src/execution_session/publication/prepared_value.rs
+++ b/crates/noon/src/execution_session/publication/prepared_value.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+/// Final P1 proof for ordinary local transform/style publication.
+///
+/// This value owns the exclusive semantic preflight and borrows the execution
+/// session mutably until publication, so neither authority can change between
+/// Runtime preparation and the one semantic point of no return.
+pub(super) struct PreparedPublication<'session, 'store> {
+    session: &'session mut ExecutionSession,
+    semantic: PreparedSemanticMutationTransaction<'store>,
+    runtime: noon_runtime::PreparedAuthoredValuePublication,
+    preparation: SemanticPublicationPreparationStats,
+}
+
+impl<'session, 'store> PreparedPublication<'session, 'store> {
+    pub(super) fn supports(prepared: &PreparedSemanticMutationTransaction<'_>) -> bool {
+        prepared.mutations().iter().all(|mutation| {
+            matches!(
+                mutation,
+                SemanticMutation::SetProperty { .. } | SemanticMutation::ReplaceStyle { .. }
+            )
+        })
+    }
+
+    pub(super) fn prepare(
+        session: &'session mut ExecutionSession,
+        semantic: PreparedSemanticMutationTransaction<'store>,
+        order_root: Option<SemanticNodeId>,
+    ) -> Result<Self, ExecutionSessionPublicationError> {
+        session.require_publication_ready(SemanticPublicationPurpose::AuthoredMutation)?;
+        session.require_published_store(semantic.store())?;
+        if let Some(root) = order_root {
+            if !session.reachability.is_execution_root(root) {
+                return Err(ExecutionSessionPublicationError::UnknownObject(root));
+            }
+        }
+
+        let plan = prepare_semantic_publication(
+            &semantic,
+            &session.execution_index,
+            &session.reachability,
+        )
+        .map_err(ExecutionSessionPublicationError::Lowering)?;
+        let preparation = plan.stats();
+        debug_assert_eq!(plan.possible_entry_count(), 0);
+        debug_assert!(plan.possible_exits().is_empty());
+        debug_assert_eq!(plan.resource_additions().text_count(), 0);
+        debug_assert_eq!(plan.resource_additions().font_count(), 0);
+        debug_assert_eq!(plan.resource_additions().geometry_count(), 0);
+
+        let runtime = session
+            .runtime
+            .prepare_authored_value_publication(
+                plan.value_transaction(),
+                session.publication_context(),
+                semantic.proposed_scene_revision(),
+            )
+            .map_err(ExecutionSessionPublicationError::Runtime)?
+            .ok_or(ExecutionSessionPublicationError::Lowering(
+                SemanticPublicationLoweringError::UnsupportedMutation { index: 0 },
+            ))?;
+
+        Ok(Self {
+            session,
+            semantic,
+            runtime,
+            preparation,
+        })
+    }
+
+    /// Cross the Semantic Scene point of no return exactly once, then perform only
+    /// commits whose complete compiler/Runtime proof is already owned by `self`.
+    pub(super) fn publish(self) -> SemanticMutationTransactionResult {
+        let Self {
+            session,
+            semantic,
+            runtime,
+            preparation,
+        } = self;
+        let (result, store) = semantic.commit_with_store();
+        session
+            .runtime
+            .commit_prepared_authored_value_publication(runtime);
+        session
+            .execution_index
+            .apply_transaction_result(store, &result);
+        session.last_structural_publication = StructuralPublicationStats {
+            preparation,
+            entered_objects: 0,
+            exited_objects: 0,
+        };
+        result
+    }
+}


### PR DESCRIPTION
Implements the bounded P1 proof from #1506.

This migrates only ordinary persistent `SetProperty` / `ReplaceStyle` publication. The lifecycle is now `SemanticMutationTransaction -> PreparedSemanticMutationTransaction -> private PreparedPublication -> publish()` for that caller family. Compiler lowering, complete Runtime transaction validation, stable object-slot resolution, and Scene/Execution/Frame revision-capacity checks all happen before Semantic Scene commit. `PreparedPublication::publish()` crosses the semantic point of no return once, then calls a Runtime prepared-value commit that returns no `Result` and performs no post-commit validation-by-`expect`.

The scope is deliberately narrow. It does not migrate structural add/remove/reorder or root-order work, prepared resources/content, scalar/reactive enrollment, callbacks/updaters, animation activation, or segment completion. Those continue through the existing general publication funnel for P2-P6. It also does not change `PreparedPathEdits`, `LiveSession` ownership, `SemanticMutationImpact`, or the `ExecutionMutationTransaction` vocabulary globally.

Existing publication regressions are the primary proof set: local transform+style updates remain row-local on a 100k-object scene; exact semantic no-op vs sub-f32 authored-only edits preserve the distinct Scene/Execution/Frame revision rules; and late lowering failure leaves Semantic Scene, Runtime frame/publication, and dirty state unchanged.

Complexity delta for P1: the repository still has the same six visible `ExecutionSession` apply entry points plus one private general funnel because later slices still need them. The migrated ordinary path now has one early classifier branch, one private final `PreparedPublication`, and one Runtime `PreparedAuthoredValuePublication`, instead of traversing updater/scalar/root/structural/effective branches and then relying on a fallible Runtime apply call whose success was asserted after semantic commit. No generic builder/framework is introduced.

Refs #1506 #1489 #1480.