### PR TITLE
Run physical performance on dedicated Mac GPU

### DIFF
--- a/.github/ci/physical-gpu-mode.test.mjs
+++ b/.github/ci/physical-gpu-mode.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  browserArgs,
+  isIdentifiedGpuAdapter,
+  isSoftwareGpuAdapter,
+} from "../../scripts/manim-raster-support.mjs";
+
+test("hardware WebGPU mode never forces SwiftShader", () => {
+  const args = browserArgs("webgpu", { gpuMode: "hardware" });
+  const joined = args.join(" ").toLowerCase();
+  assert.ok(args.includes("--enable-unsafe-webgpu"));
+  assert.ok(args.includes("--use-webgpu-power-preference=default-high-performance"));
+  assert.ok(!joined.includes("swiftshader"));
+  assert.ok(!joined.includes("--use-webgpu-adapter="));
+});
+
+test("software WebGPU mode remains deterministic", () => {
+  const args = browserArgs("webgpu");
+  assert.ok(args.includes("--use-webgpu-adapter=swiftshader"));
+});
+
+test("physical adapter classification rejects software implementations", () => {
+  const apple = {
+    vendor: "Apple",
+    architecture: "apple-m4",
+    device: "",
+    description: "Apple M4",
+    isFallbackAdapter: false,
+  };
+  assert.ok(isIdentifiedGpuAdapter(apple));
+  assert.equal(isSoftwareGpuAdapter(apple), false);
+  assert.equal(isSoftwareGpuAdapter({ description: "Google SwiftShader" }), true);
+  assert.equal(isSoftwareGpuAdapter({ description: "llvmpipe" }), true);
+  assert.equal(isSoftwareGpuAdapter({ isFallbackAdapter: true }), true);
+  assert.equal(isIdentifiedGpuAdapter({}), false);
+});

--- a/.github/workflows/perf-physical-device.yml
+++ b/.github/workflows/perf-physical-device.yml
@@ -4,18 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       device_id:
-        description: Stable physical device ID (for example macbook-m4-pro)
+        description: Stable physical device ID (for example yongkyun-mac)
         required: true
+        default: yongkyun-mac
         type: string
       backends:
         description: Comma-separated renderer backends
         required: true
-        default: webgpu,webgl
+        default: webgpu
         type: string
       suites:
         description: Comma-separated suites (frame,corpus,authoring,dynamic-stress)
         required: true
-        default: frame,corpus,authoring,dynamic-stress
+        default: dynamic-stress
         type: string
       width:
         description: Canvas backing width
@@ -53,12 +54,18 @@ permissions:
 
 jobs:
   baseline:
-    # This workflow is intentionally physical-runner-only. Do not replace this
-    # with github-hosted runners or SwiftShader and call the result a P8 baseline.
-    runs-on: self-hosted
+    # Dedicated physical Mac runner. The custom label prevents this workload
+    # from landing on an unrelated self-hosted machine.
+    runs-on: [self-hosted, macOS, noon-physical]
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
+      - name: Verify physical macOS runner
+        shell: bash
+        run: |
+          test "$(uname -s)" = "Darwin"
+          echo "Runner: ${RUNNER_NAME:-unknown}"
+          system_profiler SPHardwareDataType SPDisplaysDataType || true
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
@@ -80,6 +87,7 @@ jobs:
           NOON_PERF_DEVICE_ID: ${{ inputs.device_id }}
           NOON_PERF_BACKENDS: ${{ inputs.backends }}
           NOON_PERF_SUITES: ${{ inputs.suites }}
+          NOON_PERF_GPU_MODE: hardware
           NOON_PERF_WIDTH: ${{ inputs.width }}
           NOON_PERF_HEIGHT: ${{ inputs.height }}
           NOON_PERF_DPR: ${{ inputs.dpr }}

--- a/scripts/manim-raster-support.mjs
+++ b/scripts/manim-raster-support.mjs
@@ -5,8 +5,23 @@ export function rasterFixtureSource(source, scene) {
   return `${adapted}\nfor _name, _cls in tuple(globals().items()):\n    if isinstance(_cls, type) and issubclass(_cls, Scene) and _cls is not ${scene}:\n        _cls.__module__ = "raster_fixture_library"\ndel _cls\n`;
 }
 
-export function browserArgs(backend) {
+export function browserArgs(backend, { gpuMode = "software" } = {}) {
+  if (!new Set(["software", "hardware"]).has(gpuMode)) {
+    throw new Error(`unsupported GPU mode: ${gpuMode}`);
+  }
   if (backend === "webgpu") {
+    if (gpuMode === "hardware") {
+      return [
+        "--enable-unsafe-webgpu",
+        "--use-gpu-in-tests",
+        "--ignore-gpu-blocklist",
+        "--enable-accelerated-2d-canvas",
+        "--use-webgpu-power-preference=default-high-performance",
+        "--force-high-performance-gpu",
+        "--disable-gpu-sandbox",
+        "--disable-dev-shm-usage",
+      ];
+    }
     return [
       "--enable-unsafe-webgpu",
       "--enable-unsafe-swiftshader",
@@ -21,6 +36,16 @@ export function browserArgs(backend) {
       "--disable-dev-shm-usage",
     ];
   }
+  if (gpuMode === "hardware") {
+    return [
+      "--disable-features=WebGPU",
+      "--use-gpu-in-tests",
+      "--ignore-gpu-blocklist",
+      "--force-high-performance-gpu",
+      "--disable-gpu-sandbox",
+      "--disable-dev-shm-usage",
+    ];
+  }
   return [
     "--disable-features=WebGPU",
     "--enable-unsafe-swiftshader",
@@ -30,6 +55,24 @@ export function browserArgs(backend) {
     "--disable-gpu-sandbox",
     "--disable-dev-shm-usage",
   ];
+}
+
+export function isIdentifiedGpuAdapter(info) {
+  if (!info || typeof info !== "object") return false;
+  return [info.vendor, info.architecture, info.device, info.description]
+    .some((value) => typeof value === "string" && value.trim() !== "")
+    || typeof info.isFallbackAdapter === "boolean";
+}
+
+export function isSoftwareGpuAdapter(info) {
+  if (!info || typeof info !== "object") return false;
+  if (info.isFallbackAdapter === true) return true;
+  const description = [info.vendor, info.architecture, info.device, info.description]
+    .filter((value) => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  return ["swiftshader", "llvmpipe", "software rasterizer", "software adapter"]
+    .some((needle) => description.includes(needle));
 }
 
 // Runtime geometry uses f32. Absolute shared-property callbacks can round by a

--- a/scripts/perf-device-run.mjs
+++ b/scripts/perf-device-run.mjs
@@ -8,6 +8,8 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const deviceId = process.env.NOON_PERF_DEVICE_ID?.trim();
 assert.ok(deviceId, "NOON_PERF_DEVICE_ID is required for a physical-machine baseline");
 assert.match(deviceId, /^[a-zA-Z0-9._-]+$/, "device ID must be filesystem-safe");
+const gpuMode = process.env.NOON_PERF_GPU_MODE ?? "hardware";
+assert.ok(["hardware", "software"].includes(gpuMode), "NOON_PERF_GPU_MODE must be hardware or software");
 
 const backends = list(process.env.NOON_PERF_BACKENDS ?? "webgpu,webgl");
 for (const backend of backends) {
@@ -57,6 +59,7 @@ for (const backend of backends) {
     const webgpuMinimumFps = process.env.NOON_PERF_DYNAMIC_STRESS_WEBGPU_MIN_FPS?.trim();
     run("scripts/retained-dynamic-stress-perf.mjs", {
       NOON_RETAINED_STRESS_BACKEND: backend,
+      NOON_RETAINED_STRESS_GPU_MODE: gpuMode,
       NOON_RETAINED_STRESS_ARTIFACT: relative,
       NOON_RETAINED_STRESS_SAMPLE_HZ: process.env.NOON_PERF_TARGET_HZ ?? "60",
       ...(backend === "webgpu" && webgpuMinimumFps
@@ -69,7 +72,7 @@ for (const backend of backends) {
 
 const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
 const bundle = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   benchmark: "Noon named physical-device performance bundle",
   generatedAt: new Date().toISOString(),
   deviceId,
@@ -78,6 +81,7 @@ const bundle = {
   configuration: {
     backends,
     suites,
+    gpuMode,
     width: process.env.NOON_PERF_WIDTH ?? "960",
     height: process.env.NOON_PERF_HEIGHT ?? "540",
     devicePixelRatio: process.env.NOON_PERF_DPR ?? "1",

--- a/scripts/retained-dynamic-stress-perf.mjs
+++ b/scripts/retained-dynamic-stress-perf.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import playwright from "playwright";
 import { serveRepository } from "./browser-test-server.mjs";
-import { browserArgs } from "./manim-raster-support.mjs";
+import { browserArgs, isIdentifiedGpuAdapter, isSoftwareGpuAdapter } from "./manim-raster-support.mjs";
 import { STRESS_DURATION_SECONDS, STRESS_SAMPLE_HZ, STRESS_SOURCE_SHA256,
   validateStressReport } from "./retained-dynamic-stress-perf-lib.mjs";
 
@@ -16,6 +16,8 @@ const sourceSha256 = createHash("sha256").update(await readFile(path.join(root, 
 assert.equal(sourceSha256, STRESS_SOURCE_SHA256, "review the complete stress workload before updating its hash");
 const backend = process.env.NOON_RETAINED_STRESS_BACKEND ?? "webgpu";
 assert.ok(["webgpu", "webgl"].includes(backend), "unsupported backend");
+const gpuMode = process.env.NOON_RETAINED_STRESS_GPU_MODE ?? "software";
+assert.ok(["software", "hardware"].includes(gpuMode), "unsupported GPU mode");
 const sampleHz = integer("SAMPLE_HZ", STRESS_SAMPLE_HZ);
 const loops = integer("WORKER_LOOPS", 2);
 const minimumEffectiveFps = optionalPositiveNumber("MIN_EFFECTIVE_FPS");
@@ -25,10 +27,10 @@ assert.ok(transports.length > 0 && new Set(transports).size === transports.lengt
 const artifact = path.resolve(root, process.env.NOON_RETAINED_STRESS_ARTIFACT
   ?? `perf-artifacts/shared-dynamic-stress-${backend}.json`);
 const report = {
-  schemaVersion: 2,
+  schemaVersion: 3,
   benchmark: "Noon shared authored dynamic stress profile",
   commit: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
-  generatedAt: new Date().toISOString(), sourcePath, sourceSha256, backend, sampleHz,
+  generatedAt: new Date().toISOString(), sourcePath, sourceSha256, backend, gpuMode, sampleHz,
   loopsPerTransport: loops,
   minimumEffectiveFps,
   measurement: "Fresh source per loop; sample round trip includes source continuation, worker, runtime and rendering",
@@ -38,7 +40,11 @@ const report = {
 const server = await serveRepository(root, integer("PORT", 4192), { crossOriginIsolated: true });
 let browser;
 try {
-  browser = await playwright.chromium.launch({ channel: "chromium", headless: true, args: browserArgs(backend) });
+  browser = await playwright.chromium.launch({
+    channel: "chromium",
+    headless: true,
+    args: browserArgs(backend, { gpuMode }),
+  });
   for (const transportMode of transports) {
     for (let loop = 0; loop < loops; loop += 1) {
       const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
@@ -51,6 +57,14 @@ try {
           targetHz: String(sampleHz), includeSamples: "1", transportMode,
           sharedSlotCapacity: String(32 * 1024 * 1024) });
         await page.goto(`${server.baseUrl}/web/scene-perf.html?${params}`);
+        const adapterInfo = backend === "webgpu" ? await webGpuAdapterInfo(page) : null;
+        if (backend === "webgpu" && gpuMode === "hardware") {
+          assert.ok(adapterInfo, "hardware WebGPU adapter unavailable");
+          assert.ok(isIdentifiedGpuAdapter(adapterInfo),
+            `hardware WebGPU adapter identity unavailable: ${JSON.stringify(adapterInfo)}`);
+          assert.ok(!isSoftwareGpuAdapter(adapterInfo),
+            `physical WebGPU run resolved to a software adapter: ${JSON.stringify(adapterInfo)}`);
+        }
         await page.waitForFunction(() => ["complete", "error"].includes(document.querySelector("#status")?.dataset.state), null, { timeout: 180000 });
         const result = await page.evaluate(() => ({ state: document.querySelector("#status").dataset.state,
           status: document.querySelector("#status").value, profile: window.__NOON_SCENE_PERF__ }));
@@ -62,9 +76,10 @@ try {
           sampleHz,
           minimumEffectiveFps,
         });
-        report.runs.push({ transportMode, loop, phases, profile: result.profile });
+        report.runs.push({ transportMode, loop, adapterInfo, phases, profile: result.profile });
         const effectiveFps = result.profile.cadence.effective?.effectiveFps;
-        console.log(`PASS ${backend} ${transportMode} fresh source ${loop + 1}/${loops}: ${format(effectiveFps)} FPS, ${phases.length} phases`);
+        const adapter = adapterInfo ? `, adapter ${adapterSummary(adapterInfo)}` : "";
+        console.log(`PASS ${backend}/${gpuMode} ${transportMode} fresh source ${loop + 1}/${loops}: ${format(effectiveFps)} FPS, ${phases.length} phases${adapter}`);
       } finally { await page.close(); }
     }
   }
@@ -72,6 +87,32 @@ try {
   await writeFile(artifact, JSON.stringify(report, null, 2));
   console.log(`Wrote ${artifact}`);
 } finally { await browser?.close(); await server.close(); }
+
+async function webGpuAdapterInfo(page) {
+  return page.evaluate(async () => {
+    if (!navigator.gpu) return null;
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+    if (!adapter) return null;
+    let info = adapter.info ?? null;
+    if (!info && typeof adapter.requestAdapterInfo === "function") {
+      info = await adapter.requestAdapterInfo();
+    }
+    return {
+      vendor: String(info?.vendor ?? ""),
+      architecture: String(info?.architecture ?? ""),
+      device: String(info?.device ?? ""),
+      description: String(info?.description ?? ""),
+      isFallbackAdapter: typeof adapter.isFallbackAdapter === "boolean" ? adapter.isFallbackAdapter : null,
+    };
+  });
+}
+
+function adapterSummary(info) {
+  return [info.vendor, info.architecture, info.device, info.description]
+    .map(value => String(value ?? "").trim())
+    .filter(Boolean)
+    .join(" / ") || "unidentified";
+}
 
 function integer(name, fallback) {
   const value = Number(process.env[`NOON_RETAINED_STRESS_${name}`] ?? fallback);


### PR DESCRIPTION
## Summary

Wire Noon's physical performance workflow to a dedicated macOS self-hosted runner and make Dynamic Load use and verify the real GPU instead of forcing SwiftShader.

- target `[self-hosted, macOS, noon-physical]`
- default the physical workflow to WebGPU + Dynamic Load with device ID `yongkyun-mac`
- add hardware/software GPU modes to browser launch args without changing existing software-mode callers
- run physical Dynamic Load with `NOON_PERF_GPU_MODE=hardware`
- record WebGPU adapter identity in the performance artifact
- reject SwiftShader, llvmpipe, fallback/software adapters for physical WebGPU runs
- add CI tests proving hardware mode cannot force SwiftShader

## Why

The existing self-hosted workflow ran on a physical machine but `browserArgs("webgpu")` explicitly forced SwiftShader, so it could not establish real-device GPU FPS. This makes the physical baseline genuinely physical and gives the Mac a dedicated runner label.

## Mac setup required

After merge, register the Mac as a GitHub self-hosted macOS runner and add the custom label `noon-physical`. No GitHub token or runner credential is stored in the repository.