### PR TITLE
feat(svg): add svg_default fallback styling

### DIFF
--- a/.github/workflows/manim-svg-raster-differential.yml
+++ b/.github/workflows/manim-svg-raster-differential.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "crates/noon/src/svg_authoring.rs"
+      - "crates/noon/src/svg_default_style.rs"
       - "crates/noon-web/src/authoring_svg.rs"
       - "web/python/_manim_svg.py"
       - "web/python/noon.py"

--- a/crates/noon-web/src/authoring_svg.rs
+++ b/crates/noon-web/src/authoring_svg.rs
@@ -6,12 +6,16 @@
 
 use std::rc::Rc;
 
+use js_sys::Array;
 use wasm_bindgen::prelude::*;
 
 use crate::{
     authoring_error::{js_error, AuthoringFailure},
     WasmAuthoringFamilyHandle, WasmAuthoringMobjectHandle, WasmAuthoringStore,
+    WasmManimGeometryOptions,
 };
+
+const SVG_DEFAULT_TRANSPORT_TAG: &str = "noon.svg-default.v1";
 
 impl From<noon::SvgAuthoringError> for AuthoringFailure {
     fn from(error: noon::SvgAuthoringError) -> Self {
@@ -39,6 +43,34 @@ impl From<noon::SvgAuthoringError> for AuthoringFailure {
 }
 
 #[wasm_bindgen]
+impl WasmManimGeometryOptions {
+    /// Build the private typed transport used by the existing SVG worker binding.
+    ///
+    /// Generic Manim `color`/`opacity` precedence is resolved by the thin Python
+    /// adapter; this boundary carries only the five effective inherited SVG paint
+    /// fields plus the ordinary optional width.
+    #[wasm_bindgen(js_name = svgDefaultTransport)]
+    pub fn svg_default_transport(
+        width: Option<f64>,
+        fill_color: Option<u32>,
+        fill_opacity: Option<f64>,
+        stroke_color: Option<u32>,
+        stroke_opacity: Option<f64>,
+        stroke_width: Option<f64>,
+    ) -> JsValue {
+        let transport = Array::new();
+        transport.push(&JsValue::from_str(SVG_DEFAULT_TRANSPORT_TAG));
+        push_optional_f64(&transport, width);
+        push_optional_u32(&transport, fill_color);
+        push_optional_f64(&transport, fill_opacity);
+        push_optional_u32(&transport, stroke_color);
+        push_optional_f64(&transport, stroke_opacity);
+        push_optional_f64(&transport, stroke_width);
+        transport.into()
+    }
+}
+
+#[wasm_bindgen]
 impl WasmAuthoringStore {
     /// Import static SVG source into this store as one retained semantic family.
     #[wasm_bindgen(js_name = createSvgFromString)]
@@ -47,19 +79,30 @@ impl WasmAuthoringStore {
         source: &str,
         should_center: bool,
         height: Option<f64>,
-        width: Option<f64>,
+        width_or_defaults: JsValue,
     ) -> Result<WasmAuthoringFamilyHandle, JsValue> {
-        noon::MobjectFamily::from_svg_str_with_options(
-            Rc::clone(&self.semantics),
-            source,
-            noon::SvgImportOptions {
-                should_center,
-                height,
-                width,
-            },
-        )
-        .map(WasmAuthoringFamilyHandle::from_semantic_family)
-        .map_err(js_error)
+        let request = parse_width_or_defaults(width_or_defaults)?;
+        let options = noon::SvgImportOptions {
+            should_center,
+            height,
+            width: request.width,
+        };
+        let family = match request.svg_default {
+            Some(svg_default) => noon::MobjectFamily::from_svg_str_with_options_and_svg_default(
+                Rc::clone(&self.semantics),
+                source,
+                options,
+                svg_default,
+            ),
+            None => noon::MobjectFamily::from_svg_str_with_options(
+                Rc::clone(&self.semantics),
+                source,
+                options,
+            ),
+        };
+        family
+            .map(WasmAuthoringFamilyHandle::from_semantic_family)
+            .map_err(js_error)
     }
 }
 
@@ -83,4 +126,84 @@ impl WasmAuthoringFamilyHandle {
             .map(WasmAuthoringMobjectHandle::from_semantic_mobject)
             .map_err(js_error)
     }
+}
+
+struct SvgImportRequest {
+    width: Option<f64>,
+    svg_default: Option<noon::SvgDefaultStyle>,
+}
+
+fn parse_width_or_defaults(value: JsValue) -> Result<SvgImportRequest, JsValue> {
+    if value.is_null() || value.is_undefined() {
+        return Ok(SvgImportRequest {
+            width: None,
+            svg_default: None,
+        });
+    }
+    if let Some(width) = value.as_f64() {
+        return Ok(SvgImportRequest {
+            width: Some(width),
+            svg_default: None,
+        });
+    }
+    if !Array::is_array(&value) {
+        return Err(invalid_svg_transport("SVG width/default transport is invalid"));
+    }
+    let transport = Array::from(&value);
+    if transport.length() != 7
+        || transport.get(0).as_string().as_deref() != Some(SVG_DEFAULT_TRANSPORT_TAG)
+    {
+        return Err(invalid_svg_transport("SVG default transport has an invalid envelope"));
+    }
+    Ok(SvgImportRequest {
+        width: optional_f64(&transport, 1, "width")?,
+        svg_default: Some(noon::SvgDefaultStyle {
+            color: None,
+            opacity: None,
+            fill_color: optional_color(&transport, 2, "fill_color")?,
+            fill_opacity: optional_f64(&transport, 3, "fill_opacity")?,
+            stroke_color: optional_color(&transport, 4, "stroke_color")?,
+            stroke_opacity: optional_f64(&transport, 5, "stroke_opacity")?,
+            stroke_width: optional_f64(&transport, 6, "stroke_width")?,
+        }),
+    })
+}
+
+fn push_optional_f64(array: &Array, value: Option<f64>) {
+    array.push(&value.map_or(JsValue::NULL, JsValue::from_f64));
+}
+
+fn push_optional_u32(array: &Array, value: Option<u32>) {
+    array.push(&value.map_or(JsValue::NULL, |value| JsValue::from_f64(f64::from(value))));
+}
+
+fn optional_f64(array: &Array, index: u32, name: &str) -> Result<Option<f64>, JsValue> {
+    let value = array.get(index);
+    if value.is_null() || value.is_undefined() {
+        return Ok(None);
+    }
+    value
+        .as_f64()
+        .map(Some)
+        .ok_or_else(|| invalid_svg_transport(&format!("SVG default {name} must be numeric")))
+}
+
+fn optional_color(array: &Array, index: u32, name: &str) -> Result<Option<noon::Color>, JsValue> {
+    let Some(value) = optional_f64(array, index, name)? else {
+        return Ok(None);
+    };
+    if value.fract() != 0.0 || !(0.0..=f64::from(0xFF_FFFF_u32)).contains(&value) {
+        return Err(invalid_svg_transport(&format!(
+            "SVG default {name} must be a 24-bit RGB integer"
+        )));
+    }
+    Ok(Some(noon::Color::from_hex(value as u32)))
+}
+
+fn invalid_svg_transport(message: &str) -> JsValue {
+    js_error(AuthoringFailure::new(
+        "invalid_input",
+        "svg.invalid_default_transport",
+        message,
+    ))
 }

--- a/crates/noon/src/lib.rs
+++ b/crates/noon/src/lib.rs
@@ -100,6 +100,7 @@ mod sector_authoring;
 mod semantic_mobject;
 mod state_replacement;
 mod svg_authoring;
+mod svg_default_style;
 mod tangent_line_authoring;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 mod text_authoring;
@@ -182,6 +183,7 @@ pub use scene_membership::SceneMembershipRequest;
 pub use semantic_mobject::{ManimGeometryOptions, ManimLineEndpoints, ManimNextToArgs, Mobject};
 pub use state_replacement::ManimBecomeOptions;
 pub use svg_authoring::{SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature};
+pub use svg_default_style::SvgDefaultStyle;
 #[cfg(any(feature = "native-text", feature = "typst"))]
 pub use text_authoring::TextAuthoringError;
 #[cfg(feature = "typst")]
@@ -204,9 +206,9 @@ pub mod prelude {
         LiveProgram, LiveSession, LiveSessionError, ManimArrow, ManimArrowOptions,
         ManimArrowVectorField, Mobject, MobjectFamily, MobjectTarget, NativeBoolSignal,
         NativeVectorSignal, RateFunction, Scene, SemanticObjectState, SemanticStyle,
-        StoredGeometry, StyleUpdate, SvgAuthoringError, SvgImportOptions, SvgUnsupportedFeature,
-        TrackerPosition, ValueTracker, Vec2, VectorFieldAxisRange, VectorFieldPoint,
-        VectorFieldRanges2D, VectorPath,
+        StoredGeometry, StyleUpdate, SvgAuthoringError, SvgDefaultStyle, SvgImportOptions,
+        SvgUnsupportedFeature, TrackerPosition, ValueTracker, Vec2, VectorFieldAxisRange,
+        VectorFieldPoint, VectorFieldRanges2D, VectorPath,
     };
 }
 

--- a/crates/noon/src/svg_default_style.rs
+++ b/crates/noon/src/svg_default_style.rs
@@ -161,11 +161,7 @@ fn source_with_svg_default(
         if prefix == "xml" {
             continue;
         }
-        push_attribute(
-            &mut wrapped,
-            &format!("xmlns:{prefix}"),
-            namespace.uri(),
-        );
+        push_attribute(&mut wrapped, &format!("xmlns:{prefix}"), namespace.uri());
     }
     wrapped.push_str(" stroke-width=\"");
     wrapped.push_str(&SVG_INITIAL_STROKE_WIDTH.to_string());
@@ -238,7 +234,7 @@ fn push_config_attributes(output: &mut String, svg_default: SvgDefaultStyle) {
 
 fn color_hex(color: Color) -> String {
     fn channel(value: f32) -> u8 {
-        (value.clamp(0.0, 1.0) * 255.0).round() as u8
+        (value.clamp(0.0, 1.0) * 255.0) as u8
     }
     format!(
         "#{:02X}{:02X}{:02X}",
@@ -286,6 +282,11 @@ mod tests {
             .iter()
             .map(|member| store.semantic_object_state_checked(*member).unwrap().style)
             .collect()
+    }
+
+    #[test]
+    fn svg_default_color_serialization_matches_manim_hex_truncation() {
+        assert_eq!(color_hex(Color::rgb(0.5, 0.1, 1.0)), "#7F19FF");
     }
 
     #[test]

--- a/crates/noon/src/svg_default_style.rs
+++ b/crates/noon/src/svg_default_style.rs
@@ -153,7 +153,21 @@ fn source_with_svg_default(
     let mut wrapped = String::with_capacity(source.len() + 256);
     wrapped.push_str("<svg xmlns=\"");
     wrapped.push_str(SVG_NAMESPACE);
-    wrapped.push_str("\" stroke-width=\"");
+    wrapped.push('"');
+    for namespace in root.namespaces() {
+        let Some(prefix) = namespace.name() else {
+            continue;
+        };
+        if prefix == "xml" {
+            continue;
+        }
+        push_attribute(
+            &mut wrapped,
+            &format!("xmlns:{prefix}"),
+            namespace.uri(),
+        );
+    }
+    wrapped.push_str(" stroke-width=\"");
     wrapped.push_str(&SVG_INITIAL_STROKE_WIDTH.to_string());
     wrapped.push_str("\"><g");
     push_config_attributes(&mut wrapped, svg_default);
@@ -423,6 +437,19 @@ mod tests {
             .unwrap();
         let style = member_styles(&scene, &family)[0].clone();
         assert!((style.stroke_width - 0.01).abs() < 1e-6);
+    }
+
+    #[test]
+    fn svg_default_preserves_prefixed_namespace_declarations() {
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:meta="urn:noon:test">
+            <path meta:label="shape" d="M0 0 L10 0 L10 10 Z"/>
+        </svg>"##;
+        let wrapped = source_with_svg_default(source, SvgDefaultStyle::default()).unwrap();
+        let document = parse_xml(&wrapped).unwrap();
+        assert_eq!(
+            document.root_element().lookup_namespace_uri(Some("meta")),
+            Some("urn:noon:test")
+        );
     }
 
     #[test]

--- a/crates/noon/src/svg_default_style.rs
+++ b/crates/noon/src/svg_default_style.rs
@@ -1,0 +1,445 @@
+//! Manim-compatible inherited `SVGMobject(svg_default=...)` fallback styling.
+//!
+//! Manim v0.21 rewrites the parsed SVG tree before shape conversion: fallback
+//! paint lives on an outer group, while presentation attributes from the original
+//! root live on an inner group and therefore win by normal SVG inheritance. This
+//! module reproduces that author-time contract and then delegates to the ordinary
+//! retained SVG importer. No SVG-specific state survives semantic publication.
+
+use crate::{MobjectFamily, Scene, StyleUpdate, SvgAuthoringError, SvgImportOptions};
+use noon_core::{Color, SemanticStore, SemanticStyle};
+use std::{cell::RefCell, rc::Rc};
+
+const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+const SVG_INITIAL_STROKE_WIDTH: f64 = 1.0;
+const MANIM_ZERO_STROKE_SENTINEL: f64 = 0.000_001;
+const ROOT_STYLE_KEYS: [&str; 6] = [
+    "fill",
+    "fill-opacity",
+    "stroke",
+    "stroke-opacity",
+    "stroke-width",
+    "style",
+];
+
+/// Fallback paint inherited by SVG leaves that do not specify those properties.
+///
+/// This is distinct from [`StyleUpdate`]: SVG defaults participate in parser-time
+/// inheritance and lose to explicit root/leaf SVG presentation, while a
+/// `StyleUpdate` is an explicit post-parse override and therefore wins.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SvgDefaultStyle {
+    pub color: Option<Color>,
+    pub opacity: Option<f64>,
+    pub fill_color: Option<Color>,
+    pub fill_opacity: Option<f64>,
+    pub stroke_width: Option<f64>,
+    pub stroke_color: Option<Color>,
+    pub stroke_opacity: Option<f64>,
+}
+
+impl Default for SvgDefaultStyle {
+    fn default() -> Self {
+        Self {
+            color: None,
+            opacity: None,
+            fill_color: None,
+            fill_opacity: None,
+            stroke_width: Some(0.0),
+            stroke_color: None,
+            stroke_opacity: None,
+        }
+    }
+}
+
+impl SvgDefaultStyle {
+    fn effective_style(self) -> StyleUpdate {
+        StyleUpdate {
+            fill_color: self.fill_color.or(self.color),
+            fill_opacity: self.fill_opacity.or(self.opacity),
+            stroke_color: self.stroke_color.or(self.color),
+            stroke_width: self.stroke_width,
+            stroke_opacity: self.stroke_opacity.or(self.opacity),
+        }
+    }
+
+    fn validate(self) -> Result<(), SvgAuthoringError> {
+        let mut style = SemanticStyle::default();
+        self.effective_style().apply(&mut style)?;
+        Ok(())
+    }
+}
+
+impl MobjectFamily {
+    /// Parse static SVG with Manim-style inherited parser fallback paint.
+    pub fn from_svg_str_with_svg_default(
+        store: Rc<RefCell<SemanticStore>>,
+        source: &str,
+        svg_default: SvgDefaultStyle,
+    ) -> Result<Self, SvgAuthoringError> {
+        Self::from_svg_str_with_options_and_svg_default(
+            store,
+            source,
+            SvgImportOptions::default(),
+            svg_default,
+        )
+    }
+
+    /// Parse static SVG with explicit placement and inherited parser fallback paint.
+    pub fn from_svg_str_with_options_and_svg_default(
+        store: Rc<RefCell<SemanticStore>>,
+        source: &str,
+        options: SvgImportOptions,
+        svg_default: SvgDefaultStyle,
+    ) -> Result<Self, SvgAuthoringError> {
+        let wrapped = source_with_svg_default(source, svg_default)?;
+        Self::from_svg_str_with_options(store, &wrapped, options)
+    }
+}
+
+impl Scene {
+    /// Parse static SVG with Manim-style inherited parser fallback paint.
+    pub fn svg_from_str_with_svg_default(
+        &self,
+        source: &str,
+        svg_default: SvgDefaultStyle,
+    ) -> Result<MobjectFamily, SvgAuthoringError> {
+        MobjectFamily::from_svg_str_with_svg_default(
+            Rc::clone(self.integration_store()),
+            source,
+            svg_default,
+        )
+    }
+
+    /// Parse static SVG with explicit placement and inherited parser fallback paint.
+    pub fn svg_from_str_with_options_and_svg_default(
+        &self,
+        source: &str,
+        options: SvgImportOptions,
+        svg_default: SvgDefaultStyle,
+    ) -> Result<MobjectFamily, SvgAuthoringError> {
+        MobjectFamily::from_svg_str_with_options_and_svg_default(
+            Rc::clone(self.integration_store()),
+            source,
+            options,
+            svg_default,
+        )
+    }
+}
+
+fn source_with_svg_default(
+    source: &str,
+    svg_default: SvgDefaultStyle,
+) -> Result<String, SvgAuthoringError> {
+    svg_default.validate()?;
+    let document = parse_xml(source)?;
+    let root = document.root_element();
+    if root.tag_name().name() != "svg" {
+        return Ok(source.to_owned());
+    }
+
+    let root_range = root.range();
+    let Some(open_end) = opening_tag_end(source, root_range.start, root_range.end) else {
+        return Ok(source.to_owned());
+    };
+    let Some(close_start) = source[root_range.start..root_range.end].rfind("</").map(|offset| {
+        root_range.start + offset
+    }) else {
+        // A self-closing root contains no drawable descendants. Validation above
+        // is still observable, but no fallback style needs to be materialized.
+        return Ok(source.to_owned());
+    };
+
+    let mut wrapped = String::with_capacity(source.len() + 256);
+    wrapped.push_str("<svg xmlns=\"");
+    wrapped.push_str(SVG_NAMESPACE);
+    wrapped.push_str("\" stroke-width=\"");
+    wrapped.push_str(&SVG_INITIAL_STROKE_WIDTH.to_string());
+    wrapped.push_str("\"><g");
+    push_config_attributes(&mut wrapped, svg_default);
+    wrapped.push_str("><g");
+    for key in ROOT_STYLE_KEYS {
+        if let Some(value) = root.attribute(key) {
+            push_attribute(&mut wrapped, key, value);
+        }
+    }
+    wrapped.push('>');
+    wrapped.push_str(&source[open_end..close_start]);
+    wrapped.push_str("</g></g></svg>");
+    Ok(wrapped)
+}
+
+fn parse_xml(source: &str) -> Result<usvg::roxmltree::Document<'_>, SvgAuthoringError> {
+    usvg::roxmltree::Document::parse_with_options(
+        source,
+        usvg::roxmltree::ParsingOptions {
+            allow_dtd: true,
+            ..Default::default()
+        },
+    )
+    .map_err(SvgAuthoringError::Xml)
+}
+
+fn opening_tag_end(source: &str, start: usize, end: usize) -> Option<usize> {
+    let mut quote = None;
+    for (offset, character) in source[start..end].char_indices() {
+        if let Some(active) = quote {
+            if character == active {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '>' => return Some(start + offset + character.len_utf8()),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn push_config_attributes(output: &mut String, svg_default: SvgDefaultStyle) {
+    let effective = svg_default.effective_style();
+    if let Some(color) = effective.fill_color {
+        push_attribute(output, "fill", &color_hex(color));
+    }
+    if let Some(opacity) = effective.fill_opacity {
+        push_attribute(output, "fill-opacity", &opacity.to_string());
+    }
+    if let Some(color) = effective.stroke_color {
+        push_attribute(output, "stroke", &color_hex(color));
+    }
+    if let Some(opacity) = effective.stroke_opacity {
+        push_attribute(output, "stroke-opacity", &opacity.to_string());
+    }
+    if let Some(width) = effective.stroke_width {
+        let value = if width == 0.0 {
+            MANIM_ZERO_STROKE_SENTINEL
+        } else {
+            width
+        };
+        push_attribute(output, "stroke-width", &value.to_string());
+    }
+}
+
+fn color_hex(color: Color) -> String {
+    fn channel(value: f32) -> u8 {
+        (value.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+    format!(
+        "#{:02X}{:02X}{:02X}",
+        channel(color.red),
+        channel(color.green),
+        channel(color.blue)
+    )
+}
+
+fn push_attribute(output: &mut String, name: &str, value: &str) {
+    output.push(' ');
+    output.push_str(name);
+    output.push_str("=\"");
+    for character in value.chars() {
+        match character {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&apos;"),
+            _ => output.push(character),
+        }
+    }
+    output.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noon_core::{SemanticPaint, SemanticStyle};
+
+    fn raw_options() -> SvgImportOptions {
+        SvgImportOptions {
+            should_center: false,
+            height: None,
+            width: None,
+        }
+    }
+
+    fn member_styles(scene: &Scene, family: &MobjectFamily) -> Vec<SemanticStyle> {
+        let store = scene.integration_store().borrow();
+        store
+            .semantic_family_members_checked(family.node_id())
+            .unwrap()
+            .iter()
+            .map(|member| store.semantic_object_state_checked(*member).unwrap().style)
+            .collect()
+    }
+
+    #[test]
+    fn svg_default_supplies_missing_leaf_paint() {
+        let scene = Scene::new();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0 L10 0 L10 10 Z"/>
+        </svg>"##;
+        let family = scene
+            .svg_from_str_with_options_and_svg_default(
+                source,
+                raw_options(),
+                SvgDefaultStyle {
+                    fill_color: Some(Color::from_hex(0x123456)),
+                    fill_opacity: Some(0.25),
+                    stroke_color: Some(Color::from_hex(0xABCDEF)),
+                    stroke_opacity: Some(0.5),
+                    stroke_width: Some(3.0),
+                    ..SvgDefaultStyle::default()
+                },
+            )
+            .unwrap();
+        let styles = member_styles(&scene, &family);
+        assert_eq!(styles.len(), 1);
+        assert_eq!(
+            styles[0].fill,
+            Some(SemanticPaint::Solid(Color::from_hex(0x123456)))
+        );
+        assert_eq!(
+            styles[0].stroke,
+            Some(SemanticPaint::Solid(Color::from_hex(0xABCDEF)))
+        );
+        assert!((styles[0].fill_opacity - 0.25).abs() < 1e-6);
+        assert!((styles[0].stroke_opacity - 0.5).abs() < 1e-6);
+        assert!((styles[0].stroke_width - 0.03).abs() < 1e-6);
+    }
+
+    #[test]
+    fn root_and_leaf_presentation_override_svg_default() {
+        let scene = Scene::new();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg" fill="#112233" stroke="#445566" stroke-width="4">
+            <rect x="0" y="0" width="5" height="5"/>
+            <rect x="5" y="0" width="5" height="5" fill="#778899" stroke="#AABBCC" stroke-width="6"/>
+        </svg>"##;
+        let family = scene
+            .svg_from_str_with_options_and_svg_default(
+                source,
+                raw_options(),
+                SvgDefaultStyle {
+                    color: Some(Color::from_hex(0xFF0000)),
+                    stroke_width: Some(2.0),
+                    ..SvgDefaultStyle::default()
+                },
+            )
+            .unwrap();
+        let styles = member_styles(&scene, &family);
+        assert_eq!(styles.len(), 2);
+        assert_eq!(
+            styles[0].fill,
+            Some(SemanticPaint::Solid(Color::from_hex(0x112233)))
+        );
+        assert_eq!(
+            styles[0].stroke,
+            Some(SemanticPaint::Solid(Color::from_hex(0x445566)))
+        );
+        assert!((styles[0].stroke_width - 0.04).abs() < 1e-6);
+        assert_eq!(
+            styles[1].fill,
+            Some(SemanticPaint::Solid(Color::from_hex(0x778899)))
+        );
+        assert_eq!(
+            styles[1].stroke,
+            Some(SemanticPaint::Solid(Color::from_hex(0xAABBCC)))
+        );
+        assert!((styles[1].stroke_width - 0.06).abs() < 1e-6);
+    }
+
+    #[test]
+    fn specific_svg_defaults_override_generic_color_and_opacity() {
+        let scene = Scene::new();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0 L10 0 L10 10 Z"/>
+        </svg>"##;
+        let family = scene
+            .svg_from_str_with_options_and_svg_default(
+                source,
+                raw_options(),
+                SvgDefaultStyle {
+                    color: Some(Color::from_hex(0x0000FF)),
+                    opacity: Some(0.2),
+                    fill_color: Some(Color::from_hex(0xFF0000)),
+                    fill_opacity: Some(0.3),
+                    stroke_color: Some(Color::from_hex(0x00FF00)),
+                    stroke_opacity: Some(0.4),
+                    stroke_width: Some(2.0),
+                },
+            )
+            .unwrap();
+        let style = member_styles(&scene, &family)[0].clone();
+        assert_eq!(
+            style.fill,
+            Some(SemanticPaint::Solid(Color::from_hex(0xFF0000)))
+        );
+        assert_eq!(
+            style.stroke,
+            Some(SemanticPaint::Solid(Color::from_hex(0x00FF00)))
+        );
+        assert!((style.fill_opacity - 0.3).abs() < 1e-6);
+        assert!((style.stroke_opacity - 0.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn zero_svg_default_stroke_width_retains_stroke_only_path() {
+        let scene = Scene::new();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0 L10 0" fill="none"/>
+        </svg>"##;
+        let family = scene
+            .svg_from_str_with_options_and_svg_default(
+                source,
+                raw_options(),
+                SvgDefaultStyle {
+                    stroke_color: Some(Color::from_hex(0xFFFFFF)),
+                    stroke_width: Some(0.0),
+                    ..SvgDefaultStyle::default()
+                },
+            )
+            .unwrap();
+        let styles = member_styles(&scene, &family);
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0].stroke_width, 0.0);
+    }
+
+    #[test]
+    fn absent_svg_default_stroke_width_uses_svg_initial_width() {
+        let scene = Scene::new();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 0 L10 0" fill="none" stroke="#FFFFFF"/>
+        </svg>"##;
+        let family = scene
+            .svg_from_str_with_options_and_svg_default(
+                source,
+                raw_options(),
+                SvgDefaultStyle {
+                    stroke_width: None,
+                    ..SvgDefaultStyle::default()
+                },
+            )
+            .unwrap();
+        let style = member_styles(&scene, &family)[0].clone();
+        assert!((style.stroke_width - 0.01).abs() < 1e-6);
+    }
+
+    #[test]
+    fn invalid_svg_default_fails_before_publication() {
+        let scene = Scene::new();
+        let before = scene.revision();
+        let source = r##"<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L1 0"/></svg>"##;
+        assert!(matches!(
+            scene.svg_from_str_with_svg_default(
+                source,
+                SvgDefaultStyle {
+                    opacity: Some(1.5),
+                    ..SvgDefaultStyle::default()
+                }
+            ),
+            Err(SvgAuthoringError::Authoring(_))
+        ));
+        assert_eq!(scene.revision(), before);
+    }
+}

--- a/parity/manim-v0.21/core-examples/svg_default_fallback.py
+++ b/parity/manim-v0.21/core-examples/svg_default_fallback.py
@@ -1,0 +1,29 @@
+from manim import *
+from pathlib import Path
+
+
+SVG_SOURCE = """<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="40" height="50"/>
+  <circle cx="75" cy="30" r="20" fill="#58C4DD"/>
+  <path d="M105 5 L150 30 L105 55 Z"
+        style="fill:#FFFFFF;stroke:#FC6255;stroke-opacity:0.5;stroke-width:3"/>
+</svg>"""
+
+SVG_DEFAULT = {
+    "color": "#9C27B0",
+    "opacity": 0.35,
+    "fill_color": "#FC6255",
+    "fill_opacity": None,
+    "stroke_width": 6,
+    "stroke_color": "#83C167",
+    "stroke_opacity": 0.85,
+}
+
+
+class SvgDefaultFallback(Scene):
+    def construct(self):
+        path = Path("/tmp/noon_svg_default_parity.svg")
+        path.write_text(SVG_SOURCE)
+        icon = SVGMobject(str(path), svg_default=SVG_DEFAULT)
+        self.add(icon)
+        self.wait(0.2)

--- a/parity/manim-v0.21/svg-manifest.json
+++ b/parity/manim-v0.21/svg-manifest.json
@@ -15,6 +15,12 @@
       "scene": "SvgStaticImport",
       "source": "parity/manim-v0.21/core-examples/svg_static_import.py",
       "expected_duration": 0.2
+    },
+    {
+      "id": "svg-default-fallback",
+      "scene": "SvgDefaultFallback",
+      "source": "parity/manim-v0.21/core-examples/svg_default_fallback.py",
+      "expected_duration": 0.2
     }
   ],
   "sample_fractions": [

--- a/web/python/_manim_svg.py
+++ b/web/python/_manim_svg.py
@@ -1,8 +1,8 @@
 """Partial ManimCE-compatible static SVG authoring over shared Rust resources.
 
-Python owns file/string loading and wrapper identity. Shared Rust owns SVG parsing,
-compatibility normalization, retained path resources, styles, family identity and
-all later semantic mutations.
+Python owns file/string loading, Manim argument coercion and wrapper identity. Shared
+Rust owns SVG parsing, inherited fallback normalization, retained path resources,
+styles, family identity and all later semantic mutations.
 """
 
 from __future__ import annotations
@@ -20,8 +20,10 @@ from _manim_semantic_handles import (
 )
 
 try:
+    from js import noonAuthoringGeometryOptions as _svg_transport_options
     from js import noonCreateAuthoringSvgHandle as _create_svg_handle
 except ImportError:  # Native CPython tests do not have the browser bridge.
+    _svg_transport_options = None
     _create_svg_handle = None
 
 
@@ -34,6 +36,7 @@ _MANIM_DEFAULT_SVG_STYLE = {
     "stroke_color": None,
     "stroke_opacity": None,
 }
+_SVG_DEFAULT_KEYS = tuple(_MANIM_DEFAULT_SVG_STYLE)
 
 
 def _read_svg_file(file_name: object) -> tuple[Path, str]:
@@ -52,15 +55,73 @@ def _read_svg_file(file_name: object) -> tuple[Path, str]:
     raise FileNotFoundError(f"SVG file not found: {path}")
 
 
-def _validate_parser_options(svg_default: object, path_string_config: object) -> None:
-    if svg_default is not None:
-        raise NotImplementedError(
-            "custom SVGMobject svg_default requires shared Rust default-style configuration"
-        )
+def _validate_parser_options(path_string_config: object) -> None:
     if path_string_config not in (None, {}):
         raise NotImplementedError(
             "SVGMobject path_string_config is not yet supported by retained SVG import"
         )
+
+
+def _normalize_svg_default(svg_default: object | None) -> tuple[dict[str, object], bool]:
+    if svg_default is None:
+        return dict(_MANIM_DEFAULT_SVG_STYLE), False
+    try:
+        values = dict(svg_default)
+    except (TypeError, ValueError) as error:
+        raise TypeError("SVGMobject svg_default must be a dictionary") from error
+    # Manim v0.21 indexes all seven names directly while generating parser style.
+    # Preserve that observable missing-key failure while ignoring extra keys.
+    for key in _SVG_DEFAULT_KEYS:
+        if key not in values:
+            raise KeyError(key)
+    return values, True
+
+
+def _effective_default(values: dict[str, object], specific: str, generic: str) -> object:
+    value = values[specific]
+    return values[generic] if value is None else value
+
+
+def _rgb24(name: str, value: object) -> int | None:
+    if value is None:
+        return None
+    color = _compat._as_color(name, value)
+    channels = []
+    for component_name, component in (
+        ("red", color.red),
+        ("green", color.green),
+        ("blue", color.blue),
+    ):
+        channel = _base._ir._unit_interval(f"{name}.{component_name}", component)
+        channels.append(int(channel * 255.0 + 0.5))
+    return (channels[0] << 16) | (channels[1] << 8) | channels[2]
+
+
+def _optional_number(name: str, value: object) -> float | None:
+    if value is None:
+        return None
+    return _base._ir._finite_number(name, value)
+
+
+def _svg_default_transport(
+    width: float | None,
+    values: dict[str, object],
+) -> object:
+    if _svg_transport_options is None:
+        raise RuntimeError("custom SVGMobject svg_default requires the shared Rust authoring host")
+    fill_color = _effective_default(values, "fill_color", "color")
+    fill_opacity = _effective_default(values, "fill_opacity", "opacity")
+    stroke_color = _effective_default(values, "stroke_color", "color")
+    stroke_opacity = _effective_default(values, "stroke_opacity", "opacity")
+    return engine_call(
+        _svg_transport_options.svgDefaultTransport,
+        width,
+        _rgb24("svg_default.fill_color", fill_color),
+        _optional_number("svg_default.fill_opacity", fill_opacity),
+        _rgb24("svg_default.stroke_color", stroke_color),
+        _optional_number("svg_default.stroke_opacity", stroke_opacity),
+        _optional_number("svg_default.stroke_width", values["stroke_width"]),
+    )
 
 
 def _wrap_imported_family(owner: "SVGMobject", family: object) -> None:
@@ -77,8 +138,9 @@ def _wrap_imported_family(owner: "SVGMobject", family: object) -> None:
 class SVGMobject(_compat.VGroup):
     """Static SVG imported as one retained semantic family.
 
-    Direct filesystem paths and :meth:`from_string` are supported in this partial
-    slice. Browser URL/blob loading, non-default parser configuration, cache-policy
+    Direct filesystem paths, :meth:`from_string`, inherited ``svg_default`` paint
+    and ordinary constructor paint overrides are supported in this partial slice.
+    Browser URL/blob loading, non-default path-string tuning, cache-policy
     compatibility and construction after live execution starts remain explicit gaps.
     """
 
@@ -112,7 +174,8 @@ class SVGMobject(_compat.VGroup):
             raise NotImplementedError(
                 "live SVGMobject construction requires atomic retained-resource publication"
             )
-        _validate_parser_options(svg_default, path_string_config)
+        _validate_parser_options(path_string_config)
+        normalized_svg_default, has_custom_svg_default = _normalize_svg_default(svg_default)
         if not use_svg_cache:
             # Cache choice is not a visual semantic. Noon currently relies on the
             # shared immutable resource arena rather than Manim's wrapper cache.
@@ -138,16 +201,19 @@ class SVGMobject(_compat.VGroup):
         self.stroke_color = stroke_color
         self.stroke_opacity = stroke_opacity
         self.stroke_width = 0 if stroke_width is None else float(stroke_width)
-        self.svg_default = dict(_MANIM_DEFAULT_SVG_STYLE)
+        self.svg_default = normalized_svg_default
         self.path_string_config = {} if path_string_config is None else path_string_config
         self.id_to_vgroup_dict = {}
 
+        width_or_defaults = self.svg_width
+        if has_custom_svg_default:
+            width_or_defaults = _svg_default_transport(self.svg_width, self.svg_default)
         family = engine_call(
             _create_svg_handle,
             source,
             self.should_center,
             self.svg_height,
-            self.svg_width,
+            width_or_defaults,
         )
         _wrap_imported_family(self, family)
 

--- a/web/python/_manim_svg.py
+++ b/web/python/_manim_svg.py
@@ -93,7 +93,8 @@ def _rgb24(name: str, value: object) -> int | None:
         ("blue", color.blue),
     ):
         channel = _base._ir._unit_interval(f"{name}.{component_name}", component)
-        channels.append(int(channel * 255.0 + 0.5))
+        # ManimColor.to_hex() truncates each float channel after scaling by 255.
+        channels.append(int(channel * 255.0))
     return (channels[0] << 16) | (channels[1] << 8) | channels[2]
 
 

--- a/web/python/test_manim_svg_facade.py
+++ b/web/python/test_manim_svg_facade.py
@@ -96,6 +96,12 @@ class SvgFacadeTests(unittest.TestCase):
         self.assertEqual(create_calls[0][3], ("svg-default-transport", *transport_calls[0]))
         self.assertEqual(value.svg_default, defaults)
 
+    def test_svg_default_float_color_matches_manim_hex_truncation(self):
+        self.assertEqual(
+            svg._rgb24("svg_default.fill_color", noon.Color(0.5, 0.1, 1.0)),
+            0x7F19FF,
+        )
+
     def test_custom_svg_default_requires_all_manim_keys_before_rust_call(self):
         calls = []
         defaults = dict(svg._MANIM_DEFAULT_SVG_STYLE)

--- a/web/python/test_manim_svg_facade.py
+++ b/web/python/test_manim_svg_facade.py
@@ -56,6 +56,55 @@ class SvgFacadeTests(unittest.TestCase):
             )],
         )
 
+    def test_custom_svg_default_uses_effective_typed_transport(self):
+        create_calls = []
+        transport_calls = []
+        family = _FamilyHandle(count=1)
+
+        class Options:
+            @staticmethod
+            def svgDefaultTransport(*args):
+                transport_calls.append(args)
+                return ("svg-default-transport", *args)
+
+        def create(source, should_center, height, width_or_defaults):
+            create_calls.append((source, should_center, height, width_or_defaults))
+            return family
+
+        defaults = {
+            "color": "#010203",
+            "opacity": 0.2,
+            "fill_color": "#112233",
+            "fill_opacity": None,
+            "stroke_width": None,
+            "stroke_color": None,
+            "stroke_opacity": 0.8,
+        }
+        source = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L1 0"/></svg>'
+        with (
+            patch.object(svg, "_svg_transport_options", Options),
+            patch.object(svg, "_create_svg_handle", create),
+        ):
+            value = svg.SVGMobject.from_string(source, width=4.0, height=None, svg_default=defaults)
+
+        self.assertIs(value._semantic_family_handle, family)
+        self.assertEqual(
+            transport_calls,
+            [(4.0, 0x112233, 0.2, 0x010203, 0.8, None)],
+        )
+        self.assertEqual(create_calls[0][:3], (source, True, None))
+        self.assertEqual(create_calls[0][3], ("svg-default-transport", *transport_calls[0]))
+        self.assertEqual(value.svg_default, defaults)
+
+    def test_custom_svg_default_requires_all_manim_keys_before_rust_call(self):
+        calls = []
+        defaults = dict(svg._MANIM_DEFAULT_SVG_STYLE)
+        defaults.pop("stroke_opacity")
+        with patch.object(svg, "_create_svg_handle", lambda *args: calls.append(args)):
+            with self.assertRaisesRegex(KeyError, "stroke_opacity"):
+                svg.SVGMobject.from_string("<svg/>", svg_default=defaults)
+        self.assertEqual(calls, [])
+
     def test_unsupported_parser_configuration_fails_before_rust_call(self):
         calls = []
         with patch.object(svg, "_create_svg_handle", lambda *args: calls.append(args)):


### PR DESCRIPTION
## Summary

Adds the shared author-time foundation for ManimCE v0.21 `SVGMobject(svg_default=...)` fallback styling.

- introduces typed `SvgDefaultStyle` in the public Rust facade/prelude
- models Manim's parser-time inherited fallback semantics rather than post-parse overrides
- preserves Manim precedence: specific fill/stroke defaults > generic color/opacity, original root presentation > fallback, leaf presentation > inherited values
- preserves SVG's initial stroke width when custom `stroke_width=None`
- retains Manim's zero-width stroke-only paths through the existing parse sentinel
- validates defaults before semantic publication and adds focused shared-Rust tests
- wires the Python/WASM facade through typed effective fallback paint values
- adds a source-equivalent ManimCE v0.21 Cairo fixture and the dedicated static-SVG raster manifest coverage

## Qualification
- focused Rust semantic tests cover inheritance, precedence, zero-width retention, SVG initial width, and atomic invalid-default failure
- Python facade tests cover exact seven-key Manim dictionary behavior and typed transport coercion
- `svg_default` parity is included in the WebGPU/WebGL static SVG vs pinned ManimCE 0.21.0 raster gate

## Out of scope
No gradients/patterns, clip/mask/filter/group compositing, `path_string_config`, cache-policy parity, live SVG replacement, or renderer/runtime SVG state.

Roadmap: #79