### PR TITLE
docs: classify static SVGMobject support as partial

### DIFF
--- a/compat/manim-v0.21.0.json
+++ b/compat/manim-v0.21.0.json
@@ -85,7 +85,7 @@
     "StreamLines": {"status": "blocked", "category": "visualization", "dependency": "#88"},
     "BarChart": {"status": "blocked", "category": "visualization", "dependency": "#88/#85"},
     "SampleSpace": {"status": "blocked", "category": "visualization", "dependency": "#88"},
-    "SVGMobject": {"status": "blocked", "category": "asset-import", "dependency": "#79"},
+    "SVGMobject": {"status": "partial", "category": "asset-import", "dependency": "#79", "evidence": "parity/manim-v0.21/core-examples/svg_static_import.py; parity/manim-v0.21/svg-manifest.json; scripts/svg-authoring-smoke.mjs; canonical SVG semantic/raster differential fixtures", "reason": "Static vector SVG import is implemented through shared Rust and parity-qualified for the supported subset: paths/common primitives, groups/use, viewBox/transforms, solid fill/stroke/opacity, and string/bytes/file/URL authoring into retained semantic families. SVG text/images, gradients/patterns, clips/masks/filters/group compositing, dashed/even-odd/stroke-first/miter-clip cases, broader parser configuration, and remaining mobile qualification are still pending under #79."},
     "ImageMobject": {"status": "blocked", "category": "asset-import", "dependency": "#79"}
   },
   "module_rules": [


### PR DESCRIPTION
## Summary

Promote the canonical ManimCE v0.21 compatibility classification for `SVGMobject` from `blocked` to `partial` now that #1493 is merged.

This is deliberately narrower than claiming full SVG support:

- records the executable/static SVG evidence landed in #1493
- describes the qualified subset: paths/common primitives, groups/use, viewBox/transforms, solid fill/stroke/opacity, and string/bytes/file/URL authoring into retained semantic families
- keeps dependency #79 open for SVG text/images, gradients/patterns, clipping/masking/filtering/group compositing, dashed/even-odd/stroke-first/miter-clip cases, broader parser configuration, and remaining mobile qualification
- leaves `ImageMobject` classified as `blocked`

## Validation

- branch is one commit ahead of current base `862209acb396d5de574b60e624474354013f256c`
- only `compat/manim-v0.21.0.json` changes (2 additions / 2 deletions)
- classification remains conservative (`partial`, not `supported`)

Follow-up to #1493; advances #79.