### PR TITLE
Route persistent Scene membership through owned execution

### DIFF
--- a/crates/noon/src/authoring_error.rs
+++ b/crates/noon/src/authoring_error.rs
@@ -1,8 +1,9 @@
 //! Structured failures produced by shared Rust authoring operations.
 //!
-//! Existing semantic, resource and transaction causes remain intact. These errors
-//! do not replace live publication, segment or activation errors, and never infer
-//! categories from diagnostics.
+//! Existing semantic, resource and transaction causes remain intact. Scene-owned
+//! running edits retain execution-publication causes explicitly; dedicated live
+//! segment and activation errors remain separate and no category is inferred from
+//! diagnostics.
 
 /// A concrete unsupported payload or operation in ordinary shared authoring.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -175,6 +176,8 @@ pub enum AuthoringError {
     Semantic(noon_core::SemanticSceneOperationError),
     /// Transaction preflight failed before commit.
     Transaction(noon_core::SemanticMutationTransactionError),
+    /// Scene-owned running authoring failed during execution publication.
+    ExecutionPublication(crate::ExecutionSessionPublicationError),
     /// A high-precision value cannot lower to renderer coordinates.
     VectorLowering(noon_core::SemanticLoweringError),
     /// Immutable geometry resource validation failed.
@@ -287,6 +290,7 @@ impl std::fmt::Display for AuthoringError {
             Self::EmptyInputName { kind } => write!(f, "native input {kind} must not be empty"),
             Self::Semantic(error) => error.fmt(f),
             Self::Transaction(error) => error.fmt(f),
+            Self::ExecutionPublication(error) => error.fmt(f),
             Self::VectorLowering(error) => error.fmt(f),
             Self::GeometryResource(error) => error.fmt(f),
             Self::PathQuery(error) => error.fmt(f),
@@ -310,6 +314,7 @@ impl std::error::Error for AuthoringError {
             Self::FamilyPairing(error) => Some(error),
             Self::Semantic(error) => Some(error),
             Self::Transaction(error) => Some(error),
+            Self::ExecutionPublication(error) => Some(error),
             Self::VectorLowering(error) => Some(error),
             Self::GeometryResource(error) => Some(error),
             Self::PathQuery(error) => Some(error),
@@ -337,6 +342,12 @@ impl From<noon_core::SemanticSceneOperationError> for AuthoringError {
 impl From<noon_core::SemanticMutationTransactionError> for AuthoringError {
     fn from(error: noon_core::SemanticMutationTransactionError) -> Self {
         Self::Transaction(error)
+    }
+}
+
+impl From<crate::ExecutionSessionPublicationError> for AuthoringError {
+    fn from(error: crate::ExecutionSessionPublicationError) -> Self {
+        Self::ExecutionPublication(error)
     }
 }
 

--- a/crates/noon/src/scene.rs
+++ b/crates/noon/src/scene.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use noon_core::{
     AnimationOptions, GeometryRef, RateFunction, SemanticMutationImpact,
-    SemanticMutationTransaction, SemanticNodeCreation, SemanticNodeId, SemanticStore,
-    SemanticStyle, VectorPath,
+    SemanticMutationTransaction, SemanticMutationTransactionResult, SemanticNodeCreation,
+    SemanticNodeId, SemanticStore, SemanticStyle, VectorPath,
 };
 use std::{cell::RefCell, rc::Rc};
 
@@ -53,9 +53,9 @@ impl Scene {
     /// Raw shared arena access for explicit integration, not live mutation.
     ///
     /// External edits can invalidate generational handles and leave an existing
-    /// execution session on a stale scene revision. Use `Scene::live` and its
-    /// coherent publication operations for edits after lowering. No revision
-    /// validation is bypassed by this accessor; see [`crate::integration`].
+    /// execution session on a stale scene revision. Use Scene-owned persistent
+    /// operations after lowering. No revision validation is bypassed by this
+    /// accessor; see [`crate::integration`].
     pub fn integration_store(&self) -> &Rc<RefCell<SemanticStore>> {
         &self.store
     }
@@ -127,35 +127,53 @@ impl Scene {
 
     /// Prepare and apply one atomic authored membership edit.
     ///
-    /// Errors preserve semantic identities and causes in [`AuthoringError`].
-    /// After execution bootstrap, use [`LiveSession::edit_membership`] instead:
-    /// direct authored edits invalidate that session's publication revision.
+    /// Before execution bootstrap this commits only to the Semantic Scene. Once
+    /// this Scene owns execution, the same transaction is published atomically
+    /// through that execution component. No external Scene/session pairing is
+    /// required for persistent membership edits.
     pub fn edit_membership(
         &mut self,
         request: SceneMembershipRequest<'_>,
-    ) -> Result<noon_core::SemanticMutationTransactionResult, AuthoringError> {
+    ) -> Result<SemanticMutationTransactionResult, AuthoringError> {
         let transaction =
             crate::scene_membership::prepare_scene_membership(&self.store, self.root, request)?;
-        crate::scene_membership::apply_scene_membership(&self.store, transaction)
+        self.apply_semantic_transaction(transaction)
+    }
+
+    /// Route one canonical persistent semantic transaction through the Scene's
+    /// current control state. This is the ownership seam for ordinary mutation:
+    /// cold Scenes commit authored state directly; running Scenes use the existing
+    /// prepared execution publication protocol without relowering or mirroring.
+    pub(crate) fn apply_semantic_transaction(
+        &mut self,
+        transaction: SemanticMutationTransaction,
+    ) -> Result<SemanticMutationTransactionResult, AuthoringError> {
+        if let Some(execution) = self.execution.as_mut() {
+            let mut store = self.store.borrow_mut();
+            return execution
+                .apply_semantic_transaction_at_root(&mut store, self.root, transaction)
+                .map_err(AuthoringError::from);
+        }
+        transaction
+            .apply(&mut self.store.borrow_mut())
+            .map_err(AuthoringError::from)
     }
 
     pub fn add_many(
         &mut self,
         members: &[MobjectTarget<'_>],
-    ) -> Result<noon_core::SemanticMutationTransactionResult, AuthoringError> {
+    ) -> Result<SemanticMutationTransactionResult, AuthoringError> {
         self.edit_membership(SceneMembershipRequest::Add(members))
     }
 
     pub fn remove_many(
         &mut self,
         members: &[MobjectTarget<'_>],
-    ) -> Result<noon_core::SemanticMutationTransactionResult, AuthoringError> {
+    ) -> Result<SemanticMutationTransactionResult, AuthoringError> {
         self.edit_membership(SceneMembershipRequest::Remove(members))
     }
 
-    pub fn clear(
-        &mut self,
-    ) -> Result<noon_core::SemanticMutationTransactionResult, AuthoringError> {
+    pub fn clear(&mut self) -> Result<SemanticMutationTransactionResult, AuthoringError> {
         self.edit_membership(SceneMembershipRequest::Clear)
     }
 
@@ -163,7 +181,7 @@ impl Scene {
         &mut self,
         old: MobjectTarget<'_>,
         new: MobjectTarget<'_>,
-    ) -> Result<noon_core::SemanticMutationTransactionResult, AuthoringError> {
+    ) -> Result<SemanticMutationTransactionResult, AuthoringError> {
         self.edit_membership(SceneMembershipRequest::Replace { old, new })
     }
 
@@ -298,8 +316,9 @@ impl Scene {
         LiveSession::new(store, root, execution)
     }
 
-    /// Borrow the already-published execution session for supported live membership,
-    /// property edits, and effective-value queries. This facade retains no scene/runtime state.
+    /// Borrow an explicitly supplied execution session for compatibility during
+    /// the control-surface migration. Scene-owned persistent operations do not
+    /// require this pairing once execution is installed in the Scene itself.
     pub fn live<'a>(&'a self, session: &'a mut ExecutionSession) -> LiveSession<'a> {
         LiveSession::new(&self.store, self.root, session)
     }

--- a/crates/noon/src/scene/tests.rs
+++ b/crates/noon/src/scene/tests.rs
@@ -162,6 +162,76 @@ fn batch_membership_uses_authoritative_root_order_and_one_revision() {
 }
 
 #[test]
+fn scene_owned_membership_publishes_running_edits_and_rejects_stale_state_atomically() {
+    let mut scene = Scene::new();
+    let first = scene.circle(1.0).unwrap();
+    let candidate = scene.rectangle(2.0, 1.0).unwrap();
+    let mut detached_editor = scene.square(1.0).unwrap();
+    let execution = scene.execution_session().unwrap();
+    scene.install_execution(execution);
+
+    let before = scene.revision();
+    scene.add(&first).unwrap();
+    assert_eq!(scene.revision().get(), before.get() + 1);
+    assert!(scene
+        .owned_execution()
+        .execution_object_id(first.node_id())
+        .is_some());
+    assert_eq!(
+        scene
+            .owned_execution()
+            .publication_context()
+            .scene_revision(),
+        scene.revision()
+    );
+
+    scene.remove(&first).unwrap();
+    assert!(!scene
+        .owned_execution()
+        .semantic_object_is_reachable(first.node_id()));
+    assert!(scene
+        .integration_store()
+        .borrow()
+        .node(scene.root())
+        .unwrap()
+        .members()
+        .is_empty());
+
+    detached_editor.set_translation(1.0, 0.0).unwrap();
+    let stale_revision = scene.revision();
+    let publication = scene.owned_execution().publication_context();
+    let members = scene
+        .integration_store()
+        .borrow()
+        .node(scene.root())
+        .unwrap()
+        .members()
+        .to_vec();
+    let error = scene.add(&candidate).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::LiveSessionError::Publication(
+            crate::ExecutionSessionPublicationError::StaleSceneRevision { .. }
+        )
+    ));
+    assert_eq!(scene.revision(), stale_revision);
+    assert_eq!(scene.owned_execution().publication_context(), publication);
+    assert_eq!(
+        scene
+            .integration_store()
+            .borrow()
+            .node(scene.root())
+            .unwrap()
+            .members(),
+        members.as_slice()
+    );
+    assert!(scene
+        .owned_execution()
+        .execution_object_id(candidate.node_id())
+        .is_none());
+}
+
+#[test]
 fn initial_animation_root_rejects_foreign_and_stale_declaration_handles() {
     fn root(scene: &Scene) -> crate::DeclaredAnimation {
         scene

--- a/crates/noon/src/scene_membership.rs
+++ b/crates/noon/src/scene_membership.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, rc::Rc};
 
 use noon_core::{
-    plan_semantic_scene_membership, SemanticMutationTransaction, SemanticMutationTransactionResult,
-    SemanticNodeId, SemanticSceneMembershipRequest, SemanticStore,
+    plan_semantic_scene_membership, SemanticMutationTransaction, SemanticNodeId,
+    SemanticSceneMembershipRequest, SemanticStore,
 };
 
 use crate::{AuthoringError, MobjectTarget};
@@ -76,29 +76,20 @@ pub(crate) fn prepare_scene_membership(
     .map_err(Into::into)
 }
 
-pub(crate) fn apply_scene_membership(
-    store: &Rc<RefCell<SemanticStore>>,
-    transaction: SemanticMutationTransaction,
-) -> Result<SemanticMutationTransactionResult, AuthoringError> {
-    transaction
-        .apply(&mut store.borrow_mut())
-        .map_err(Into::into)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::error::Error;
 
     #[test]
-    fn transaction_application_keeps_preflight_error_and_commits_nothing() {
-        let scene = crate::Scene::new();
+    fn scene_router_keeps_preflight_error_and_commits_nothing() {
+        let mut scene = crate::Scene::new();
         let object = scene.circle(1.0).unwrap();
         let revision = scene.integration_store().borrow().scene_revision();
         let mut transaction = SemanticMutationTransaction::new();
         transaction.add_member(scene.root(), object.node_id());
         transaction.add_member(object.node_id(), scene.root());
-        let error = apply_scene_membership(scene.integration_store(), transaction).unwrap_err();
+        let error = scene.apply_semantic_transaction(transaction).unwrap_err();
         let AuthoringError::Transaction(cause) = &error else {
             panic!("transaction errors must retain their category")
         };


### PR DESCRIPTION
Implements the first bounded control-path slice of #1510 after #1413/#1416 landed.

## Control-path change

- adds one Scene-owned generic semantic transaction router: cold Scenes commit semantic state directly; running Scenes publish through the already-owned ExecutionSession at the authoritative root;
- routes Scene add/remove/batch/replace/clear membership through that Scene-owned path, removing the post-bootstrap requirement that those Scene operations be performed through an externally paired `Scene::live(&mut ExecutionSession)`;
- deletes the old cold-only `scene_membership::apply_scene_membership` forwarding function;
- preserves the established public `AuthoringError` API and adds `AuthoringError::ExecutionPublication` as the explicit running-only publication cause instead of exposing `LiveSessionError` from ordinary Scene authoring;
- adds focused regressions proving running membership updates semantic + execution state coherently and stale publication fails before semantic membership/runtime mutation.

Before this slice, Scene membership prepared then committed directly while running membership required `Scene::live(...) -> LiveSession::edit_membership -> LiveSession::apply -> ExecutionSession`. After this slice, Scene membership has one dispatcher with exactly two ownership branches: cold semantic apply or running root-aware execution publication.

## Complexity delta

Exact one-commit diff versus base `4582e47d` at this restack:
- 4 changed files;
- +126 / -35 LOC including tests;
- deletes one production forwarding function (`apply_scene_membership`);
- adds one private Scene routing method instead of a new context/trait/framework;
- preserves provider/consumer compatibility for `Scene::add/remove/add_many/remove_many/clear/replace` error types.

The running removal regression intentionally checks authoritative root membership plus execution reachability. It does not require retained execution slots or dense compatibility frame rows to be destroyed; those may remain reusable after detachment.

This intentionally does not move layout/path/boolean/point-matching algorithms, redesign #1506 publication, internalize the public ExecutionSession, or delete LiveSession yet. A stacked #1510 follow-up is limited to two production files: factor the Scene-owned running publication helper and make compatibility `LiveSession::apply` delegate to it, removing the remaining duplicate generic publication branch without moving feature algorithms.

## Validation

Current exact one-commit head: `da5eae75171845e2e08f3fefafcf7d4be180b040`, built directly on `4582e47d8d61c2b2201aa13b2fdef030e4f8ba0a`. The feature blobs are byte-identical to the corrected prior heads; only ancestry has moved as the concurrent B3 stack landed.

Exact-head qualification is currently queued behind repository-wide Actions saturation. Prior provider isolation identified the public error-type regression on an older head; the current tree restores the established `AuthoringError` contract and carries execution publication failures through its dedicated variant. This exact head remains the merge authority.

Refs #1510 #1484 #1480.