### PR TITLE
Add retained performance cases before optimization

### DIFF
--- a/benchmarks/performance-scenes.json
+++ b/benchmarks/performance-scenes.json
@@ -135,16 +135,31 @@
       "classification": "scalability-only",
       "domains": ["P6", "P7"],
       "dimensions": ["warm-rerun", "one-object-edit", "identity-stabilization", "seek", "time-to-visible"]
+    },
+    {
+      "id": "retained-dynamic-stress",
+      "source": "web/python/examples/manim_parity_stress_grid.py",
+      "runner": "node scripts/retained-dynamic-stress-perf.mjs",
+      "classification": "adversarial",
+      "domains": ["P2", "P4", "P7"],
+      "dimensions": [
+        "source-continuation",
+        "600-object-morph",
+        "cold-morph-activation",
+        "steady-morph-locality",
+        "lifecycle-churn",
+        "worker-transport"
+      ]
     }
   ],
   "domainCoverage": {
     "P1": ["getting-started", "timed-composition", "tutorial-value-tracker"],
-    "P2": ["getting-started", "analytic-field-180", "painter-order-overlap"],
+    "P2": ["getting-started", "analytic-field-180", "painter-order-overlap", "retained-dynamic-stress"],
     "P3": ["analytic-field-180", "painter-order-overlap"],
-    "P4": ["create-shapes", "filled-path-transform"],
+    "P4": ["create-shapes", "filled-path-transform", "retained-dynamic-stress"],
     "P5": ["tutorial-value-tracker", "host-updater-follow"],
     "P6": ["getting-started", "authoring-edit-rerun-seek"],
-    "P7": ["analytic-field-180", "create-shapes", "host-updater-follow", "authoring-edit-rerun-seek"]
+    "P7": ["analytic-field-180", "create-shapes", "host-updater-follow", "authoring-edit-rerun-seek", "retained-dynamic-stress"]
   },
   "futureCoverage": [
     {

--- a/scripts/retained-dynamic-stress-perf-lib.mjs
+++ b/scripts/retained-dynamic-stress-perf-lib.mjs
@@ -20,6 +20,48 @@ export const STRESS_PHASES = Object.freeze([
   { id: "final-wave", start: 4.46, end: STRESS_DURATION_SECONDS },
 ]);
 
+// Performance cases deliberately describe user-visible workload slices rather
+// than implementation stages. They remain valid if transport, residency, or GPU
+// representation changes. The activation cases isolate the first measured frames
+// after a morph phase becomes active; steady cases exclude those frames so cold
+// preparation cannot hide a steady-state regression (or vice versa).
+export const STRESS_PERFORMANCE_CASES = Object.freeze([
+  {
+    id: "morph-a-activation",
+    phase: "morph-a",
+    takeFirstSamples: 2,
+    intent: "first activation of the first 600-object morph phase",
+  },
+  {
+    id: "morph-a-steady",
+    phase: "morph-a",
+    skipFirstSamples: 2,
+    intent: "steady retained playback after the first morph phase is active",
+  },
+  {
+    id: "morph-b-activation",
+    phase: "morph-b",
+    takeFirstSamples: 2,
+    intent: "first activation of the second 600-object morph phase",
+  },
+  {
+    id: "morph-b-steady",
+    phase: "morph-b",
+    skipFirstSamples: 2,
+    intent: "steady retained playback after the second morph phase is active",
+  },
+  {
+    id: "turbulence",
+    phase: "turbulence",
+    intent: "high-frequency multi-object transform/style activity",
+  },
+  {
+    id: "lifecycle-churn",
+    phase: "lifecycle-churn",
+    intent: "structural presence/lifecycle churn after the morph phases",
+  },
+]);
+
 export function fixedStressSampleTimes(
   duration = STRESS_DURATION_SECONDS,
   sampleHz = STRESS_SAMPLE_HZ,
@@ -38,16 +80,45 @@ export function classifyStressPhase(time) {
   )?.id ?? null;
 }
 
+function timingSummary(values) {
+  assert.ok(values.length > 0, "performance case must contain at least one sample");
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    min: sorted[0],
+    max: sorted.at(-1),
+    mean: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+    p95: sorted[Math.ceil(sorted.length * 0.95) - 1],
+  };
+}
+
 export function summarizeStressPhases(samples) {
   return STRESS_PHASES.map((phase) => {
     const values = samples.filter((sample) => classifyStressPhase(sample.sceneTime) === phase.id)
-      .map((sample) => sample.advanceRoundTripMs).sort((a, b) => a - b);
+      .map((sample) => sample.advanceRoundTripMs);
     assert.ok(values.length > 0, `${phase.id} must be sampled`);
-    return { ...phase, samples: values.length, advanceRoundTripMs: {
-      min: values[0], max: values.at(-1),
-      mean: values.reduce((sum, value) => sum + value, 0) / values.length,
-      p95: values[Math.ceil(values.length * 0.95) - 1],
-    } };
+    return { ...phase, samples: values.length, advanceRoundTripMs: timingSummary(values) };
+  });
+}
+
+export function summarizeStressCases(samples) {
+  return STRESS_PERFORMANCE_CASES.map((performanceCase) => {
+    let selected = samples.filter(
+      (sample) => classifyStressPhase(sample.sceneTime) === performanceCase.phase,
+    );
+    if (performanceCase.takeFirstSamples !== undefined) {
+      selected = selected.slice(0, performanceCase.takeFirstSamples);
+    }
+    if (performanceCase.skipFirstSamples !== undefined) {
+      selected = selected.slice(performanceCase.skipFirstSamples);
+    }
+    assert.ok(selected.length > 0, `${performanceCase.id} must contain measured samples`);
+    return {
+      ...performanceCase,
+      samples: selected.length,
+      firstSceneTime: selected[0].sceneTime,
+      lastSceneTime: selected.at(-1).sceneTime,
+      advanceRoundTripMs: timingSummary(selected.map((sample) => sample.advanceRoundTripMs)),
+    };
   });
 }
 

--- a/scripts/retained-dynamic-stress-perf-lib.test.mjs
+++ b/scripts/retained-dynamic-stress-perf-lib.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fixedStressSampleTimes, classifyStressPhase, validateStressReport } from "./retained-dynamic-stress-perf-lib.mjs";
+import {
+  STRESS_PERFORMANCE_CASES,
+  fixedStressSampleTimes,
+  classifyStressPhase,
+  summarizeStressCases,
+  validateStressReport,
+} from "./retained-dynamic-stress-perf-lib.mjs";
 const options = { transportMode: "shared", rendererBackend: "WebGPU", sampleHz: 60 };
 function complete() {
   return { schemaVersion: 2, setup: { warmupFrames: 0 }, scene: { objects: 626 },
@@ -18,6 +24,47 @@ test("complete fixed samples preserve all ten authored phases and measured timin
   assert.equal(classifyStressPhase(0.35), "create-grid");
   assert.equal(classifyStressPhase(5), "final-wave");
   assert.equal(classifyStressPhase(5.01), null);
+});
+test("performance cases separate cold morph activation from steady playback", () => {
+  const report = complete();
+  const cases = summarizeStressCases(report.samples);
+  assert.deepEqual(cases.map(performanceCase => performanceCase.id),
+    STRESS_PERFORMANCE_CASES.map(performanceCase => performanceCase.id));
+  const byId = Object.fromEntries(cases.map(performanceCase => [performanceCase.id, performanceCase]));
+
+  assert.equal(byId["morph-a-activation"].samples, 2);
+  assert.equal(byId["morph-a-steady"].samples, 31);
+  assert.equal(byId["morph-b-activation"].samples, 2);
+  assert.equal(byId["morph-b-steady"].samples, 31);
+  assert.equal(byId.turbulence.samples, 27);
+  assert.equal(byId["lifecycle-churn"].samples, 63);
+
+  assert.equal(byId["morph-a-activation"].firstSceneTime, 0.9);
+  assert.equal(byId["morph-a-activation"].lastSceneTime, 55 / 60);
+  assert.equal(byId["morph-a-steady"].firstSceneTime, 56 / 60);
+  assert.equal(byId["morph-b-activation"].firstSceneTime, 131 / 60);
+  assert.equal(byId["morph-b-steady"].firstSceneTime, 133 / 60);
+  assert.ok(cases.every(performanceCase => performanceCase.advanceRoundTripMs.p95 === 3));
+});
+test("activation outlier cannot be hidden by a fast steady morph case", () => {
+  const report = complete();
+  const firstMorphA = report.samples.find(sample => classifyStressPhase(sample.sceneTime) === "morph-a");
+  firstMorphA.advanceRoundTripMs = 80;
+  const cases = Object.fromEntries(
+    summarizeStressCases(report.samples).map(performanceCase => [performanceCase.id, performanceCase]),
+  );
+  assert.equal(cases["morph-a-activation"].advanceRoundTripMs.p95, 80);
+  assert.equal(cases["morph-a-steady"].advanceRoundTripMs.p95, 3);
+});
+test("steady morph regression cannot be hidden by a fast activation case", () => {
+  const report = complete();
+  const morphA = report.samples.filter(sample => classifyStressPhase(sample.sceneTime) === "morph-a");
+  for (const sample of morphA.slice(2)) sample.advanceRoundTripMs = 40;
+  const cases = Object.fromEntries(
+    summarizeStressCases(report.samples).map(performanceCase => [performanceCase.id, performanceCase]),
+  );
+  assert.equal(cases["morph-a-activation"].advanceRoundTripMs.p95, 3);
+  assert.equal(cases["morph-a-steady"].advanceRoundTripMs.p95, 40);
 });
 test("optional physical cadence floor rejects an FPS regression", () => {
   validateStressReport(complete(), { ...options, minimumEffectiveFps: 55 });

--- a/scripts/retained-dynamic-stress-perf.mjs
+++ b/scripts/retained-dynamic-stress-perf.mjs
@@ -7,8 +7,14 @@ import { fileURLToPath } from "node:url";
 import playwright from "playwright";
 import { serveRepository } from "./browser-test-server.mjs";
 import { browserArgs, isIdentifiedGpuAdapter, isSoftwareGpuAdapter } from "./manim-raster-support.mjs";
-import { STRESS_DURATION_SECONDS, STRESS_SAMPLE_HZ, STRESS_SOURCE_SHA256,
-  validateStressReport } from "./retained-dynamic-stress-perf-lib.mjs";
+import {
+  STRESS_DURATION_SECONDS,
+  STRESS_PERFORMANCE_CASES,
+  STRESS_SAMPLE_HZ,
+  STRESS_SOURCE_SHA256,
+  summarizeStressCases,
+  validateStressReport,
+} from "./retained-dynamic-stress-perf-lib.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const sourcePath = "web/python/examples/manim_parity_stress_grid.py";
@@ -34,7 +40,11 @@ const report = {
   loopsPerTransport: loops,
   minimumEffectiveFps,
   measurement: "Fresh source per loop; sample round trip includes source continuation, worker, runtime and rendering",
-  performanceBudgets: { status: "unavailable", reason: "Isolated CPU/GPU, morph activation and warm replay metrics are not measured by shared source execution" },
+  performanceCases: STRESS_PERFORMANCE_CASES,
+  performanceBudgets: {
+    status: "not-enforced",
+    reason: "Cases are measured first; isolated CPU/GPU attribution and physical per-case budgets are added separately",
+  },
   runs: [],
 };
 const server = await serveRepository(root, integer("PORT", 4192), { crossOriginIsolated: true });
@@ -76,10 +86,11 @@ try {
           sampleHz,
           minimumEffectiveFps,
         });
-        report.runs.push({ transportMode, loop, adapterInfo, phases, profile: result.profile });
+        const cases = summarizeStressCases(result.profile.samples);
+        report.runs.push({ transportMode, loop, adapterInfo, phases, cases, profile: result.profile });
         const effectiveFps = result.profile.cadence.effective?.effectiveFps;
         const adapter = adapterInfo ? `, adapter ${adapterSummary(adapterInfo)}` : "";
-        console.log(`PASS ${backend}/${gpuMode} ${transportMode} fresh source ${loop + 1}/${loops}: ${format(effectiveFps)} FPS, ${phases.length} phases${adapter}`);
+        console.log(`PASS ${backend}/${gpuMode} ${transportMode} fresh source ${loop + 1}/${loops}: ${format(effectiveFps)} FPS, ${phases.length} phases, ${cases.length} performance cases${adapter}`);
       } finally { await page.close(); }
     }
   }


### PR DESCRIPTION
## Summary

Create the performance cases first, before changing runtime, transport, residency, or renderer implementation.

This PR is intentionally measurement/test-only:

- split Dynamic Load morph phases into explicit cold-activation and steady-state cases;
- keep turbulence and lifecycle churn as separate named cases;
- prove activation spikes cannot be averaged away by a fast steady phase, and steady regressions cannot be hidden by a fast activation;
- emit the case summaries in the retained Dynamic Load artifact for both transferable and shared transport;
- register Dynamic Load as an official auxiliary performance-corpus case.

## Cases

1. `morph-a-activation` — first two measured samples after the first 600-object morph becomes active.
2. `morph-a-steady` — remainder of the first morph phase.
3. `morph-b-activation` — first two measured samples after the second morph becomes active.
4. `morph-b-steady` — remainder of the second morph phase.
5. `turbulence` — high-frequency multi-object transform/style activity.
6. `lifecycle-churn` — structural presence/lifecycle churn after morphing.

The source hash and complete 5-second / 300-sample workload remain unchanged. No budgets are enforced yet; this PR establishes stable case boundaries first so subsequent preload/transport work can be measured against the same cases.

## Architecture / locality

Advances #955/C3 measurement discipline without adding a new execution authority or transport. The cases are defined by authored workload behavior, not by current implementation stages, so they remain valid if JSON transport, resource installation, or GPU representation changes.

## Validation

CI should run the existing `retained-dynamic-stress-perf-lib.test.mjs` through the normal web preflight. No engine/runtime/renderer behavior is changed.